### PR TITLE
Unify pipeline params in config.py

### DIFF
--- a/src/jkp/data/config.py
+++ b/src/jkp/data/config.py
@@ -1,10 +1,46 @@
 from datetime import date
 
+import polars as pl
+
+# Last calendar date kept in pipeline outputs.
 END_DATE = date(2025, 12, 31)
 
+# Earliest fiscal-period-end date kept when building the standardized
+# accounting panel; rows with `datadate` before this are dropped.
+ACCOUNTING_START_DATE = pl.datetime(1949, 12, 31)
+
+# CRSP MSF / DSF row filters: 1 keeps the row, 0 drops it.
 MAIN_FILTERS = {
     "primary_sec": 1,
     "common": 1,
     "obs_main": 1,
     "exch_main": 1,
 }
+
+# Number of per-characteristic lazy pipelines collected concurrently per
+# chunk in `run_portfolio` (bounds peak memory of sort buffers / join hash
+# tables when running over hundreds of characteristics).
+COLLECT_CHUNK_SIZE = 20
+
+# Number of portfolios characteristics are sorted into (e.g. 3 -> tertiles).
+PORTFOLIO_PFS = 3
+
+# Minimum number of stocks per (industry, month) group required for the
+# group to contribute to characteristic breakpoints.
+PORTFOLIO_BP_MIN_N = 10
+
+# Minimum number of stocks a country-month needs to be eligible for the
+# regional aggregation step.
+REGIONAL_STOCKS_MIN = 5
+
+# Minimum months of history (in months; multiplied by 21 trading days for
+# daily aggregation) required for a characteristic to enter regional pfs.
+REGIONAL_MONTHS_MIN = 5 * 12
+
+# Minimum number of countries required for a regional portfolio to be
+# reported.
+REGIONAL_COUNTRIES_MIN = 3
+
+# ISO-3 country codes excluded from regional aggregation (extreme
+# inflation / hyperinflation regimes that distort returns).
+REGIONAL_COUNTRY_EXCL = ("ZWE", "VEN")

--- a/src/jkp/data/config.py
+++ b/src/jkp/data/config.py
@@ -18,8 +18,9 @@ MAIN_FILTERS = {
 }
 
 # Number of per-characteristic lazy pipelines collected concurrently per
-# chunk in `run_portfolio` (bounds peak memory of sort buffers / join hash
-# tables when running over hundreds of characteristics).
+# chunk in `portfolios()`' chunked `collect_all` logic (bounds peak memory
+# of sort buffers / join hash tables when running over hundreds of
+# characteristics).
 COLLECT_CHUNK_SIZE = 20
 
 # Number of portfolios characteristics are sorted into (e.g. 3 -> tertiles).

--- a/src/jkp/data/main.py
+++ b/src/jkp/data/main.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import polars as pl
-
 from .aux_functions import (
     acc_chars_list,
     add_ret_exc_wins,
@@ -47,7 +45,7 @@ from .aux_functions import (
     setup_folder_structure,
     standardized_accounting_data,
 )
-from .config import END_DATE
+from .config import ACCOUNTING_START_DATE, END_DATE
 from .paths import DataPaths
 from .wrds_credentials import get_wrds_credentials
 
@@ -80,7 +78,7 @@ def run_pipeline(*, persistent_connection: bool = False, output_dir: Path) -> No
     add_ret_exc_wins("d")
     market_returns("world_dsf.parquet", "d", 1, "return_cutoffs_daily.parquet")
     market_returns("world_msf.parquet", "m", 1, "return_cutoffs.parquet")
-    standardized_accounting_data("world", 1, "world_msf.parquet", 1, pl.datetime(1949, 12, 31))
+    standardized_accounting_data("world", 1, "world_msf.parquet", 1, ACCOUNTING_START_DATE)
     create_acc_chars(
         "acc_std_ann.parquet",
         "achars_world.parquet",

--- a/src/jkp/data/portfolio.py
+++ b/src/jkp/data/portfolio.py
@@ -5,7 +5,16 @@ from pathlib import Path
 
 import polars as pl
 
-from .config import END_DATE
+from .config import (
+    COLLECT_CHUNK_SIZE,
+    END_DATE,
+    PORTFOLIO_BP_MIN_N,
+    PORTFOLIO_PFS,
+    REGIONAL_COUNTRIES_MIN,
+    REGIONAL_COUNTRY_EXCL,
+    REGIONAL_MONTHS_MIN,
+    REGIONAL_STOCKS_MIN,
+)
 from .output_writer import (
     configure_output_format,
     convert_outputs_to_csv,
@@ -575,11 +584,8 @@ def portfolios(
                 )
                 pf_daily_lazys.append(pf_daily_x)
 
-    # Batch-collect per-char lazy pipelines in chunks to bound peak memory.
-    # Each chunk runs its LazyFrames concurrently via collect_all; chunks are
-    # processed sequentially so at most COLLECT_CHUNK_SIZE chars' worth of
-    # sort buffers / join hash tables live simultaneously.
-    COLLECT_CHUNK_SIZE = 20
+    # Batch-collect per-char lazy pipelines in chunks to bound peak memory
+    # (see COLLECT_CHUNK_SIZE in config.py).
     pf_returns_df: pl.DataFrame | None = None
     pf_daily_df: pl.DataFrame | None = None
 
@@ -957,20 +963,20 @@ def run_portfolio(*, output_format: str = "parquet", output_dir: Path) -> None:
     # Portfolio construction settings
     settings = {
         "end_date": END_DATE,
-        "pfs": 3,
+        "pfs": PORTFOLIO_PFS,
         "source": ["CRSP", "COMPUSTAT"],
         "wins_ret": True,
         "bps": "non_mc",
-        "bp_min_n": 10,
+        "bp_min_n": PORTFOLIO_BP_MIN_N,
         "cmp": {"us": True, "int": False},
         "signals": {"us": False, "int": False, "standardize": True, "weight": "vw_cap"},
         "regional_pfs": {
             "ret_type": "vw_cap",
-            "country_excl": ["ZWE", "VEN"],
+            "country_excl": list(REGIONAL_COUNTRY_EXCL),
             "country_weights": "market_cap",
-            "stocks_min": 5,
-            "months_min": 5 * 12,
-            "countries_min": 3,
+            "stocks_min": REGIONAL_STOCKS_MIN,
+            "months_min": REGIONAL_MONTHS_MIN,
+            "countries_min": REGIONAL_COUNTRIES_MIN,
         },
         "daily_pf": True,
         "ind_pf": True,

--- a/tests/unit/test_download_and_config.py
+++ b/tests/unit/test_download_and_config.py
@@ -20,7 +20,18 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 
-from jkp.data.config import END_DATE, MAIN_FILTERS
+from jkp.data.config import (
+    ACCOUNTING_START_DATE,
+    COLLECT_CHUNK_SIZE,
+    END_DATE,
+    MAIN_FILTERS,
+    PORTFOLIO_BP_MIN_N,
+    PORTFOLIO_PFS,
+    REGIONAL_COUNTRIES_MIN,
+    REGIONAL_COUNTRY_EXCL,
+    REGIONAL_MONTHS_MIN,
+    REGIONAL_STOCKS_MIN,
+)
 
 # =============================================================================
 # Tests: config
@@ -59,6 +70,63 @@ class TestConfig:
         """All MAIN_FILTERS values should be 1 (the passing value)."""
         for k, v in MAIN_FILTERS.items():
             assert v == 1, f"MAIN_FILTERS['{k}'] should be 1, got {v}"
+
+    def test_accounting_start_date_is_polars_expr(self):
+        """ACCOUNTING_START_DATE should be a Polars expression (consumed inline)."""
+        assert isinstance(ACCOUNTING_START_DATE, pl.Expr), (
+            f"ACCOUNTING_START_DATE should be pl.Expr, got {type(ACCOUNTING_START_DATE)}"
+        )
+
+    def test_accounting_start_date_value(self):
+        """ACCOUNTING_START_DATE should evaluate to 1949-12-31."""
+        evaluated = pl.select(ACCOUNTING_START_DATE).item()
+        assert evaluated.date() == date(1949, 12, 31), (
+            f"ACCOUNTING_START_DATE should be 1949-12-31, got {evaluated}"
+        )
+
+    def test_collect_chunk_size_is_positive_int(self):
+        """COLLECT_CHUNK_SIZE must be a positive int (used as a slice step)."""
+        assert isinstance(COLLECT_CHUNK_SIZE, int) and COLLECT_CHUNK_SIZE > 0, (
+            f"COLLECT_CHUNK_SIZE should be a positive int, got {COLLECT_CHUNK_SIZE!r}"
+        )
+
+    def test_portfolio_pfs_value(self):
+        """PORTFOLIO_PFS pins the portfolio sort count (tertiles by default)."""
+        assert PORTFOLIO_PFS == 3, f"PORTFOLIO_PFS expected 3, got {PORTFOLIO_PFS}"
+
+    def test_portfolio_bp_min_n_value(self):
+        """PORTFOLIO_BP_MIN_N pins the per-(industry, month) breakpoint min."""
+        assert PORTFOLIO_BP_MIN_N == 10, f"PORTFOLIO_BP_MIN_N expected 10, got {PORTFOLIO_BP_MIN_N}"
+
+    def test_regional_stocks_min_value(self):
+        """REGIONAL_STOCKS_MIN pins the per-country-month minimum."""
+        assert REGIONAL_STOCKS_MIN == 5, (
+            f"REGIONAL_STOCKS_MIN expected 5, got {REGIONAL_STOCKS_MIN}"
+        )
+
+    def test_regional_months_min_value(self):
+        """REGIONAL_MONTHS_MIN pins the 5-year history minimum."""
+        assert REGIONAL_MONTHS_MIN == 60, (
+            f"REGIONAL_MONTHS_MIN expected 60 months, got {REGIONAL_MONTHS_MIN}"
+        )
+
+    def test_regional_countries_min_value(self):
+        """REGIONAL_COUNTRIES_MIN pins the regional aggregation minimum."""
+        assert REGIONAL_COUNTRIES_MIN == 3, (
+            f"REGIONAL_COUNTRIES_MIN expected 3, got {REGIONAL_COUNTRIES_MIN}"
+        )
+
+    def test_regional_country_excl_is_immutable(self):
+        """REGIONAL_COUNTRY_EXCL must be a tuple to prevent accidental mutation."""
+        assert isinstance(REGIONAL_COUNTRY_EXCL, tuple), (
+            f"REGIONAL_COUNTRY_EXCL should be a tuple, got {type(REGIONAL_COUNTRY_EXCL)}"
+        )
+
+    def test_regional_country_excl_value(self):
+        """REGIONAL_COUNTRY_EXCL pins the excluded ISO-3 codes."""
+        assert REGIONAL_COUNTRY_EXCL == ("ZWE", "VEN"), (
+            f"REGIONAL_COUNTRY_EXCL expected ('ZWE', 'VEN'), got {REGIONAL_COUNTRY_EXCL}"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Move 8 hardcoded pipeline parameters from `src/jkp/data/main.py` and `src/jkp/data/portfolio.py` into `src/jkp/data/config.py`, extending the precedent already set by `END_DATE` and `MAIN_FILTERS`. Each new constant carries a one-line `#` comment describing what it controls.

| Source | Was | Now |
|---|---|---|
| `main.py:81` | `pl.datetime(1949, 12, 31)` | `ACCOUNTING_START_DATE` |
| `portfolio.py` (function-local) | `COLLECT_CHUNK_SIZE = 20` | `COLLECT_CHUNK_SIZE` |
| `portfolio.py` settings dict | `pfs: 3` | `PORTFOLIO_PFS` |
| `portfolio.py` settings dict | `bp_min_n: 10` | `PORTFOLIO_BP_MIN_N` |
| `portfolio.py` settings dict | `stocks_min: 5` | `REGIONAL_STOCKS_MIN` |
| `portfolio.py` settings dict | `months_min: 5*12` | `REGIONAL_MONTHS_MIN` |
| `portfolio.py` settings dict | `countries_min: 3` | `REGIONAL_COUNTRIES_MIN` |
| `portfolio.py` settings dict | `country_excl: ["ZWE","VEN"]` | `REGIONAL_COUNTRY_EXCL` (tuple) |

`REGIONAL_COUNTRY_EXCL` is stored as a tuple to prevent accidental module-level mutation; `portfolio.py` wraps it in `list(...)` at use-site to preserve the existing settings-dict shape.

## Change Type

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [x] Infrastructure change (CI, config, dependencies)
- [ ] Documentation only
- [ ] Performance-impacting change

## Methodological Impact

None. Pure refactor — all 8 values are moved verbatim, no defaults change.

## Data Impact

None. Outputs are byte-identical (verified by `tests/unit/test_portfolio.py` and `tests/unit/test_portfolio_parity.py`, which still pass).

## Breaking Changes

None.

## Tests

`tests/unit/test_download_and_config.py::TestConfig` extended with type + value assertions for each new constant — regression guard against unintended changes:

- `ACCOUNTING_START_DATE` is `pl.Expr` evaluating to 1949-12-31
- `COLLECT_CHUNK_SIZE` is positive int
- `PORTFOLIO_PFS == 3`, `PORTFOLIO_BP_MIN_N == 10`
- `REGIONAL_STOCKS_MIN == 5`, `REGIONAL_MONTHS_MIN == 60`, `REGIONAL_COUNTRIES_MIN == 3`
- `REGIONAL_COUNTRY_EXCL` is a `tuple` equal to `("ZWE", "VEN")`

Full unit suite: 356 passed, 3 skipped (pre-existing skips for non-USA cases).

## Checklist

- [x] I have run the tests locally (`pytest`)
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [ ] I have verified the pipeline runs successfully after my changes
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

Pipeline run not executed locally (requires WRDS + ~450 GB RAM) — relying on parity tests.

## Additional Notes

Closes #121.

Test literals in `tests/unit/test_portfolio.py` and `tests/unit/test_portfolio_parity.py` were intentionally left as hardcoded `pfs=3`, `bp_min_n=10` — those are test-case parameters, not production defaults, and shouldn't be coupled to config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)