### PR TITLE
Fix: Remove usincflg constraint to include ADRs and foreign companies

### DIFF
--- a/code/aux_functions.py
+++ b/code/aux_functions.py
@@ -548,7 +548,6 @@ def gen_crsp_sf(freq):
     securitytype_expr = sf.securitytype
     securitysubtype_expr = sf.securitysubtype
     sharetype_expr = sf.sharetype
-    usincflg_expr = sf.usincflg
     issuertype_expr = sf.issuertype
 
     is_common_expr = (
@@ -556,7 +555,6 @@ def gen_crsp_sf(freq):
         & (securitysubtype_expr == "COM")
         & (sharetype_expr == "NS")
         & (issuertype_expr.isin(["ACOR", "CORP"]))
-        & (usincflg_expr == "Y")
     )
 
     shrcd_expr = ibis.cases(


### PR DESCRIPTION
## Summary

- Remove the `usincflg = 'Y'` constraint from the CRSP CIZ schema filter in `gen_crsp_sf()`
- This constraint was excluding ADRs and foreign companies (shrcd=12), causing ~2,594 missing IDs compared to the original SAS/R implementation

## Background

Investigation in #32 identified that the Python port was missing securities present in the SAS/R baseline. The root cause was the `usincflg = 'Y'` constraint which filters to only US-incorporated companies, excluding:
- ADRs (American Depositary Receipts)
- Foreign companies trading on US exchanges

## Test plan

- [x] Unit tests pass (107/107)
- [x] Verified `gen_crsp_sf()` executes successfully on Yale HPC with WRDS data
- [x] Confirmed the fix increases coverage to match SAS/R baseline

Fixes #32