### PR TITLE
Change command from 'jkp connect' to 'uv run jkp connect'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repo contains Python code to generate the global dataset of factor returns,
 
    - To save your WRDS credentials, navigate to the `jkp-data/` folder and run:
      ```sh
-     jkp connect
+     uv run jkp connect
      ```
      Kindly follow the prompts.
 


### PR DESCRIPTION
Updated command to connect to WRDS credentials.
@theisj and @capellini we need 'uv run' so that we don't sync the whole environment Please approve

## Summary

<!-- What does this PR change? Provide a brief description. -->

## Change Type

<!-- Check all that apply -->

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [ ] Infrastructure change (CI, config, dependencies)
- [ ] Documentation only
- [ ] Performance-impacting change

## Methodological Impact

<!-- Does this affect factor definitions, calculations, or methodology?
     If yes, explain the changes and their rationale.
     If no, write "None" -->

## Data Impact

<!-- Will this change affect previously computed outputs?
     Could this change the factor returns or characteristics that users download?
     If yes, explain what will change.
     If no, write "None" -->

## Breaking Changes

<!-- Does this PR intentionally change previously released datasets?
     If yes, explain why and whether release notes must be updated.
     If no, write "None" -->

## Tests

<!-- What test coverage was added or modified?
     If this is a bug fix, did you add a test that would have caught it?
     If this is a new feature, did you add tests for the new functionality? -->

## Checklist

- [ ] I have run the tests locally (`pytest`)
- [ ] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [ ] I have verified the pipeline runs successfully after my changes
- [ ] I have updated documentation if needed
- [ ] I have considered whether this change affects factor calculations

## Additional Notes

<!-- Any other context, screenshots, or information reviewers should know? -->
