### PR TITLE
feat: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,173 @@
+name: Bug Report
+description: Report a bug or error in the JKP data pipeline
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug. Please fill out the form below as completely as possible to help us diagnose and fix the issue.
+
+  - type: dropdown
+    id: script
+    attributes:
+      label: Which script were you running?
+      description: Select the script that produced the error
+      options:
+        - main.py (data generation)
+        - portfolio.py (factor returns)
+        - wrds_credentials.py (credential setup)
+        - Other (please specify in description)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: error_category
+    attributes:
+      label: Error Category
+      description: What type of error did you encounter?
+      options:
+        - WRDS connection / authentication
+        - Data download failure
+        - Memory / OOM error
+        - Computation error
+        - File I/O error
+        - Missing dependencies
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run `uv run python code/main.py`
+        2. Wait for WRDS authentication
+        3. See error at step X
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Describe what you expected...
+    validations:
+      required: true
+
+  - type: textarea
+    id: error_output
+    attributes:
+      label: Error Output / Stack Trace
+      description: Please paste the full error message and stack trace
+      render: shell
+      placeholder: |
+        Traceback (most recent call last):
+          File "code/main.py", line X, in <module>
+            ...
+        Error: ...
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: e.g., Ubuntu 22.04, macOS 14.0, Windows 11
+      placeholder: Ubuntu 22.04
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python Version
+      description: Output of `python --version`
+      placeholder: "3.11.x"
+    validations:
+      required: true
+
+  - type: input
+    id: polars_version
+    attributes:
+      label: Polars Version
+      description: Output of `python -c "import polars; print(polars.__version__)"`
+      placeholder: "1.34.0"
+    validations:
+      required: true
+
+  - type: input
+    id: uv_version
+    attributes:
+      label: uv Version
+      description: Output of `uv --version`
+      placeholder: "0.x.x"
+    validations:
+      required: true
+
+  - type: input
+    id: ram
+    attributes:
+      label: Available RAM
+      description: How much RAM does your system have?
+      placeholder: "450 GB"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: wrds_auth
+    attributes:
+      label: WRDS Authentication Method
+      description: How are you authenticating with WRDS?
+      options:
+        - Stored credentials (keyring)
+        - Manual entry each run
+        - Not applicable
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: wrds_2fa
+    attributes:
+      label: WRDS Two-Factor Authentication
+      description: Did you complete the 2FA step (e.g., Duo notification)?
+      options:
+        - label: Yes, I approved the 2FA request
+        - label: No 2FA prompt appeared
+        - label: 2FA failed or timed out
+        - label: Not applicable
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other information that might be helpful (screenshots, log files, etc.)
+      placeholder: Add any other context here...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following
+      options:
+        - label: I have searched existing issues to ensure this bug has not already been reported
+          required: true
+        - label: I am using the latest version of the code from the main branch
+          required: true
+        - label: I have read the README and followed the setup instructions
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/bkelly-lab/jkp-data/discussions
+    about: Ask general questions, share ideas, or discuss the project with the community
+  - name: JKP Factors Website
+    url: https://jkpfactors.com
+    about: Access pre-computed global factor returns and documentation
+  - name: Documentation PDF
+    url: https://jkpfactors.s3.amazonaws.com/documents/Documentation.pdf
+    about: Read detailed documentation for JKP factor data
+  - name: Original Paper
+    url: https://onlinelibrary.wiley.com/doi/full/10.1111/jofi.13249
+    about: "Read the original paper: 'Is there a Replication Crisis in Finance?' (Jensen, Kelly, and Pedersen, JF 2023)"

--- a/.github/ISSUE_TEMPLATE/data_discrepancy.yml
+++ b/.github/ISSUE_TEMPLATE/data_discrepancy.yml
@@ -1,0 +1,359 @@
+name: Data Discrepancy
+description: Report incorrect, missing, or unexpected data values
+title: "[Data]: "
+labels: ["data-issue", "triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a data discrepancy. Accurate data is critical for academic research. Please provide as much detail as possible.
+
+  - type: dropdown
+    id: discrepancy_type
+    attributes:
+      label: Type of Discrepancy
+      description: What kind of data issue did you find?
+      options:
+        - Missing data (NaN/null where values expected)
+        - Wrong values (numerically incorrect)
+        - Differs from published JKP factors
+        - Differs from previous run
+        - Differs from external source (WRDS, Compustat, etc.)
+        - Unexpected format or structure
+        - Date range issue
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data_type
+    attributes:
+      label: Affected Data Type
+      description: What type of data is affected?
+      options:
+        - Firm characteristics
+        - Factor returns (monthly)
+        - Factor returns (daily)
+        - Stock returns
+        - Accounting data
+        - Market returns
+        - Industry portfolios
+        - Regional factors
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: characteristic
+    attributes:
+      label: Affected Characteristic(s)
+      description: Select the primary characteristic affected (if applicable)
+      multiple: true
+      options:
+        - age
+        - aliq_at
+        - aliq_mat
+        - ami_126d
+        - at_be
+        - at_gr1
+        - at_me
+        - at_turnover
+        - be_gr1a
+        - be_me
+        - beta_60m
+        - beta_dimson_21d
+        - betabab_1260d
+        - betadown_252d
+        - bev_mev
+        - bidaskhl_21d
+        - capex_abn
+        - capx_gr1
+        - capx_gr2
+        - capx_gr3
+        - cash_at
+        - chcsho_12m
+        - coa_gr1a
+        - col_gr1a
+        - cop_at
+        - cop_atl1
+        - corr_1260d
+        - coskew_21d
+        - cowc_gr1a
+        - dbnetis_at
+        - debt_gr3
+        - debt_me
+        - dgp_dsale
+        - div12m_me
+        - dolvol_126d
+        - dolvol_var_126d
+        - dsale_dinv
+        - dsale_drec
+        - dsale_dsga
+        - earnings_variability
+        - ebit_bev
+        - ebit_sale
+        - ebitda_mev
+        - emp_gr1
+        - eq_dur
+        - eqnetis_at
+        - eqnpo_12m
+        - eqnpo_me
+        - eqpo_me
+        - f_score
+        - fcf_me
+        - fnl_gr1a
+        - gp_at
+        - gp_atl1
+        - ival_me
+        - inv_gr1
+        - inv_gr1a
+        - iskew_capm_21d
+        - iskew_ff3_21d
+        - iskew_hxz4_21d
+        - ivol_capm_21d
+        - ivol_capm_252d
+        - ivol_ff3_21d
+        - ivol_hxz4_21d
+        - kz_index
+        - lnoa_gr1a
+        - lti_gr1a
+        - market_equity
+        - mispricing_mgmt
+        - mispricing_perf
+        - ncoa_gr1a
+        - ncol_gr1a
+        - netdebt_me
+        - netis_at
+        - nfna_gr1a
+        - ni_ar1
+        - ni_be
+        - ni_inc8q
+        - ni_ivol
+        - ni_me
+        - niq_at
+        - niq_at_chg1
+        - niq_be
+        - niq_be_chg1
+        - niq_su
+        - nncoa_gr1a
+        - noa_at
+        - noa_gr1a
+        - o_score
+        - oaccruals_at
+        - oaccruals_ni
+        - ocf_at
+        - ocf_at_chg1
+        - ocf_me
+        - ocfq_saleq_std
+        - op_at
+        - op_atl1
+        - ope_be
+        - ope_bel1
+        - opex_at
+        - pi_nix
+        - ppeinv_gr1a
+        - prc
+        - prc_highprc_252d
+        - qmj
+        - qmj_growth
+        - qmj_prof
+        - qmj_safety
+        - rd_me
+        - rd_sale
+        - rd5_at
+        - resff3_12_1
+        - resff3_6_1
+        - ret_1_0
+        - ret_12_1
+        - ret_12_7
+        - ret_3_1
+        - ret_6_1
+        - ret_60_12
+        - ret_9_1
+        - rmax1_21d
+        - rmax5_21d
+        - rmax5_rvol_21d
+        - rskew_21d
+        - rvol_21d
+        - sale_bev
+        - sale_emp_gr1
+        - sale_gr1
+        - sale_gr3
+        - sale_me
+        - saleq_gr1
+        - saleq_su
+        - seas_1_1an
+        - seas_1_1na
+        - seas_11_15an
+        - seas_11_15na
+        - seas_16_20an
+        - seas_16_20na
+        - seas_2_5an
+        - seas_2_5na
+        - seas_6_10an
+        - seas_6_10na
+        - sti_gr1a
+        - taccruals_at
+        - taccruals_ni
+        - tangibility
+        - tax_gr1a
+        - turnover_126d
+        - turnover_var_126d
+        - z_score
+        - zero_trades_126d
+        - zero_trades_21d
+        - zero_trades_252d
+        - Other (specify in description)
+        - Multiple / Not specific to one characteristic
+    validations:
+      required: false
+
+  - type: dropdown
+    id: country_region
+    attributes:
+      label: Country/Region Affected
+      description: Which country or region shows the discrepancy?
+      options:
+        - USA
+        - World (all countries)
+        - Developed markets
+        - Emerging markets
+        - World ex-US
+        - AUS (Australia)
+        - AUT (Austria)
+        - BEL (Belgium)
+        - CAN (Canada)
+        - CHE (Switzerland)
+        - CHN (China)
+        - DEU (Germany)
+        - DNK (Denmark)
+        - ESP (Spain)
+        - FIN (Finland)
+        - FRA (France)
+        - GBR (United Kingdom)
+        - HKG (Hong Kong)
+        - IND (India)
+        - IRL (Ireland)
+        - ISR (Israel)
+        - ITA (Italy)
+        - JPN (Japan)
+        - KOR (South Korea)
+        - NLD (Netherlands)
+        - NOR (Norway)
+        - NZL (New Zealand)
+        - PRT (Portugal)
+        - SGP (Singapore)
+        - SWE (Sweden)
+        - TWN (Taiwan)
+        - Other (specify in description)
+        - Multiple countries
+    validations:
+      required: true
+
+  - type: input
+    id: date_range_start
+    attributes:
+      label: Start Date of Affected Period
+      description: When does the discrepancy begin? (YYYY-MM-DD format)
+      placeholder: "1990-01-31"
+    validations:
+      required: false
+
+  - type: input
+    id: date_range_end
+    attributes:
+      label: End Date of Affected Period
+      description: When does the discrepancy end? (YYYY-MM-DD format)
+      placeholder: "2024-12-31"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: comparison_baseline
+    attributes:
+      label: Comparison Baseline
+      description: What are you comparing against?
+      options:
+        - Published JKP factors (jkpfactors.com)
+        - WRDS Global Factor Data
+        - Previous run of this codebase
+        - Original SAS/R codebase output
+        - Kenneth French Data Library
+        - AQR data
+        - Published academic paper
+        - Other external source
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Detailed Description
+      description: Describe the discrepancy in detail
+      placeholder: |
+        What values did you expect?
+        What values did you observe?
+        How large is the discrepancy?
+    validations:
+      required: true
+
+  - type: textarea
+    id: sample_data
+    attributes:
+      label: Sample of Problematic Data
+      description: Provide a sample showing the issue (e.g., a few rows with expected vs actual values)
+      render: markdown
+      placeholder: |
+        | date       | characteristic | expected | actual   |
+        |------------|----------------|----------|----------|
+        | 2023-12-31 | be_me          | 0.85     | 0.42     |
+        | 2023-11-30 | be_me          | 0.83     | NaN      |
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction_code
+    attributes:
+      label: Code to Reproduce (Optional)
+      description: If you have code that demonstrates the discrepancy, please share it
+      render: python
+      placeholder: |
+        import polars as pl
+
+        # Load the data
+        df = pl.read_parquet("data/processed/characteristics/USA.parquet")
+
+        # Show the discrepancy
+        print(df.filter(pl.col("characteristic") == "be_me"))
+    validations:
+      required: false
+
+  - type: input
+    id: run_date
+    attributes:
+      label: Date Code Was Run
+      description: When did you run the pipeline? (YYYY-MM-DD)
+      placeholder: "2024-01-15"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other information that might be helpful
+      placeholder: Links to papers, screenshots, related issues, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following
+      options:
+        - label: I have searched existing issues to ensure this discrepancy has not already been reported
+          required: true
+        - label: I have verified my comparison baseline is reliable
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,99 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the JKP data pipeline
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an improvement to the JKP data pipeline. Please describe your idea in detail.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: Describe the feature you would like to see
+      placeholder: |
+        What would you like to be added or changed?
+        How would it work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case / Motivation
+      description: Why do you need this feature? What problem does it solve?
+      placeholder: |
+        Describe your use case...
+        What are you trying to accomplish?
+    validations:
+      required: true
+
+  - type: textarea
+    id: academic_justification
+    attributes:
+      label: Academic / Industry Justification (if applicable)
+      description: For new characteristics or methodological changes, please provide academic references
+      placeholder: |
+        - Reference paper(s): Author (Year), "Title", Journal
+        - Why is this important for finance research?
+        - Is this characteristic used in industry?
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed_implementation
+    attributes:
+      label: Proposed Implementation (Optional)
+      description: If you have ideas on how to implement this, please share
+      placeholder: |
+        - Which files would need to change?
+        - What data sources would be needed?
+        - Any technical considerations?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: willingness_to_contribute
+    attributes:
+      label: Willingness to Contribute
+      description: Would you be willing to help implement this feature?
+      options:
+        - "Yes, I can implement this myself and submit a PR"
+        - "Yes, I can help with testing/validation"
+        - "Yes, I can help with documentation"
+        - "No, but I can provide detailed specifications"
+        - "No, I am just suggesting the idea"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative approaches?
+      placeholder: What other solutions have you thought about?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other information that might be helpful
+      placeholder: Screenshots, links, related projects, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following
+      options:
+        - label: I have searched existing issues to ensure this feature has not already been requested
+          required: true
+        - label: I have read the documentation to confirm this feature does not already exist
+          required: true

--- a/.github/ISSUE_TEMPLATE/other_question.yml
+++ b/.github/ISSUE_TEMPLATE/other_question.yml
@@ -1,0 +1,70 @@
+name: Question / Other Issue
+description: Ask a question or report an issue that does not fit other categories
+title: "[Question]: "
+labels: ["question", "triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question or an issue that does not fit the bug report, data discrepancy, or feature request templates? Please describe it below.
+
+        **Note:** For general discussions, consider using [GitHub Discussions](https://github.com/bkelly-lab/jkp-data/discussions) instead.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What category best describes your question?
+      options:
+        - Methodology / academic question
+        - Data interpretation
+        - Setup / installation help
+        - Usage / how-to question
+        - Documentation clarification
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe your question or issue
+      placeholder: |
+        What would you like to know?
+        What are you trying to understand?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Relevant Context
+      description: Any background information that might help us understand your question
+      placeholder: |
+        - What have you already tried?
+        - What documentation have you read?
+        - Any relevant code or data examples?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional Information
+      description: Any other details you would like to share
+      placeholder: Links, screenshots, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following
+      options:
+        - label: I have searched existing issues and discussions for an answer
+          required: true
+        - label: I have read the documentation
+          required: true


### PR DESCRIPTION
## Summary

- Add 4 structured YAML issue form templates for improved issue quality and triage
- Configure template chooser with links to GitHub Discussions, jkpfactors.com, and documentation
- Disable blank issues to ensure users provide structured information

## Templates Added

| Template | Purpose |
|----------|---------|
| `bug_report.yml` | Code bugs, crashes, WRDS/setup issues with environment fields |
| `data_discrepancy.yml` | Data quality issues with dropdown for all 153 characteristics |
| `feature_request.yml` | Enhancement proposals (open-ended, with academic justification field) |
| `other_question.yml` | Catch-all for issues that don't fit other categories |

## Manual Steps After Merge

1. **Enable GitHub Discussions** in repository settings (Settings → Features → Discussions)
2. **Create labels** if not already present: `bug`, `data-issue`, `enhancement`, `question`, `triage`

## Test plan

- [ ] Navigate to Issues → New Issue and verify all 4 templates appear
- [ ] Verify contact links to Discussions, jkpfactors.com, and paper appear
- [ ] Test each form renders correctly with all fields
- [ ] Verify blank issues are disabled