### PR TITLE
docs: add WRDS data-usage disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repo contains Python code to generate the global dataset of factor returns, stock returns, and firm characteristics from [“Is there a Replication Crisis in Finance?”](https://onlinelibrary.wiley.com/doi/full/10.1111/jofi.13249) by Jensen, Kelly, and Pedersen (Journal of Finance, 2023).
 
+## Data Usage
+
+This package requires a valid [WRDS](https://wrds-www.wharton.upenn.edu/) subscription. The authors do not distribute WRDS, CRSP, Compustat, or IBES data; this tool only orchestrates the user's own licensed downloads and transformations. Outputs generated locally are derived from your licensed WRDS data and remain subject to your WRDS and vendor license terms.
+
+If you do not have a WRDS subscription, you can still access pre-computed factor portfolios at [jkpfactors.com](https://jkpfactors.com) and pre-computed stock returns and firm characteristics at the [WRDS Global Factor Data page](https://wrds-www.wharton.upenn.edu/pages/get-data/contributed-data-forms/global-factor-data/).
+
 ## Instructions
 
 ### Prerequisites

--- a/src/jkp/data/resources/README.md
+++ b/src/jkp/data/resources/README.md
@@ -1,7 +1,7 @@
 # Data Directory
 
 Data files in this directory authored by Jensen, Kelly, and Pedersen are
-licensed under [CC BY-NC 4.0](../DATA_LICENSE)
+licensed under [CC BY-NC 4.0](https://github.com/bkelly-lab/jkp-data/blob/main/DATA_LICENSE)
 (Creative Commons Attribution-NonCommercial 4.0). When this file appears in
 your output directory, it accompanies generated factor portfolios, stock
 returns, and firm characteristics; those outputs are also subject to your

--- a/src/jkp/data/resources/README.md
+++ b/src/jkp/data/resources/README.md
@@ -1,7 +1,11 @@
 # Data Directory
 
-All data contained in this directory is licensed under
-[CC BY-NC 4.0](../DATA_LICENSE) (Creative Commons Attribution-NonCommercial 4.0).
+Data files in this directory authored by Jensen, Kelly, and Pedersen are
+licensed under [CC BY-NC 4.0](../DATA_LICENSE)
+(Creative Commons Attribution-NonCommercial 4.0). When this file appears in
+your output directory, it accompanies generated factor portfolios, stock
+returns, and firm characteristics; those outputs are also subject to your
+WRDS and vendor license terms.
 
 ## Usage
 
@@ -15,3 +19,22 @@ If you use this data, please cite:
 > Jensen, T. I., Kelly, B. T., & Pedersen, L. H. (2023).
 > Is There a Replication Crisis in Finance?
 > *Journal of Finance*. https://doi.org/10.1111/jofi.13249
+
+## Bundled reference files (source distribution)
+
+The `jkp-data` package source ships with the following reference
+classification files under `src/jkp/data/resources/`. None are derived from
+WRDS, CRSP, Compustat, or IBES vendor data:
+
+- **`Siccodes49.txt`** — Fama-French 49-industry classification mapping SIC
+  codes to industry groups. Sourced from Ken French's
+  [data library](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html);
+  subject to its own publicly-available terms.
+- **`cluster_labels.csv`** — Maps firm characteristics to thematic clusters
+  (e.g., "Low Leverage", "Investment", "Size", "Low Risk"). Authored by
+  Jensen, Kelly, and Pedersen.
+- **`country_classification.xlsx`** — Country-to-region mapping used to
+  group outputs. Authored by Jensen, Kelly, and Pedersen.
+- **`factor_details.xlsx`** — Metadata describing factor portfolios
+  (cluster membership, descriptions). Authored by Jensen, Kelly, and
+  Pedersen.


### PR DESCRIPTION
## Summary

Adds a prominent "Data Usage" section to the top-level `README.md` clarifying that `jkp-data` requires the user's own WRDS subscription and does not redistribute WRDS, CRSP, Compustat, or IBES data. Also documents the provenance of bundled reference files in `src/jkp/data/resources/README.md` and reframes its license summary to accurately distinguish JKP-authored files from the Fama-French 49-industry classification (`Siccodes49.txt`) sourced from Ken French's public data library.

This is a Tier 0 prerequisite for publishing the package to PyPI: a public package without an explicit WRDS disclaimer risks vendor complaints, reputational consequences for the authors' institutional WRDS subscriptions, and accidental contributor violations (e.g., bundling real CRSP samples as test fixtures).

Closes #94.

## Change Type

- [x] Documentation only

## Methodological Impact

None.

## Data Impact

None.

## Breaking Changes

None.

## Tests

No new tests. Existing `tests/unit/test_paths.py` (which exercises the bundled `resources/README.md` via `get_data_readme_path()`) still passes — the file is still present at the same location and is still copied into the user's output directory by `aux_functions.create_directories()`.

## Checklist

- [x] I have run the tests locally (`pytest`) — `tests/unit/test_paths.py` passes
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [ ] I have verified the pipeline runs successfully after my changes — N/A, docs-only
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations — it does not

## Additional Notes

The bundled-files audit confirmed none of `Siccodes49.txt`, `cluster_labels.csv`, `country_classification.xlsx`, or `factor_details.xlsx` are derived from WRDS, CRSP, Compustat, or IBES vendor data. They are reference classifications either authored by Jensen, Kelly, and Pedersen or sourced from Ken French's publicly-available data library.