### PR TITLE
Rename project from sas-python-migrate to jkp-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "sas-python-migrate"
+name = "jkp-data"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1066,6 +1066,77 @@ wheels = [
 ]
 
 [[package]]
+name = "jkp-data"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "datetime" },
+    { name = "duckdb" },
+    { name = "fastexcel" },
+    { name = "ibis-framework", extra = ["duckdb", "postgres"] },
+    { name = "keyring" },
+    { name = "keyrings-alt" },
+    { name = "numpy" },
+    { name = "polars" },
+    { name = "polars-ds" },
+    { name = "polars-ols" },
+    { name = "pyarrow" },
+    { name = "pycryptodomex" },
+    { name = "sqlalchemy" },
+    { name = "tqdm" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ipykernel" },
+    { name = "jupyter" },
+    { name = "matplotlib" },
+]
+lint = [
+    { name = "pyright" },
+    { name = "ruff" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datetime", specifier = "==5.4" },
+    { name = "duckdb", specifier = "==1.4.3" },
+    { name = "fastexcel", specifier = ">=0.16.0" },
+    { name = "ibis-framework", extras = ["duckdb", "postgres"], specifier = "==11.0" },
+    { name = "keyring", specifier = "==25.6.0" },
+    { name = "keyrings-alt", specifier = "==5.0.2" },
+    { name = "numpy", specifier = "==1.26.4" },
+    { name = "polars", specifier = "==1.34.0" },
+    { name = "polars-ds", specifier = "==0.10.2" },
+    { name = "polars-ols", specifier = "==0.3.5" },
+    { name = "pyarrow", specifier = "==16.1.0" },
+    { name = "pycryptodomex", specifier = "==3.23.0" },
+    { name = "sqlalchemy", specifier = "==1.4.49" },
+    { name = "tqdm", specifier = "==4.66.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipykernel", specifier = ">=7.1.0" },
+    { name = "jupyter", specifier = ">=1.1.1" },
+    { name = "matplotlib", specifier = ">=3.10.8" },
+]
+lint = [
+    { name = "pyright", specifier = ">=1.1.350" },
+    { name = "ruff", specifier = ">=0.4.0" },
+]
+test = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
+]
+
+[[package]]
 name = "json5"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2642,77 +2713,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
     { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
-]
-
-[[package]]
-name = "sas-python-migrate"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "datetime" },
-    { name = "duckdb" },
-    { name = "fastexcel" },
-    { name = "ibis-framework", extra = ["duckdb", "postgres"] },
-    { name = "keyring" },
-    { name = "keyrings-alt" },
-    { name = "numpy" },
-    { name = "polars" },
-    { name = "polars-ds" },
-    { name = "polars-ols" },
-    { name = "pyarrow" },
-    { name = "pycryptodomex" },
-    { name = "sqlalchemy" },
-    { name = "tqdm" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "ipykernel" },
-    { name = "jupyter" },
-    { name = "matplotlib" },
-]
-lint = [
-    { name = "pyright" },
-    { name = "ruff" },
-]
-test = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-xdist" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "datetime", specifier = "==5.4" },
-    { name = "duckdb", specifier = "==1.4.3" },
-    { name = "fastexcel", specifier = ">=0.16.0" },
-    { name = "ibis-framework", extras = ["duckdb", "postgres"], specifier = "==11.0" },
-    { name = "keyring", specifier = "==25.6.0" },
-    { name = "keyrings-alt", specifier = "==5.0.2" },
-    { name = "numpy", specifier = "==1.26.4" },
-    { name = "polars", specifier = "==1.34.0" },
-    { name = "polars-ds", specifier = "==0.10.2" },
-    { name = "polars-ols", specifier = "==0.3.5" },
-    { name = "pyarrow", specifier = "==16.1.0" },
-    { name = "pycryptodomex", specifier = "==3.23.0" },
-    { name = "sqlalchemy", specifier = "==1.4.49" },
-    { name = "tqdm", specifier = "==4.66.5" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "ipykernel", specifier = ">=7.1.0" },
-    { name = "jupyter", specifier = ">=1.1.1" },
-    { name = "matplotlib", specifier = ">=3.10.8" },
-]
-lint = [
-    { name = "pyright", specifier = ">=1.1.350" },
-    { name = "ruff", specifier = ">=0.4.0" },
-]
-test = [
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-cov", specifier = ">=4.1.0" },
-    { name = "pytest-xdist", specifier = ">=3.5.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update project name in `pyproject.toml` from `sas-python-migrate` to `jkp-data` to match the renamed repository
- Regenerate `uv.lock` to reflect the new project name

## Test plan
- [ ] Verify `uv sync` works with the updated project name
- [ ] Confirm CI status checks pass