### PR TITLE
Add import for polars_ols module

### DIFF
--- a/code/aux_functions.py
+++ b/code/aux_functions.py
@@ -8,7 +8,7 @@ import duckdb
 import ibis
 import polars as pl
 import polars_ds as pds
-import polars_ols
+import polars_ols  # noqa: F401 - required for least_squares method on polars expressions
 from ibis import _
 from polars import col
 


### PR DESCRIPTION
This is suggested by Rob (@capellini).  Adding this import solves the bug of AttributeError: 'Expr' object has no attribute ‘least_squares'