### PR TITLE
fix: correct clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo contains Python code to generate the global dataset of factor returns,
 
    - Clone the folder to your local machine by running the following command from your terminal:
      ```sh
-     git clone git@github.com:bkelly-lab/SAS-Python-Migrate.git
+     git clone git@github.com:bkelly-lab/jkp-data.git
      ```
 2. **Input WRDS credentials**
 


### PR DESCRIPTION
## Summary
- Fix incorrect clone URL in README that referenced the old internal repo name

## Details
The clone command in the README referenced `SAS-Python-Migrate` (the old internal repo name) instead of `jkp-data` (the public repo name). This would cause users to fail when trying to clone the repository.

**Before:**
```sh
git clone git@github.com:bkelly-lab/SAS-Python-Migrate.git
```

**After:**
```sh
git clone git@github.com:bkelly-lab/jkp-data.git
```