### PR TITLE
Add py.typed marker for type information distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ where = ["src"]
 namespaces = true
 
 [tool.setuptools.package-data]
-"jkp.data" = ["resources/*"]
+"jkp.data" = ["py.typed", "resources/*"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

Adds an empty `src/jkp/data/py.typed` marker file and updates `[tool.setuptools.package-data]` so the marker ships in built wheels and sdists. Without this marker, downstream type-checkers (mypy, pyright) ignore type annotations declared inside the package, and consumers see the public surface as `Any`.

The marker is placed in the `jkp.data` submodule rather than the `jkp` namespace, per the typing specification for namespace packages:
https://typing.python.org/en/latest/spec/distributing.html

This is a Tier 0 prerequisite for publishing the package to PyPI.

Closes #95.

## Change Type

- [x] Infrastructure change (CI, config, dependencies)

## Methodological Impact

None.

## Data Impact

None.

## Breaking Changes

None.

## Tests

No new tests. Verified manually that the marker is included in both the wheel and the sdist:

```
$ uv build
$ unzip -l dist/jkp_data-0.1.0-py3-none-any.whl | grep py.typed
        0  ...   jkp/data/py.typed
$ tar tzf dist/jkp_data-0.1.0.tar.gz | grep py.typed
jkp_data-0.1.0/src/jkp/data/py.typed
```

## Checklist

- [x] I have run the tests locally (`pytest`) — no test changes; existing tests unaffected
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [ ] I have verified the pipeline runs successfully after my changes — N/A, packaging-only change
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations — it does not

## Additional Notes

The marker file is intentionally empty — that's the convention for the `py.typed` mechanism; the file's existence is the signal. The actual type information comes from annotations already in the source code.