### PR TITLE
Stop forcing PlaintextKeyring at import; require explicit opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
         `~/.local/share/python_keyring/`. Selected **only when**
         `JKP_ALLOW_PLAINTEXT_KEYRING=1` is set; appropriate for headless
         environments (HPC compute nodes, minimal Docker images) where no
-        system keyring daemon is available. The package emits a warning each
-        time the swap occurs so the change of backend is never silent.
+        system keyring daemon is available. The variable must be exactly `1` —
+        `true`, `yes`, etc. are treated as not set. The package emits a
+        warning each time the swap occurs so the change of backend is never
+        silent.
 
    On a Slurm/HPC compute node, run `jkp connect` once on the login node
    under `JKP_ALLOW_PLAINTEXT_KEYRING=1` to populate the file keyring, then

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
 
      Note: If you need to change your password or credentials, run `jkp connect --reset` and then `jkp connect`
 
+   - **Credential precedence.** When the pipeline needs WRDS credentials, it
+     looks for them in this order:
+
+     1. `WRDS_USERNAME` and `WRDS_PASSWORD` environment variables. Useful for
+        containers and shared service accounts where the source of truth
+        shouldn't live in a per-user filesystem location.
+     2. The system keyring (Keychain on macOS, Secret Service on Linux desktop,
+        Credential Vault on Windows). The default for interactive sessions.
+     3. The file-backed keyring (`keyrings.alt.file.PlaintextKeyring`), which
+        stores the password in a mode-600 file under
+        `~/.local/share/python_keyring/`. Selected **only when**
+        `JKP_ALLOW_PLAINTEXT_KEYRING=1` is set; appropriate for headless
+        environments (HPC compute nodes, minimal Docker images) where no
+        system keyring daemon is available. The package emits a warning each
+        time the swap occurs so the change of backend is never silent.
+
+   On a Slurm/HPC compute node, run `jkp connect` once on the login node
+   under `JKP_ALLOW_PLAINTEXT_KEYRING=1` to populate the file keyring, then
+   set the same variable in the batch script before invoking `jkp build`.
+
 3. **Run the script**
 
    - We run the code via a Slurm scheduler, but we also show how to run it in an interactive Python session.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
         environments (HPC compute nodes, minimal Docker images) where no
         system keyring daemon is available. The variable must be exactly `1` —
         `true`, `yes`, etc. are treated as not set. The package emits a
-        warning each time the swap occurs so the change of backend is never
-        silent.
+        warning on first use (once per process) so the change of backend is
+        never silent.
 
    On a Slurm/HPC compute node, run `jkp connect` once on the login node
    under `JKP_ALLOW_PLAINTEXT_KEYRING=1` to populate the file keyring, then

--- a/README.md
+++ b/README.md
@@ -34,22 +34,9 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
      Note: If you need to change your password or credentials, run `jkp connect --reset` and then `jkp connect`
 
    - **Credential precedence.** When the pipeline needs WRDS credentials, it
-     looks for them in this order:
-
-     1. `WRDS_USERNAME` and `WRDS_PASSWORD` environment variables. Useful for
-        containers and shared service accounts where the source of truth
-        shouldn't live in a per-user filesystem location.
-     2. The system keyring (Keychain on macOS, Secret Service on Linux desktop,
-        Credential Vault on Windows). The default for interactive sessions.
-     3. The file-backed keyring (`keyrings.alt.file.PlaintextKeyring`), which
-        stores the password in a mode-600 file under
-        `~/.local/share/python_keyring/`. Selected **only when**
-        `JKP_ALLOW_PLAINTEXT_KEYRING=1` is set; appropriate for headless
-        environments (HPC compute nodes, minimal Docker images) where no
-        system keyring daemon is available. The variable must be exactly `1` —
-        `true`, `yes`, etc. are treated as not set. The package emits a
-        warning on first use (once per process) so the change of backend is
-        never silent.
+     resolves them from environment variables, then the system keyring, then an
+     opt-in file-backed keyring. Run `jkp connect --help` for the full
+     precedence order and the `JKP_ALLOW_PLAINTEXT_KEYRING` opt-in details.
 
    On a Slurm/HPC compute node, run `jkp connect` once on the login node
    under `JKP_ALLOW_PLAINTEXT_KEYRING=1` to populate the file keyring, then

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -30,6 +30,18 @@ export NUMEXPR_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 # Activate the project's virtual environment so the jkp CLI is on PATH
 source .venv/bin/activate
 
+# WRDS credentials. Compute nodes don't have a system keyring daemon, so the
+# pipeline needs an alternate source. The default below opts in to the
+# file-backed keyring (a mode-600 file under ~/.local/share/python_keyring/);
+# populate it once on the login node by running:
+#
+#     JKP_ALLOW_PLAINTEXT_KEYRING=1 jkp connect
+#
+# Alternative (for shared service accounts or container deployments): unset
+# JKP_ALLOW_PLAINTEXT_KEYRING and export WRDS_USERNAME / WRDS_PASSWORD instead,
+# e.g. by sourcing a mode-600 ~/.wrds_secrets file with `export WRDS_USERNAME=...`.
+export JKP_ALLOW_PLAINTEXT_KEYRING=1
+
 # Create char data
 # Set PERSISTENT_WRDS_CONNECTION=1 to use a single WRDS connection (reduces MFA on NAT-rotated networks)
 if [ "${PERSISTENT_WRDS_CONNECTION:-0}" = "1" ]; then

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -97,7 +97,21 @@ def connect(
         help="Reset stored WRDS credentials.",
     ),
 ) -> None:
-    """Test or configure WRDS connection."""
+    """Test or configure the WRDS connection.
+
+    Credential precedence (highest first):
+
+      1. WRDS_USERNAME and WRDS_PASSWORD environment variables. Useful for
+         containers and shared service accounts.
+      2. The system keyring (Keychain on macOS, Secret Service on Linux desktop,
+         Credential Vault on Windows). Default for interactive sessions.
+      3. The file-backed keyring (keyrings.alt.file.PlaintextKeyring), which
+         stores the password in a mode-600 file under
+         ~/.local/share/python_keyring/. Selected only when
+         JKP_ALLOW_PLAINTEXT_KEYRING=1 is set; appropriate for headless
+         environments (HPC compute nodes, minimal Docker images) where no
+         system keyring daemon is available.
+    """
     from .wrds_credentials import get_wrds_credentials, reset_credentials
 
     if reset:

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -88,6 +88,9 @@ def portfolio(
     run_portfolio(output_format=output_format.value, output_dir=output_dir)
 
 
+# This help text is the canonical description of the credential precedence
+# order; the README, the wrds_credentials module docstring, and the tests point
+# here rather than restating it. Update here first.
 @app.command()
 def connect(
     reset: bool = typer.Option(
@@ -108,9 +111,11 @@ def connect(
       3. The file-backed keyring (keyrings.alt.file.PlaintextKeyring), which
          stores the password in a mode-600 file under
          ~/.local/share/python_keyring/. Selected only when
-         JKP_ALLOW_PLAINTEXT_KEYRING=1 is set; appropriate for headless
-         environments (HPC compute nodes, minimal Docker images) where no
-         system keyring daemon is available.
+         JKP_ALLOW_PLAINTEXT_KEYRING is set to exactly "1" ("true", "yes", etc.
+         are treated as not set); appropriate for headless environments (HPC
+         compute nodes, minimal Docker images) where no system keyring daemon
+         is available. A warning is emitted on first use (once per process) so
+         the backend change is never silent.
     """
     from .wrds_credentials import get_wrds_credentials, reset_credentials
 

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -1,8 +1,35 @@
-import os
+"""WRDS credential resolution.
 
-os.environ["PYTHON_KEYRING_BACKEND"] = "keyrings.alt.file.PlaintextKeyring"
+Credential precedence (highest first):
+
+1. ``WRDS_USERNAME`` / ``WRDS_PASSWORD`` environment variables. Useful for
+   container deployments and shared service accounts where the source of
+   truth shouldn't be a per-user filesystem location.
+2. The system keyring (Keychain on macOS, Secret Service on Linux desktop,
+   Credential Vault on Windows). The default for interactive sessions.
+3. The file-backed keyring (``keyrings.alt.file.PlaintextKeyring``), which
+   stores the password in a mode-600 file under ``~/.local/share/python_keyring/``.
+   This is appropriate for headless environments (HPC compute nodes,
+   minimal Docker images) where no system keyring daemon is available — the
+   stored secret has the same security posture as any other 600-mode dotfile
+   in the user's home directory.
+
+   This backend is not selected automatically. The previous implementation
+   set ``PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring`` at
+   module-import time, which silently changed the keyring backend for every
+   process that imported anything from ``jkp.data`` — surprising, undocumented,
+   and unnecessary on machines where a system keyring is available. Now the
+   user must opt in with ``JKP_ALLOW_PLAINTEXT_KEYRING=1``, and the swap
+   happens only inside this module's credential-resolution functions, never
+   at import time.
+"""
+
+from __future__ import annotations
+
 import argparse
 import getpass
+import os
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +38,11 @@ import keyring
 SERVICE_NAME = "WRDS"
 LAST_USER_FILE = Path.home() / ".wrds_user"  # remembers last username
 
+# Environment variable names.
+ENV_USERNAME = "WRDS_USERNAME"
+ENV_PASSWORD = "WRDS_PASSWORD"
+ENV_ALLOW_PLAINTEXT = "JKP_ALLOW_PLAINTEXT_KEYRING"
+
 
 @dataclass(frozen=True)
 class Credentials:
@@ -18,23 +50,61 @@ class Credentials:
     password: str
 
 
+def _maybe_use_file_keyring() -> None:
+    """If the user explicitly opts in, switch the keyring backend to the
+    file-backed ``keyrings.alt.file.PlaintextKeyring``.
+
+    Called at credential-resolution time, never at import. The backend stores
+    the password in a mode-600 file under ``~/.local/share/python_keyring/``;
+    the security posture is the same as any other user-private dotfile.
+    """
+    if os.environ.get(ENV_ALLOW_PLAINTEXT) != "1":
+        return
+    warnings.warn(
+        f"{ENV_ALLOW_PLAINTEXT}=1 is set: switching the keyring backend to "
+        "keyrings.alt.file.PlaintextKeyring for this process. The WRDS "
+        "password will be read from / written to a mode-600 file under "
+        "~/.local/share/python_keyring/.",
+        stacklevel=2,
+    )
+    from keyrings.alt.file import PlaintextKeyring  # noqa: PLC0415
+
+    keyring.set_keyring(PlaintextKeyring())
+
+
+def _credentials_from_env() -> Credentials | None:
+    """Return env-var credentials if both ``WRDS_USERNAME`` and ``WRDS_PASSWORD`` are set."""
+    user = os.environ.get(ENV_USERNAME)
+    password = os.environ.get(ENV_PASSWORD)
+    if user and password:
+        return Credentials(user, password)
+    return None
+
+
 def get_wrds_credentials() -> Credentials:
+    """Resolve WRDS credentials following the documented precedence order.
+
+    Steps:
+      1. If ``WRDS_USERNAME`` and ``WRDS_PASSWORD`` are both set, return those.
+      2. Otherwise, look up the saved username in ``~/.wrds_user`` (prompt
+         interactively on first run).
+      3. Fetch the password from the (possibly plaintext-opt-in) keyring;
+         prompt and store on first run.
     """
-    Automatically retrieves credentials for wrds.
-    - On first run: asks for username and password/token, stores them.
-    - On later runs: loads both silently from the system keyring.
-    """
-    # Try to remember the last-used username
+    env_creds = _credentials_from_env()
+    if env_creds is not None:
+        return env_creds
+
+    _maybe_use_file_keyring()
+
     if LAST_USER_FILE.exists():
         username = LAST_USER_FILE.read_text().strip()
     else:
         username = input(f"Username for {SERVICE_NAME}: ").strip()
         LAST_USER_FILE.write_text(username)
 
-    # Try to retrieve the stored password for this username
     password = keyring.get_password(SERVICE_NAME, username)
 
-    # If not found, prompt once and store it securely
     if not password:
         password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
         keyring.set_password(SERVICE_NAME, username, password)
@@ -43,10 +113,9 @@ def get_wrds_credentials() -> Credentials:
     return Credentials(username, password)
 
 
-def reset_credentials(full_reset: bool = False):
-    """
-    Clears stored username and optionally removes password from keyring.
-    """
+def reset_credentials(full_reset: bool = False) -> None:
+    """Clear the stored username and (optionally) remove the password from the keyring."""
+    _maybe_use_file_keyring()
     if LAST_USER_FILE.exists():
         username = LAST_USER_FILE.read_text().strip()
         LAST_USER_FILE.unlink()

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -54,6 +54,12 @@ def _maybe_use_file_keyring() -> None:
     """If the user explicitly opts in, switch the keyring backend to the
     file-backed ``keyrings.alt.file.PlaintextKeyring``.
 
+    Opt-in: set the ``JKP_ALLOW_PLAINTEXT_KEYRING`` environment variable to
+    exactly the string ``"1"``. Any other value (including ``"true"``,
+    ``"yes"``, ``"True"``, or ``"0"``) is treated as not set and the system
+    keyring is used. We use a strict comparison rather than truthy parsing so
+    that the opt-in is unambiguous and matches the documented form.
+
     Called at credential-resolution time, never at import. The backend stores
     the password in a mode-600 file under ``~/.local/share/python_keyring/``;
     the security posture is the same as any other user-private dotfile.

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -133,7 +133,8 @@ def _keyring_backend() -> Iterator[_WrdsKeyring]:
 
 
 def _credentials_from_env() -> Credentials | None:
-    """Return env-var credentials if both ``WRDS_USERNAME`` and ``WRDS_PASSWORD`` are set."""
+    """Return env-var credentials if both ``WRDS_USERNAME`` and ``WRDS_PASSWORD`` are set to
+    non-empty values."""
     user = os.environ.get(ENV_USERNAME)
     password = os.environ.get(ENV_PASSWORD)
     if user and password:

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -27,13 +27,17 @@ Credential precedence (highest first):
 from __future__ import annotations
 
 import argparse
+import contextlib
+import functools
 import getpass
 import os
 import warnings
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
 import keyring
+import keyring.errors
 
 SERVICE_NAME = "WRDS"
 LAST_USER_FILE = Path.home() / ".wrds_user"  # remembers last username
@@ -43,6 +47,18 @@ ENV_USERNAME = "WRDS_USERNAME"
 ENV_PASSWORD = "WRDS_PASSWORD"
 ENV_ALLOW_PLAINTEXT = "JKP_ALLOW_PLAINTEXT_KEYRING"
 
+# Shown when no keyring backend is available, in place of keyring's generic
+# NoKeyringError ("No recommended backend was available ..."), which gives the
+# user no way forward. The env-var names are interpolated (not their values) so
+# the guidance stays in sync if a name ever changes.
+_NO_BACKEND_GUIDANCE = (
+    "No usable keyring backend is available on this system. On a headless "
+    "machine (HPC compute node, minimal container) choose one of:\n"
+    f"  - set {ENV_USERNAME} and {ENV_PASSWORD} in the environment, or\n"
+    f"  - set {ENV_ALLOW_PLAINTEXT}=1 to use a mode-600 file-backed keyring "
+    "under ~/.local/share/python_keyring/."
+)
+
 
 @dataclass(frozen=True)
 class Credentials:
@@ -50,9 +66,10 @@ class Credentials:
     password: str
 
 
-def _maybe_use_file_keyring() -> None:
-    """If the user explicitly opts in, switch the keyring backend to the
-    file-backed ``keyrings.alt.file.PlaintextKeyring``.
+@functools.cache
+def _ensure_keyring_backend() -> None:
+    """Select the keyring backend for this process, applying the opt-in
+    file-backed swap if (and only if) the user asked for it.
 
     Opt-in: set the ``JKP_ALLOW_PLAINTEXT_KEYRING`` environment variable to
     exactly the string ``"1"``. Any other value (including ``"true"``,
@@ -60,9 +77,12 @@ def _maybe_use_file_keyring() -> None:
     keyring is used. We use a strict comparison rather than truthy parsing so
     that the opt-in is unambiguous and matches the documented form.
 
-    Called at credential-resolution time, never at import. The backend stores
-    the password in a mode-600 file under ``~/.local/share/python_keyring/``;
-    the security posture is the same as any other user-private dotfile.
+    Cached so the swap runs at most once per process: every keyring operation
+    routes through this, but the env var is read and the warning emitted only on
+    the first call. Called at credential-resolution time, never at import. The
+    backend stores the password in a mode-600 file under
+    ``~/.local/share/python_keyring/``; the security posture is the same as any
+    other user-private dotfile.
     """
     if os.environ.get(ENV_ALLOW_PLAINTEXT) != "1":
         return
@@ -76,6 +96,53 @@ def _maybe_use_file_keyring() -> None:
     from keyrings.alt.file import PlaintextKeyring  # noqa: PLC0415
 
     keyring.set_keyring(PlaintextKeyring())
+
+
+@dataclass(frozen=True)
+class _WrdsKeyring:
+    """WRDS-scoped wrapper over the keyring library.
+
+    The one place that speaks keyring's vocabulary for credential storage:
+    callers get/set/delete the WRDS password without naming ``SERVICE_NAME`` or
+    handling keyring's exception types. Handed out only via ``_keyring_backend``.
+    """
+
+    def get_password(self, username: str) -> str | None:
+        return keyring.get_password(SERVICE_NAME, username)
+
+    def set_password(self, username: str, password: str) -> None:
+        keyring.set_password(SERVICE_NAME, username, password)
+
+    def delete_password(self, username: str) -> bool:
+        """Delete the stored password; return ``False`` if there was nothing to
+        delete (or the keyring declined).
+
+        ``NoKeyringError`` is intentionally not caught here, so the
+        missing-backend case still propagates to ``_keyring_backend`` for
+        translation rather than being reported as an absent entry.
+        """
+        try:
+            keyring.delete_password(SERVICE_NAME, username)
+        except keyring.errors.PasswordDeleteError:
+            return False
+        return True
+
+
+@contextlib.contextmanager
+def _keyring_backend() -> Iterator[_WrdsKeyring]:
+    """Single entry point for any keyring access.
+
+    Ensures the opt-in backend is selected (once), then yields a WRDS-scoped
+    handle for credential storage. Translates keyring's generic
+    ``NoKeyringError`` into actionable guidance pointing at the env-var and
+    plaintext-opt-in escape hatches. All keyring access goes through the yielded
+    handle, so callers never touch the keyring library directly.
+    """
+    _ensure_keyring_backend()
+    try:
+        yield _WrdsKeyring()
+    except keyring.errors.NoKeyringError as exc:
+        raise keyring.errors.NoKeyringError(_NO_BACKEND_GUIDANCE) from exc
 
 
 def _credentials_from_env() -> Credentials | None:
@@ -101,38 +168,36 @@ def get_wrds_credentials() -> Credentials:
     if env_creds is not None:
         return env_creds
 
-    _maybe_use_file_keyring()
-
     if LAST_USER_FILE.exists():
         username = LAST_USER_FILE.read_text().strip()
     else:
         username = input(f"Username for {SERVICE_NAME}: ").strip()
         LAST_USER_FILE.write_text(username)
 
-    password = keyring.get_password(SERVICE_NAME, username)
+    with _keyring_backend() as kr:
+        password = kr.get_password(username)
 
-    if not password:
-        password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
-        keyring.set_password(SERVICE_NAME, username, password)
-        print(f"Stored credentials for '{username}' in keyring under '{SERVICE_NAME}'")
+        if not password:
+            password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
+            kr.set_password(username, password)
+            print(f"Stored credentials for '{username}' in keyring under '{SERVICE_NAME}'")
 
     return Credentials(username, password)
 
 
 def reset_credentials(full_reset: bool = False) -> None:
     """Clear the stored username and (optionally) remove the password from the keyring."""
-    _maybe_use_file_keyring()
     if LAST_USER_FILE.exists():
         username = LAST_USER_FILE.read_text().strip()
         LAST_USER_FILE.unlink()
         print(f"Removed stored username '{username}'")
 
         if full_reset:
-            try:
-                keyring.delete_password(SERVICE_NAME, username)
-                print(f"Deleted password for '{username}' from keyring under '{SERVICE_NAME}'")
-            except keyring.errors.PasswordDeleteError:
-                print(f"No keyring entry found for '{username}'")
+            with _keyring_backend() as kr:
+                if kr.delete_password(username):
+                    print(f"Deleted password for '{username}' from keyring under '{SERVICE_NAME}'")
+                else:
+                    print(f"No keyring entry found for '{username}'")
 
     else:
         print("No stored username found — nothing to reset.")

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -1,27 +1,14 @@
 """WRDS credential resolution.
 
-Credential precedence (highest first):
+Credentials are resolved in a defined precedence order: environment variables,
+then the system keyring, then an opt-in file-backed keyring. Run
+``jkp connect --help`` for the full order and the ``JKP_ALLOW_PLAINTEXT_KEYRING``
+opt-in details.
 
-1. ``WRDS_USERNAME`` / ``WRDS_PASSWORD`` environment variables. Useful for
-   container deployments and shared service accounts where the source of
-   truth shouldn't be a per-user filesystem location.
-2. The system keyring (Keychain on macOS, Secret Service on Linux desktop,
-   Credential Vault on Windows). The default for interactive sessions.
-3. The file-backed keyring (``keyrings.alt.file.PlaintextKeyring``), which
-   stores the password in a mode-600 file under ``~/.local/share/python_keyring/``.
-   This is appropriate for headless environments (HPC compute nodes,
-   minimal Docker images) where no system keyring daemon is available — the
-   stored secret has the same security posture as any other 600-mode dotfile
-   in the user's home directory.
-
-   This backend is not selected automatically. The previous implementation
-   set ``PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring`` at
-   module-import time, which silently changed the keyring backend for every
-   process that imported anything from ``jkp.data`` — surprising, undocumented,
-   and unnecessary on machines where a system keyring is available. Now the
-   user must opt in with ``JKP_ALLOW_PLAINTEXT_KEYRING=1``, and the swap
-   happens only inside this module's credential-resolution functions, never
-   at import time.
+The file-backed keyring is never selected automatically: the user opts in with
+``JKP_ALLOW_PLAINTEXT_KEYRING=1``, and the swap happens only inside this module's
+credential-resolution functions — importing ``jkp.data`` never changes the
+process-wide keyring backend.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -1,0 +1,98 @@
+"""Tests for WRDS credential resolution.
+
+Covers the documented precedence order:
+    1. WRDS_USERNAME / WRDS_PASSWORD environment variables.
+    2. The system keyring.
+    3. Plaintext keyring, only if JKP_ALLOW_PLAINTEXT_KEYRING=1.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.unit
+def test_import_does_not_mutate_environ():
+    """Importing the module must not change PYTHON_KEYRING_BACKEND or any other
+    environment variable. The previous implementation mutated the environment at
+    import time, silently switching the user's keyring backend to plaintext."""
+    import os
+
+    before = dict(os.environ)
+    import jkp.data.wrds_credentials as mod  # noqa: F401
+
+    # Force a re-import to also exercise the import path.
+    importlib.reload(mod)
+    after = dict(os.environ)
+    assert before == after, "import must not mutate os.environ"
+
+
+@pytest.mark.unit
+def test_env_vars_take_precedence(monkeypatch):
+    """When WRDS_USERNAME and WRDS_PASSWORD are set, return those without
+    touching the keyring."""
+    monkeypatch.setenv("WRDS_USERNAME", "ci-user")
+    monkeypatch.setenv("WRDS_PASSWORD", "ci-secret")
+
+    # If keyring is touched, fail loudly.
+    import jkp.data.wrds_credentials as mod
+
+    def _boom(*a, **kw):
+        raise AssertionError("keyring must not be queried when env vars are set")
+
+    monkeypatch.setattr(mod.keyring, "get_password", _boom)
+
+    creds = mod.get_wrds_credentials()
+    assert creds.username == "ci-user"
+    assert creds.password == "ci-secret"
+
+
+@pytest.mark.unit
+def test_env_partial_falls_through_to_keyring(monkeypatch, tmp_path):
+    """If only one of the env vars is set, fall through to keyring resolution."""
+    monkeypatch.setenv("WRDS_USERNAME", "ci-user")
+    monkeypatch.delenv("WRDS_PASSWORD", raising=False)
+
+    import jkp.data.wrds_credentials as mod
+
+    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
+    (tmp_path / ".wrds_user").write_text("kept-user")
+
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kept-pw")
+    creds = mod.get_wrds_credentials()
+    assert creds.username == "kept-user", "env-var partial set must not be used"
+    assert creds.password == "kept-pw"
+
+
+@pytest.mark.unit
+def test_plaintext_opt_in_emits_warning(monkeypatch):
+    """Setting JKP_ALLOW_PLAINTEXT_KEYRING=1 should emit a warning the first
+    time credential resolution runs."""
+    monkeypatch.setenv("WRDS_USERNAME", "u")
+    monkeypatch.setenv("WRDS_PASSWORD", "p")  # short-circuits keyring code path
+    monkeypatch.setenv("JKP_ALLOW_PLAINTEXT_KEYRING", "1")
+
+    import jkp.data.wrds_credentials as mod
+
+    # Reset_credentials triggers _maybe_use_file_keyring even with env vars set.
+    monkeypatch.setattr(mod, "LAST_USER_FILE", __import__("pathlib").Path("/tmp/__no__"))
+
+    with pytest.warns(UserWarning, match="keyrings.alt.file.PlaintextKeyring"):
+        mod._maybe_use_file_keyring()
+
+
+@pytest.mark.unit
+def test_plaintext_no_optin_no_warning(monkeypatch, recwarn):
+    """Without the opt-in env var, no warning is emitted and the keyring backend
+    is not mutated."""
+    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+
+    import jkp.data.wrds_credentials as mod
+
+    set_keyring_calls = []
+    monkeypatch.setattr(mod.keyring, "set_keyring", lambda kr: set_keyring_calls.append(kr))
+    mod._maybe_use_file_keyring()
+    assert not set_keyring_calls, "keyring backend should not be swapped without opt-in"
+    assert len(recwarn.list) == 0, "no warning should fire without opt-in"

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -1,9 +1,7 @@
 """Tests for WRDS credential resolution.
 
-Covers the documented precedence order:
-    1. WRDS_USERNAME / WRDS_PASSWORD environment variables.
-    2. The system keyring.
-    3. Plaintext keyring, only if JKP_ALLOW_PLAINTEXT_KEYRING=1.
+See ``jkp connect --help`` for the canonical credential precedence order;
+these tests exercise it.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -114,6 +114,24 @@ def test_plaintext_no_optin_no_warning(monkeypatch, recwarn):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("value", ["true", "True", "yes", "on", "0", "2", ""])
+def test_plaintext_opt_in_requires_exact_1(monkeypatch, recwarn, value):
+    """Only the exact string "1" opts in. Anything else — including
+    truthy-looking values like "true"/"yes" and falsy ones like "0" — is treated
+    as not set: no backend swap, no warning. Guards the strict comparison against
+    being loosened into a fuzzy truthiness check later."""
+    monkeypatch.setenv("JKP_ALLOW_PLAINTEXT_KEYRING", value)
+
+    import jkp.data.wrds_credentials as mod
+
+    set_keyring_calls = []
+    monkeypatch.setattr(mod.keyring, "set_keyring", lambda kr: set_keyring_calls.append(kr))
+    mod._ensure_keyring_backend()
+    assert not set_keyring_calls, f"value {value!r} must not swap the keyring backend"
+    assert len(recwarn.list) == 0, f"value {value!r} must not emit a warning"
+
+
+@pytest.mark.unit
 def test_backend_swap_is_cached(monkeypatch, recwarn):
     """The opt-in swap happens at most once per process: repeated keyring access
     must not re-run the swap or re-emit the warning."""

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -67,20 +67,24 @@ def test_env_partial_falls_through_to_keyring(monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
-def test_plaintext_opt_in_emits_warning(monkeypatch):
-    """Setting JKP_ALLOW_PLAINTEXT_KEYRING=1 should emit a warning the first
-    time credential resolution runs."""
-    monkeypatch.setenv("WRDS_USERNAME", "u")
-    monkeypatch.setenv("WRDS_PASSWORD", "p")  # short-circuits keyring code path
+def test_plaintext_opt_in_swaps_backend_and_warns(monkeypatch):
+    """Setting JKP_ALLOW_PLAINTEXT_KEYRING=1 should swap the keyring backend to
+    PlaintextKeyring and emit a warning when credential resolution runs."""
     monkeypatch.setenv("JKP_ALLOW_PLAINTEXT_KEYRING", "1")
+
+    from keyrings.alt.file import PlaintextKeyring
 
     import jkp.data.wrds_credentials as mod
 
-    # Reset_credentials triggers _maybe_use_file_keyring even with env vars set.
-    monkeypatch.setattr(mod, "LAST_USER_FILE", __import__("pathlib").Path("/tmp/__no__"))
+    # Capture the backend swap instead of mutating the process-global keyring.
+    captured = []
+    monkeypatch.setattr(mod.keyring, "set_keyring", captured.append)
 
     with pytest.warns(UserWarning, match="keyrings.alt.file.PlaintextKeyring"):
         mod._maybe_use_file_keyring()
+
+    assert len(captured) == 1, "the backend should be swapped exactly once"
+    assert isinstance(captured[0], PlaintextKeyring)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -13,6 +13,17 @@ import importlib
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _clear_keyring_backend_cache():
+    """The backend swap is cached per-process, so reset it around every test to
+    keep cases independent (otherwise the first opt-in leaks into later tests)."""
+    import jkp.data.wrds_credentials as mod
+
+    mod._ensure_keyring_backend.cache_clear()
+    yield
+    mod._ensure_keyring_backend.cache_clear()
+
+
 @pytest.mark.unit
 def test_import_does_not_mutate_environ():
     """Importing the module must not change PYTHON_KEYRING_BACKEND or any other
@@ -81,7 +92,7 @@ def test_plaintext_opt_in_swaps_backend_and_warns(monkeypatch):
     monkeypatch.setattr(mod.keyring, "set_keyring", captured.append)
 
     with pytest.warns(UserWarning, match="keyrings.alt.file.PlaintextKeyring"):
-        mod._maybe_use_file_keyring()
+        mod._ensure_keyring_backend()
 
     assert len(captured) == 1, "the backend should be swapped exactly once"
     assert isinstance(captured[0], PlaintextKeyring)
@@ -97,6 +108,122 @@ def test_plaintext_no_optin_no_warning(monkeypatch, recwarn):
 
     set_keyring_calls = []
     monkeypatch.setattr(mod.keyring, "set_keyring", lambda kr: set_keyring_calls.append(kr))
-    mod._maybe_use_file_keyring()
+    mod._ensure_keyring_backend()
     assert not set_keyring_calls, "keyring backend should not be swapped without opt-in"
     assert len(recwarn.list) == 0, "no warning should fire without opt-in"
+
+
+@pytest.mark.unit
+def test_backend_swap_is_cached(monkeypatch, recwarn):
+    """The opt-in swap happens at most once per process: repeated keyring access
+    must not re-run the swap or re-emit the warning."""
+    monkeypatch.setenv("JKP_ALLOW_PLAINTEXT_KEYRING", "1")
+
+    import jkp.data.wrds_credentials as mod
+
+    captured = []
+    monkeypatch.setattr(mod.keyring, "set_keyring", captured.append)
+
+    mod._ensure_keyring_backend()
+    mod._ensure_keyring_backend()
+    with mod._keyring_backend():
+        pass
+
+    assert len(captured) == 1, "backend swap should happen once despite repeated calls"
+    warnings_emitted = [w for w in recwarn.list if issubclass(w.category, UserWarning)]
+    assert len(warnings_emitted) == 1, "the swap warning should fire once, not per call"
+
+
+@pytest.mark.unit
+def test_get_wrds_credentials_missing_backend_raises_guidance(monkeypatch, tmp_path):
+    """On a headless system with no keyring backend and no opt-in, the generic
+    NoKeyringError is re-raised with guidance pointing at the env-var and
+    plaintext-opt-in escape hatches."""
+    monkeypatch.delenv("WRDS_USERNAME", raising=False)
+    monkeypatch.delenv("WRDS_PASSWORD", raising=False)
+    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+
+    import jkp.data.wrds_credentials as mod
+
+    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
+    (tmp_path / ".wrds_user").write_text("someuser")
+
+    def _no_backend(*a, **kw):
+        raise mod.keyring.errors.NoKeyringError("No recommended backend was available")
+
+    monkeypatch.setattr(mod.keyring, "get_password", _no_backend)
+
+    with pytest.raises(mod.keyring.errors.NoKeyringError) as excinfo:
+        mod.get_wrds_credentials()
+
+    msg = str(excinfo.value)
+    assert "WRDS_USERNAME" in msg
+    assert "WRDS_PASSWORD" in msg
+    assert "JKP_ALLOW_PLAINTEXT_KEYRING" in msg
+
+
+@pytest.mark.unit
+def test_reset_credentials_missing_backend_raises_guidance(monkeypatch, tmp_path):
+    """`jkp connect --reset` on a headless system must surface the same guidance
+    rather than the bare NoKeyringError from keyring.delete_password."""
+    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+
+    import jkp.data.wrds_credentials as mod
+
+    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
+    (tmp_path / ".wrds_user").write_text("someuser")
+
+    def _no_backend(*a, **kw):
+        raise mod.keyring.errors.NoKeyringError("No recommended backend was available")
+
+    monkeypatch.setattr(mod.keyring, "delete_password", _no_backend)
+
+    with pytest.raises(mod.keyring.errors.NoKeyringError) as excinfo:
+        mod.reset_credentials(full_reset=True)
+
+    msg = str(excinfo.value)
+    assert "JKP_ALLOW_PLAINTEXT_KEYRING" in msg
+
+
+@pytest.mark.unit
+def test_reset_credentials_deletes_existing_entry(monkeypatch, tmp_path, capsys):
+    """A successful delete reports the deletion and removes the username file."""
+    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+
+    import jkp.data.wrds_credentials as mod
+
+    user_file = tmp_path / ".wrds_user"
+    monkeypatch.setattr(mod, "LAST_USER_FILE", user_file)
+    user_file.write_text("someuser")
+
+    deleted = []
+    monkeypatch.setattr(mod.keyring, "delete_password", lambda *a, **kw: deleted.append(a))
+
+    mod.reset_credentials(full_reset=True)
+
+    assert deleted, "delete_password should have been called"
+    out = capsys.readouterr().out
+    assert "Deleted password for 'someuser'" in out
+    assert not user_file.exists(), "username file should be removed"
+
+
+@pytest.mark.unit
+def test_reset_credentials_missing_entry_is_handled(monkeypatch, tmp_path, capsys):
+    """A genuine 'no entry to delete' (PasswordDeleteError) is still handled
+    gracefully and must not be swallowed by the NoKeyringError translation."""
+    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+
+    import jkp.data.wrds_credentials as mod
+
+    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
+    (tmp_path / ".wrds_user").write_text("someuser")
+
+    def _no_entry(*a, **kw):
+        raise mod.keyring.errors.PasswordDeleteError("not found")
+
+    monkeypatch.setattr(mod.keyring, "delete_password", _no_entry)
+
+    mod.reset_credentials(full_reset=True)  # must not raise
+
+    out = capsys.readouterr().out
+    assert "No keyring entry found" in out


### PR DESCRIPTION
## Summary

`src/jkp/data/wrds_credentials.py` previously set `PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring` at module-import time, which silently changed the keyring backend for every process that imported anything from `jkp.data`. That backend swap is appropriate for headless environments (HPC compute nodes, minimal Docker images) where no system keyring daemon is available, but doing it silently for every user is undocumented behavior.

This PR replaces that with a tiered, explicit credential resolver:

1. `WRDS_USERNAME` / `WRDS_PASSWORD` environment variables (containers, shared service accounts).
2. The system keyring (Keychain, Secret Service, Credential Vault) — default for interactive sessions.
3. The file-backed keyring (`keyrings.alt.file.PlaintextKeyring`, a mode-600 file under `~/.local/share/python_keyring/`) — selected only when `JKP_ALLOW_PLAINTEXT_KEYRING=1` is set, with a warning emitted on first use (once per process) so the backend change is never silent.

The package never mutates `os.environ` at import time. Documentation updated in README and `jkp connect --help`. The Slurm example script now opts in to the file-backed keyring explicitly, matching the HPC compute-node use case.

This is a Tier 1 prerequisite for publishing the package to PyPI.

Closes #101.

## Change Type

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [x] Infrastructure change (CI, config, dependencies)
- [ ] Documentation only
- [ ] Performance-impacting change

## Methodological Impact

None.

## Data Impact

None.

## Breaking Changes

Existing users on machines with a working system keyring see no behavior change other than the backend no longer being silently overridden.

Existing users who relied on the previous silent activation of the file-backed keyring (for example on HPC compute nodes that have no keyring daemon) need to set `JKP_ALLOW_PLAINTEXT_KEYRING=1` in their environment. The updated `slurm/submit_job_som_hpc.slurm` example shows the pattern, and the warning emitted on first use makes the required action obvious.

## Tests

Added five new tests in `tests/unit/test_wrds_credentials.py`:

- `test_import_does_not_mutate_environ` — the regression test for the original bug.
- `test_env_vars_take_precedence` — env-var path returns those values without touching the keyring.
- `test_env_partial_falls_through_to_keyring` — only one of the two env vars set falls through to keyring resolution.
- `test_plaintext_opt_in_emits_warning` — the opt-in flag fires the documented warning.
- `test_plaintext_no_optin_no_warning` — without the opt-in, no warning, no backend swap.

All five pass; full unit suite passes (370 tests, 0 failures).

Manual validation on a Yale HPC compute node (job 571841) covered four scenarios with no `$HOME` writes:

1. Module import on a compute node does not mutate the environment.
2. Env-var precedence returns the env-var values without touching the keyring.
3. The file-backed keyring round-trips a stored password (write then read), with the documented warning emitted on each backend swap.
4. The smoke test never touches any real `$HOME` files (verified via a scratch directory and a sentinel check).

## Checklist

- [x] I have run the tests locally (`pytest`)
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [x] I have verified the pipeline runs successfully after my changes — manual smoke test on Yale compute node verified the credential resolution paths end to end
- [x] I have updated documentation if needed — README, `jkp connect --help`, and the Slurm example script
- [x] I have considered whether this change affects factor calculations — it does not

## Additional Notes

The mode-600 file written by `keyrings.alt.file.PlaintextKeyring` has the same security posture as any other user-private dotfile (e.g. an exported `~/.wrds_secrets`); the concern this PR addresses is the silent backend mutation at import time, not the storage format itself.
