### PR TITLE
Add persistent WRDS connection mode (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ data/processed/
 Please see the release notes (`documentation/release_notes.html`) for a description of the output files and a comparison between the output of the SAS/R codebase and the new Python codebase.
 
 ## Notes
-- By default, the end date for the data in the code is 2024-12-31, which you can change by editing line 4 of the `code/main.py` file. For example, for May 6, 1992, use: `end_date = pl.datetime(1992, 5, 6)`.
+- By default, the end date for the data in the code is 2024-12-31, which you can change by editing the `end_date` assignment near the top of `code/main.py`. For example, for May 6, 1992, use: `end_date = pl.datetime(1992, 5, 6)`.
 
 - **Persistent WRDS Connection**: If you're running on an HPC cluster with NAT IP rotation (such as Yale's Bouchet cluster), you may receive many MFA prompts during data download. This happens because each database query creates a new TCP connection, and the NAT gateway assigns a random outbound IP to each connection. WRDS sees these as connections from different locations and triggers MFA for each.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Please see the release notes (`documentation/release_notes.html`) for a descript
 ## Notes
 - By default, the end date for the data in the code is 2024-12-31, which you can change by editing line 4 of the `code/main.py` file. For example, for May 6, 1992, use: `end_date = pl.datetime(1992, 5, 6)`.
 
+- **Persistent WRDS Connection**: If you're running on an HPC cluster with NAT IP rotation (such as Yale's Bouchet cluster), you may receive many MFA prompts during data download. This happens because each database query creates a new TCP connection, and the NAT gateway assigns a random outbound IP to each connection. WRDS sees these as connections from different locations and triggers MFA for each.
+
+  To avoid this, use the `--persistent-connection` flag, which maintains a single database connection throughout the download process:
+  ```sh
+  # Interactive session
+  uv run python code/main.py --persistent-connection
+
+  # Slurm job (set environment variable)
+  sbatch --export=ALL,PERSISTENT_WRDS_CONNECTION=1 slurm/submit_job_som_hpc.slurm
+  ```
+  This reduces MFA prompts from ~26 (one per table) to just 1 (at connection time).
+
 - To run the code, we utilize a high performance computing cluster, where we request 450 GB RAM and 128 CPU cores. Running the routine takes about 6 hours.
 
 - To understand the data, please refer to our [documentation](https://jkpfactors.s3.amazonaws.com/documents/Documentation.pdf). 

--- a/code/aux_functions.py
+++ b/code/aux_functions.py
@@ -730,7 +730,9 @@ def download_raw_data_tables(
         1) Connect to WRDS; iterate through a fixed list of library.tables.
         2) For each table: download to raw_tables/lib_table.parquet, applying date filtering
            when end_date is provided and the table has a known date column.
-        3) Disconnect.
+        3) If persistent_connection: ATTACH a single postgres connection and download all tables.
+           Otherwise: use postgres_scan() which creates a new connection per query.
+        4) Disconnect.
 
     Args:
         username: WRDS username

--- a/code/aux_functions.py
+++ b/code/aux_functions.py
@@ -792,8 +792,19 @@ def download_raw_data_tables(
     con.execute("INSTALL postgres; LOAD postgres;")
 
     if persistent_connection:
-        # Use ATTACH for a single persistent connection (reduces MFA on NAT-rotated networks)
-        con.execute(f"ATTACH '{wrds_session_data}' AS wrds (TYPE postgres, READ_ONLY)")
+        # Use ATTACH for a single persistent connection (reduces MFA on NAT-rotated networks).
+        # DuckDB's postgres extension includes the full connection string (with password)
+        # in error messages. If the connection fails, suppress the original exception to
+        # avoid leaking credentials in logs/tracebacks, and raise a generic error instead.
+        try:
+            con.execute(f"ATTACH '{wrds_session_data}' AS wrds (TYPE postgres, READ_ONLY)")
+        except Exception as e:
+            if password in str(e):
+                raise RuntimeError(
+                    "Failed to attach persistent WRDS connection. "
+                    "Check credentials and MFA approval."
+                ) from None
+            raise
         try:
             for table in table_names:
                 download_wrds_table_attached(

--- a/code/aux_functions.py
+++ b/code/aux_functions.py
@@ -638,6 +638,43 @@ def get_columns(conn, conninfo, lib, table):
     return [c[0] for c in cols]
 
 
+def get_columns_attached(conn, db_alias, lib, table):
+    """Get column names from an attached PostgreSQL database."""
+    cols = conn.execute(f"""
+        SELECT *
+        FROM {db_alias}.{lib}.{table}
+        LIMIT 0
+    """).description
+    return [c[0] for c in cols]
+
+
+def download_wrds_table_attached(
+    duckdb_conn,
+    db_alias,
+    table_name,
+    filename,
+    date_column: str | None = None,
+    end_date: date | None = None,
+):
+    """Download a WRDS table using an attached persistent connection."""
+    lib, table = table_name.split(".")
+    cols = get_columns_attached(duckdb_conn, db_alias, lib, table)
+    projection = build_projection(cols)
+
+    where_clause = ""
+    if date_column and end_date:
+        where_clause = f"WHERE {date_column} <= '{end_date}'"
+
+    duckdb_conn.execute(f"""
+        COPY (
+          SELECT {projection}
+          FROM {db_alias}.{lib}.{table}
+          {where_clause}
+        )
+        TO '{filename}' (FORMAT PARQUET);
+    """)
+
+
 def build_projection(cols):
     casts = []
     if "permno" in cols:
@@ -682,7 +719,9 @@ def download_wrds_table(
 
 
 @measure_time
-def download_raw_data_tables(username: str, password: str, end_date: date | None = None) -> None:
+def download_raw_data_tables(
+    username: str, password: str, end_date: date | None = None, persistent_connection: bool = False
+) -> None:
     """
     Description:
         Bulk-download core WRDS tables to raw_tables and a few curated variants with column subsets.
@@ -692,6 +731,13 @@ def download_raw_data_tables(username: str, password: str, end_date: date | None
         2) For each table: download to raw_tables/lib_table.parquet, applying date filtering
            when end_date is provided and the table has a known date column.
         3) Disconnect.
+
+    Args:
+        username: WRDS username
+        password: WRDS password
+        persistent_connection: If True, use a single persistent connection via ATTACH.
+            This reduces MFA prompts on systems with NAT IP rotation (e.g., Yale Bouchet).
+            If False (default), use postgres_scan() which creates a new connection per query.
 
     Output:
         Parquet files under raw_tables/ (Compustat, CRSP, FF, etc.).
@@ -743,16 +789,32 @@ def download_raw_data_tables(username: str, password: str, end_date: date | None
     con = duckdb.connect(":memory:")
     con.execute("INSTALL postgres; LOAD postgres;")
 
-    for table in table_names:
-        # print(f"Downloading WRDS table: {table}", flush=True)
-        download_wrds_table(
-            wrds_session_data,
-            con,
-            table,
-            "../raw/raw_tables/" + table.replace(".", "_") + ".parquet",
-            date_column=date_columns.get(table),
-            end_date=end_date,
-        )
+    if persistent_connection:
+        # Use ATTACH for a single persistent connection (reduces MFA on NAT-rotated networks)
+        con.execute(f"ATTACH '{wrds_session_data}' AS wrds (TYPE postgres, READ_ONLY)")
+        try:
+            for table in table_names:
+                download_wrds_table_attached(
+                    con,
+                    "wrds",
+                    table,
+                    "../raw/raw_tables/" + table.replace(".", "_") + ".parquet",
+                    date_column=date_columns.get(table),
+                    end_date=end_date,
+                )
+        finally:
+            con.execute("DETACH wrds")
+    else:
+        # Use postgres_scan() which creates a new connection per query (default)
+        for table in table_names:
+            download_wrds_table(
+                wrds_session_data,
+                con,
+                table,
+                "../raw/raw_tables/" + table.replace(".", "_") + ".parquet",
+                date_column=date_columns.get(table),
+                end_date=end_date,
+            )
 
     con.close()
 

--- a/code/main.py
+++ b/code/main.py
@@ -1,3 +1,5 @@
+import argparse
+
 import polars as pl
 from aux_functions import (
     acc_chars_list,
@@ -46,9 +48,22 @@ from aux_functions import (
 from config import END_DATE
 from wrds_credentials import get_wrds_credentials
 
+parser = argparse.ArgumentParser(description="JKP Factor Data Pipeline")
+parser.add_argument(
+    "--persistent-connection",
+    action="store_true",
+    help="Use a single persistent WRDS connection (reduces MFA prompts on NAT-rotated networks like Yale Bouchet)",
+)
+args = parser.parse_args()
+
 creds = get_wrds_credentials()
 setup_folder_structure()
-download_raw_data_tables(username=creds.username, password=creds.password, end_date=END_DATE)
+download_raw_data_tables(
+    username=creds.username,
+    password=creds.password,
+    end_date=END_DATE,
+    persistent_connection=args.persistent_connection,
+)
 aug_msf_v2()
 build_mcti()
 gen_raw_data_dfs()

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -24,7 +24,12 @@ export MKL_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 export NUMEXPR_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 
 # Create char data
-uv run python code/main.py
+# Set PERSISTENT_WRDS_CONNECTION=1 to use a single WRDS connection (reduces MFA on NAT-rotated networks)
+if [ "${PERSISTENT_WRDS_CONNECTION:-0}" = "1" ]; then
+    uv run python code/main.py --persistent-connection
+else
+    uv run python code/main.py
+fi
 
 # Create portfolio data
 uv run python code/portfolio.py

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -86,7 +86,8 @@ class TestDownloadRawDataTablesBranching:
         download_raw_data_tables("user", "pass", persistent_connection=False)
 
         executed_sql = [
-            str(c[0][0]) for c in mock_conn.execute.call_args_list
+            str(c[0][0])
+            for c in mock_conn.execute.call_args_list
             if c[0] and isinstance(c[0][0], str)
         ]
         sql_joined = " ".join(executed_sql)
@@ -103,7 +104,8 @@ class TestDownloadRawDataTablesBranching:
         download_raw_data_tables("user", "pass", persistent_connection=True)
 
         executed_sql = [
-            str(c[0][0]) for c in mock_conn.execute.call_args_list
+            str(c[0][0])
+            for c in mock_conn.execute.call_args_list
             if c[0] and isinstance(c[0][0], str)
         ]
         sql_joined = " ".join(executed_sql)
@@ -121,7 +123,8 @@ class TestDownloadRawDataTablesBranching:
         download_raw_data_tables("user", "pass", persistent_connection=True)
 
         executed_sql = [
-            str(c[0][0]) for c in mock_conn.execute.call_args_list
+            str(c[0][0])
+            for c in mock_conn.execute.call_args_list
             if c[0] and isinstance(c[0][0], str)
         ]
 
@@ -193,8 +196,7 @@ class TestDownloadWrdsTableAttached:
         download_wrds_table_attached(mock_conn, "wrds", "crsp.msf", "/tmp/test.parquet")
 
         copy_calls = [
-            c for c in mock_conn.execute.call_args_list
-            if c[0] and "COPY" in str(c[0][0])
+            c for c in mock_conn.execute.call_args_list if c[0] and "COPY" in str(c[0][0])
         ]
 
         assert len(copy_calls) == 1, "Should have exactly one COPY command"

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -1,0 +1,204 @@
+"""
+Tests for WRDS download functionality.
+
+This module tests the download_raw_data_tables function and its helper functions,
+particularly the persistent connection feature that uses ATTACH instead of postgres_scan().
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestBuildProjection:
+    """Tests for build_projection() function."""
+
+    def test_no_special_columns(self):
+        """When no special columns present, return simple wildcard."""
+        from aux_functions import build_projection
+
+        cols = ["date", "value", "name"]
+        result = build_projection(cols)
+        assert result == "*"
+
+    def test_permno_column_cast(self):
+        """permno column should be cast to BIGINT."""
+        from aux_functions import build_projection
+
+        cols = ["permno", "date", "ret"]
+        result = build_projection(cols)
+        assert "TRY_CAST(permno AS BIGINT) AS permno" in result
+        assert result.startswith("* REPLACE (")
+
+    def test_multiple_special_columns(self):
+        """Multiple special columns should all be cast."""
+        from aux_functions import build_projection
+
+        cols = ["permno", "permco", "sic", "sich", "date"]
+        result = build_projection(cols)
+        assert "TRY_CAST(permno AS BIGINT) AS permno" in result
+        assert "TRY_CAST(permco AS BIGINT) AS permco" in result
+        assert "TRY_CAST(sic AS BIGINT) AS sic" in result
+        assert "TRY_CAST(sich AS BIGINT) AS sich" in result
+
+
+class TestGenWrdsConnectionInfo:
+    """Tests for gen_wrds_connection_info() function."""
+
+    def test_connection_string_format(self):
+        """Connection string should have correct format."""
+        from aux_functions import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("testuser", "testpass")
+
+        assert "host=wrds-pgdata.wharton.upenn.edu" in result
+        assert "port=9737" in result
+        assert "dbname=wrds" in result
+        assert "user=testuser" in result
+        assert "password=testpass" in result
+        assert "sslmode=require" in result
+
+
+class TestDownloadRawDataTablesBranching:
+    """Tests for download_raw_data_tables() branching logic.
+
+    These tests verify that the correct download method is used based on
+    the persistent_connection parameter.
+    """
+
+    @pytest.fixture
+    def mock_duckdb(self):
+        """Create a mock DuckDB connection."""
+        with patch("aux_functions.duckdb") as mock:
+            mock_conn = MagicMock()
+            mock.connect.return_value = mock_conn
+            mock_result = MagicMock()
+            mock_result.description = [("col1",), ("col2",)]
+            mock_conn.execute.return_value = mock_result
+            yield mock, mock_conn
+
+    def test_persistent_connection_false_uses_postgres_scan(self, mock_duckdb):
+        """When persistent_connection=False, should use postgres_scan()."""
+        from aux_functions import download_raw_data_tables
+
+        mock, mock_conn = mock_duckdb
+
+        download_raw_data_tables("user", "pass", persistent_connection=False)
+
+        executed_sql = [
+            str(c[0][0]) for c in mock_conn.execute.call_args_list
+            if c[0] and isinstance(c[0][0], str)
+        ]
+        sql_joined = " ".join(executed_sql)
+
+        assert "postgres_scan" in sql_joined
+        assert "ATTACH" not in sql_joined
+
+    def test_persistent_connection_true_uses_attach(self, mock_duckdb):
+        """When persistent_connection=True, should use ATTACH."""
+        from aux_functions import download_raw_data_tables
+
+        mock, mock_conn = mock_duckdb
+
+        download_raw_data_tables("user", "pass", persistent_connection=True)
+
+        executed_sql = [
+            str(c[0][0]) for c in mock_conn.execute.call_args_list
+            if c[0] and isinstance(c[0][0], str)
+        ]
+        sql_joined = " ".join(executed_sql)
+
+        assert "ATTACH" in sql_joined
+        assert "DETACH" in sql_joined
+        assert "wrds." in sql_joined
+
+    def test_persistent_connection_true_single_attach(self, mock_duckdb):
+        """Persistent connection should only ATTACH once for all tables."""
+        from aux_functions import download_raw_data_tables
+
+        mock, mock_conn = mock_duckdb
+
+        download_raw_data_tables("user", "pass", persistent_connection=True)
+
+        executed_sql = [
+            str(c[0][0]) for c in mock_conn.execute.call_args_list
+            if c[0] and isinstance(c[0][0], str)
+        ]
+
+        attach_count = sum(1 for sql in executed_sql if "ATTACH" in sql and "DETACH" not in sql)
+        detach_count = sum(1 for sql in executed_sql if "DETACH" in sql)
+
+        assert attach_count == 1, f"Expected 1 ATTACH, got {attach_count}"
+        assert detach_count == 1, f"Expected 1 DETACH, got {detach_count}"
+
+    def test_connection_closed_after_download(self, mock_duckdb):
+        """Connection should be closed after download completes."""
+        from aux_functions import download_raw_data_tables
+
+        mock, mock_conn = mock_duckdb
+
+        download_raw_data_tables("user", "pass", persistent_connection=False)
+        mock_conn.close.assert_called_once()
+
+        mock_conn.reset_mock()
+
+        download_raw_data_tables("user", "pass", persistent_connection=True)
+        mock_conn.close.assert_called_once()
+
+
+class TestGetColumnsAttached:
+    """Tests for get_columns_attached() function."""
+
+    def test_returns_column_names(self):
+        """Should extract column names from query description."""
+        from aux_functions import get_columns_attached
+
+        mock_conn = MagicMock()
+        mock_result = MagicMock()
+        mock_result.description = [("permno",), ("date",), ("ret",)]
+        mock_conn.execute.return_value = mock_result
+
+        result = get_columns_attached(mock_conn, "wrds", "crsp", "msf")
+
+        assert result == ["permno", "date", "ret"]
+
+    def test_queries_attached_database(self):
+        """Should query the attached database with correct syntax."""
+        from aux_functions import get_columns_attached
+
+        mock_conn = MagicMock()
+        mock_result = MagicMock()
+        mock_result.description = [("col1",)]
+        mock_conn.execute.return_value = mock_result
+
+        get_columns_attached(mock_conn, "mydb", "mylib", "mytable")
+
+        call_args = mock_conn.execute.call_args[0][0]
+        assert "mydb.mylib.mytable" in call_args
+        assert "LIMIT 0" in call_args
+
+
+class TestDownloadWrdsTableAttached:
+    """Tests for download_wrds_table_attached() function."""
+
+    def test_copies_to_parquet(self):
+        """Should execute COPY TO parquet command."""
+        from aux_functions import download_wrds_table_attached
+
+        mock_conn = MagicMock()
+        mock_result = MagicMock()
+        mock_result.description = [("col1",), ("col2",)]
+        mock_conn.execute.return_value = mock_result
+
+        download_wrds_table_attached(mock_conn, "wrds", "crsp.msf", "/tmp/test.parquet")
+
+        copy_calls = [
+            c for c in mock_conn.execute.call_args_list
+            if c[0] and "COPY" in str(c[0][0])
+        ]
+
+        assert len(copy_calls) == 1, "Should have exactly one COPY command"
+        copy_sql = copy_calls[0][0][0]
+        assert "wrds.crsp.msf" in copy_sql
+        assert "/tmp/test.parquet" in copy_sql
+        assert "FORMAT PARQUET" in copy_sql


### PR DESCRIPTION
## Summary

This PR replaces #58, which had merge conflicts with `main` that could not be pushed to the original fork. The merge conflicts have been resolved here.

- Add a persistent WRDS download mode that uses a single DuckDB attached PostgreSQL connection instead of repeated `postgres_scan(...)` connections
- Wire the mode through `code/main.py` via `--persistent-connection`
- Allow Slurm runs to opt in with `PERSISTENT_WRDS_CONNECTION=1`
- Document the Bouchet/MFA motivation in the README
- Add focused unit coverage for the new WRDS branching and attached-table helpers
- Integrate with end-date filtering and centralized config from #67

## Why

On Bouchet, the existing WRDS download path triggered repeated MFA prompts because each table access opened a new TCP connection. WRDS saw those as distinct connection origins and the raw-table download became impractical. A single persistent connection avoids that behavior.

## Merge conflict resolution

The original PR (#58) conflicted with two PRs that landed on `main`:
- #67 (end-date filtering / centralized config)
- #65 (simplified winsorization)

This PR resolves those conflicts by combining both features: the persistent connection path now also supports date-column filtering via `end_date`, and `download_wrds_table_attached()` has been updated to apply WHERE clauses matching the non-persistent path.

## Impact

- Default behavior is unchanged
- Users on clusters with NAT IP rotation can opt into the persistent mode for WRDS downloads
- The Slurm script remains opt-in via environment variable rather than changing the default path

## Test plan

- [x] `uv run ruff check code/ tests/` — lint passes
- [x] `uv run pytest tests/unit/` — all 187 tests pass
- [x] No remaining merge conflict markers

Supersedes #58.
Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)