### PR TITLE
Remove os.chdir / os.system; thread DataPaths through pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Static reference data (`data/cluster_labels.csv`, `data/country_classification.x
 - New pipeline functions should be added to `aux_functions.py` and called from `main.py`
 - Use the `@measure_time` decorator on pipeline-level functions
 - Use `collect_and_write()` for the lazy→eager→parquet workflow
+- Pipeline functions in `aux_functions.py` that touch the filesystem must accept `paths: DataPaths` as their first parameter and use it for all path construction (e.g. `paths.interim_dir / "foo.parquet"`, `paths.raw_tables_dir / ...`). Never use `os.chdir`, `os.system`, or bare relative path strings. DuckDB SQL strings should interpolate `Path.as_posix()` rather than rely on cwd.
 
 **Docstring format** (the codebase uses a consistent three-part format):
 ```
@@ -116,7 +117,7 @@ See [tests/README.md](tests/README.md) for full guidance on writing tests, numer
 Key conventions to know:
 - Tests live in `tests/unit/` with shared fixtures in `tests/conftest.py`
 - Available test markers: `unit`, `integration`, `methodology`, `regression`, `expensive`, `wrds`
-- Key fixtures: `tolerance` (pre-calibrated `ToleranceSpec` levels), `assert_series_equal` (NaN-aware series comparison), `make_dataframe` (test DataFrame factory), `temp_data_dir` (temp directory with pipeline subdirectories)
+- Key fixtures: `tolerance` (pre-calibrated `ToleranceSpec` levels), `assert_series_equal` (NaN-aware series comparison), `make_dataframe` (test DataFrame factory), `temp_data_dir` (temp directory with pipeline subdirectories), `test_paths` (`DataPaths` instance rooted at `temp_data_dir`; use this for any test of a pipeline function that takes `paths: DataPaths`)
 
 ## Development Workflow
 

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -4,14 +4,11 @@ import functools
 import operator
 import os
 import re
+import shutil
 import time
 from datetime import date
 from math import exp, sqrt
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .paths import DataPaths
 
 import duckdb
 import ibis
@@ -21,6 +18,7 @@ from ibis import _
 from polars import col
 
 from .config import END_DATE, MAIN_FILTERS
+from .paths import DataPaths
 
 
 def fl_none():
@@ -75,15 +73,14 @@ def measure_time(func):
 def setup_folder_structure(paths: DataPaths) -> None:
     """
     Description:
-        Create the pipeline’s folder structure under the user-specified output directory.
+        Create the pipeline's folder structure under the user-specified output directory.
 
     Steps:
         1) Create directories: raw_tables, raw_data_dfs, characteristics, return_data, accounting_data, other_output, portfolios.
         2) Copy the data README (license and citation info) into the output directory.
-        3) Change working directory to interim_dir for subsequent pipeline functions.
 
     Output:
-        Folders created on disk (no return value). Working directory set to paths.interim_dir.
+        Folders created on disk (no return value).
     """
     import shutil
 
@@ -100,7 +97,6 @@ def setup_folder_structure(paths: DataPaths) -> None:
     (paths.processed_dir / "other_output").mkdir(parents=True, exist_ok=True)
     (paths.processed_dir / "portfolios").mkdir(parents=True, exist_ok=True)
     shutil.copy2(get_data_readme_path(), paths.base_dir / "README.md")
-    os.chdir(paths.interim_dir)
 
 
 def collect_and_write(df, filename, collect_streaming=False):
@@ -268,7 +264,7 @@ def prihist_aux(filename, alias_itemvalue):
     return df
 
 
-def gen_firmshares():
+def gen_firmshares(paths: DataPaths):
     """
     Description:
         Build a unified table of Compustat-reported shares outstanding and split factors
@@ -285,10 +281,10 @@ def gen_firmshares():
         Parquet: raw_data_dfs/__firm_shares1.parquet (gvkey, datadate, csho_fund, ajex_fund).
     """
     con = ibis.duckdb.connect(threads=os.cpu_count())
-    con.create_table("comp_fundq", con.read_parquet("../raw/raw_tables/comp_fundq.parquet"))
+    con.create_table("comp_fundq", con.read_parquet(paths.raw_tables_dir / "comp_fundq.parquet"))
     con.create_table(
         "comp_funda",
-        con.read_parquet("../raw/raw_tables/comp_funda.parquet").rename({"at_": "at"}),
+        con.read_parquet(paths.raw_tables_dir / "comp_funda.parquet").rename({"at_": "at"}),
     )
     con.raw_sql("""
     CREATE TABLE __firm_shares1 AS
@@ -303,11 +299,13 @@ def gen_firmshares():
     FROM comp_funda
     WHERE indfmt = 'INDL' AND datafmt = 'STD' AND popsrc = 'D' AND consol = 'C' AND csho IS NOT NULL AND ajex IS NOT NULL;
     """)
-    con.table("__firm_shares1").to_parquet("raw_data_dfs/__firm_shares1.parquet")
+    con.table("__firm_shares1").to_parquet(
+        paths.interim_dir / "raw_data_dfs" / "__firm_shares1.parquet"
+    )
     con.disconnect()
 
 
-def gen_prihist_files():
+def gen_prihist_files(paths: DataPaths):
     """
     Description:
         Extract Compustat security history “primary listing” flags (ROW/USA/CAN) with date
@@ -325,11 +323,11 @@ def gen_prihist_files():
     con = ibis.duckdb.connect(threads=os.cpu_count())
     con.create_table(
         "comp_sec_history",
-        con.read_parquet("../raw/raw_tables/comp_sec_history.parquet"),
+        con.read_parquet(paths.raw_tables_dir / "comp_sec_history.parquet"),
     )
     con.create_table(
         "comp_g_sec_history",
-        con.read_parquet("../raw/raw_tables/comp_g_sec_history.parquet"),
+        con.read_parquet(paths.raw_tables_dir / "comp_g_sec_history.parquet"),
     )
     con.raw_sql("""
     CREATE TABLE __prihistrow AS
@@ -357,13 +355,19 @@ def gen_prihist_files():
     WHERE item = 'PRIHISTCAN';
     """)
 
-    con.table("__prihistrow").to_parquet("raw_data_dfs/__prihistrow.parquet")
-    con.table("__prihistusa").to_parquet("raw_data_dfs/__prihistusa.parquet")
-    con.table("__prihistcan").to_parquet("raw_data_dfs/__prihistcan.parquet")
+    con.table("__prihistrow").to_parquet(
+        paths.interim_dir / "raw_data_dfs" / "__prihistrow.parquet"
+    )
+    con.table("__prihistusa").to_parquet(
+        paths.interim_dir / "raw_data_dfs" / "__prihistusa.parquet"
+    )
+    con.table("__prihistcan").to_parquet(
+        paths.interim_dir / "raw_data_dfs" / "__prihistcan.parquet"
+    )
     con.disconnect()
 
 
-def gen_fx1():
+def gen_fx1(paths: DataPaths):
     """
     Description:
         Build daily FX (to USD) series per currency using Compustat daily exchange rates.
@@ -378,7 +382,9 @@ def gen_fx1():
         Parquet: raw_data_dfs/__fx1.parquet (curcdd, datadate, fx to USD).
     """
     con = ibis.duckdb.connect(threads=os.cpu_count())
-    con.create_table("comp_exrt_dly", con.read_parquet("../raw/raw_tables/comp_exrt_dly.parquet"))
+    con.create_table(
+        "comp_exrt_dly", con.read_parquet(paths.raw_tables_dir / "comp_exrt_dly.parquet")
+    )
     con.raw_sql("""
     CREATE TABLE __fx1 AS
     SELECT DISTINCT
@@ -392,12 +398,12 @@ def gen_fx1():
     WHERE a.fromcurd = 'GBP'
     AND b.tocurd  = 'USD';
     """)
-    con.table("__fx1").to_parquet("raw_data_dfs/__fx1.parquet")
+    con.table("__fx1").to_parquet(paths.interim_dir / "raw_data_dfs" / "__fx1.parquet")
     con.disconnect()
 
 
 @measure_time
-def gen_raw_data_dfs():
+def gen_raw_data_dfs(paths: DataPaths):
     """
     Description:
         Generate a suite of “raw data” helper Parquet files from Compustat/CRSP sources.
@@ -415,13 +421,13 @@ def gen_raw_data_dfs():
     Output:
         Multiple helper Parquets under raw_data_dfs/ used in later pipelines.
     """
-    gen_firmshares()
-    sic_naics_na = sic_naics_aux("../raw/raw_tables/comp_funda.parquet")
-    collect_and_write(sic_naics_na, "raw_data_dfs/sic_naics_na.parquet")
-    sic_naics_gl = sic_naics_aux("../raw/raw_tables/comp_g_funda.parquet")
-    collect_and_write(sic_naics_gl, "raw_data_dfs/sic_naics_gl.parquet")
+    gen_firmshares(paths)
+    sic_naics_na = sic_naics_aux(paths.raw_tables_dir / "comp_funda.parquet")
+    collect_and_write(sic_naics_na, paths.interim_dir / "raw_data_dfs" / "sic_naics_na.parquet")
+    sic_naics_gl = sic_naics_aux(paths.raw_tables_dir / "comp_g_funda.parquet")
+    collect_and_write(sic_naics_gl, paths.interim_dir / "raw_data_dfs" / "sic_naics_gl.parquet")
     permno0 = (
-        pl.scan_parquet("../raw/raw_tables/crsp_stksecurityinfohist.parquet")
+        pl.scan_parquet(paths.raw_tables_dir / "crsp_stksecurityinfohist.parquet")
         .select(
             [
                 col("permno").cast(pl.Int64),
@@ -435,12 +441,12 @@ def gen_raw_data_dfs():
         .unique()
         .sort(["permno", "secinfostartdt", "secinfoenddt"])
     )
-    collect_and_write(permno0, "raw_data_dfs/permno0.parquet")
-    comp_hgics_na = comp_hgics_aux("../raw/raw_tables/comp_co_hgic.parquet")
-    collect_and_write(comp_hgics_na, "raw_data_dfs/comp_hgics_na.parquet")
-    comp_hgics_gl = comp_hgics_aux("../raw/raw_tables/comp_g_co_hgic.parquet")
-    collect_and_write(comp_hgics_gl, "raw_data_dfs/comp_hgics_gl.parquet")
-    crsp_dsedelist = pl.scan_parquet("../raw/raw_tables/crsp_stkdelists.parquet").select(
+    collect_and_write(permno0, paths.interim_dir / "raw_data_dfs" / "permno0.parquet")
+    comp_hgics_na = comp_hgics_aux(paths.raw_tables_dir / "comp_co_hgic.parquet")
+    collect_and_write(comp_hgics_na, paths.interim_dir / "raw_data_dfs" / "comp_hgics_na.parquet")
+    comp_hgics_gl = comp_hgics_aux(paths.raw_tables_dir / "comp_g_co_hgic.parquet")
+    collect_and_write(comp_hgics_gl, paths.interim_dir / "raw_data_dfs" / "comp_hgics_gl.parquet")
+    crsp_dsedelist = pl.scan_parquet(paths.raw_tables_dir / "crsp_stkdelists.parquet").select(
         [
             "delret",
             "delactiontype",
@@ -451,8 +457,8 @@ def gen_raw_data_dfs():
             "delistingdt",
         ]
     )
-    collect_and_write(crsp_dsedelist, "raw_data_dfs/crsp_dsedelist.parquet")
-    crsp_msedelist = pl.scan_parquet("../raw/raw_tables/crsp_stkdelists.parquet").select(
+    collect_and_write(crsp_dsedelist, paths.interim_dir / "raw_data_dfs" / "crsp_dsedelist.parquet")
+    crsp_msedelist = pl.scan_parquet(paths.raw_tables_dir / "crsp_stkdelists.parquet").select(
         [
             "delret",
             "delactiontype",
@@ -463,45 +469,53 @@ def gen_raw_data_dfs():
             "delistingdt",
         ]
     )
-    collect_and_write(crsp_msedelist, "raw_data_dfs/crsp_msedelist.parquet")
+    collect_and_write(crsp_msedelist, paths.interim_dir / "raw_data_dfs" / "crsp_msedelist.parquet")
     __sec_info = pl.concat(
         [
-            sec_info_aux("../raw/raw_tables/comp_security.parquet"),
-            sec_info_aux("../raw/raw_tables/comp_g_security.parquet"),
+            sec_info_aux(paths.raw_tables_dir / "comp_security.parquet"),
+            sec_info_aux(paths.raw_tables_dir / "comp_g_security.parquet"),
         ]
     )
-    collect_and_write(__sec_info, "raw_data_dfs/__sec_info.parquet")
-    build_mcti()
-    crsp_mcti_t30ret = pl.scan_parquet("raw_data_dfs/crsp_mcti.parquet").select(["caldt", "t30ret"])
-    collect_and_write(crsp_mcti_t30ret, "raw_data_dfs/crsp_mcti_t30ret.parquet")
-    ff_factors_monthly = pl.scan_parquet("../raw/raw_tables/ff_factors_monthly.parquet").select(
-        ["date", "rf"]
+    collect_and_write(__sec_info, paths.interim_dir / "raw_data_dfs" / "__sec_info.parquet")
+    build_mcti(paths)
+    crsp_mcti_t30ret = pl.scan_parquet(
+        paths.interim_dir / "raw_data_dfs" / "crsp_mcti.parquet"
+    ).select(["caldt", "t30ret"])
+    collect_and_write(
+        crsp_mcti_t30ret, paths.interim_dir / "raw_data_dfs" / "crsp_mcti_t30ret.parquet"
     )
-    collect_and_write(ff_factors_monthly, "raw_data_dfs/ff_factors_monthly.parquet")
-    comp_r_ex_codes = pl.scan_parquet("../raw/raw_tables/comp_r_ex_codes.parquet").select(
+    ff_factors_monthly = pl.scan_parquet(
+        paths.raw_tables_dir / "ff_factors_monthly.parquet"
+    ).select(["date", "rf"])
+    collect_and_write(
+        ff_factors_monthly, paths.interim_dir / "raw_data_dfs" / "ff_factors_monthly.parquet"
+    )
+    comp_r_ex_codes = pl.scan_parquet(paths.raw_tables_dir / "comp_r_ex_codes.parquet").select(
         ["exchgdesc", "exchgcd"]
     )
-    collect_and_write(comp_r_ex_codes, "raw_data_dfs/comp_r_ex_codes.parquet")
+    collect_and_write(
+        comp_r_ex_codes, paths.interim_dir / "raw_data_dfs" / "comp_r_ex_codes.parquet"
+    )
     __ex_country1 = pl.concat(
         [
-            ex_country_aux("../raw/raw_tables/comp_g_security.parquet"),
-            ex_country_aux("../raw/raw_tables/comp_security.parquet"),
+            ex_country_aux(paths.raw_tables_dir / "comp_g_security.parquet"),
+            ex_country_aux(paths.raw_tables_dir / "comp_security.parquet"),
         ]
     )
-    collect_and_write(__ex_country1, "raw_data_dfs/__ex_country1.parquet")
+    collect_and_write(__ex_country1, paths.interim_dir / "raw_data_dfs" / "__ex_country1.parquet")
     header_aux(
-        "../raw/raw_tables/comp_company.parquet",
-        "../raw/raw_tables/comp_g_company.parquet",
-        "raw_data_dfs/__header.parquet",
+        paths.raw_tables_dir / "comp_company.parquet",
+        paths.raw_tables_dir / "comp_g_company.parquet",
+        paths.interim_dir / "raw_data_dfs" / "__header.parquet",
     )
-    gen_prihist_files()
-    gen_fx1()
-    aug_msf_v2()
-    gen_crsp_sf("m").to_parquet("raw_data_dfs/__crsp_sf_m.parquet")
-    gen_crsp_sf("d").to_parquet("raw_data_dfs/__crsp_sf_d.parquet")
+    gen_prihist_files(paths)
+    gen_fx1(paths)
+    aug_msf_v2(paths)
+    gen_crsp_sf(paths, "m").to_parquet(paths.interim_dir / "raw_data_dfs" / "__crsp_sf_m.parquet")
+    gen_crsp_sf(paths, "d").to_parquet(paths.interim_dir / "raw_data_dfs" / "__crsp_sf_d.parquet")
 
 
-def gen_crsp_sf(freq):
+def gen_crsp_sf(paths: DataPaths, freq):
     """
     Description:
         Build CRSP security file enriched with names and CCM link history (monthly or daily).
@@ -519,13 +533,13 @@ def gen_crsp_sf(freq):
     """
     con = ibis.duckdb.connect(threads=os.cpu_count())
     if freq == "m":
-        sf = con.read_parquet("raw_data_dfs/crsp_msf_v2_aug.parquet")
+        sf = con.read_parquet(paths.interim_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
     elif freq == "d":
-        sf = con.read_parquet("../raw/raw_tables/crsp_dsf_v2.parquet")
+        sf = con.read_parquet(paths.raw_tables_dir / "crsp_dsf_v2.parquet")
     else:
         raise ValueError(f"Unknown freq: {freq}")
-    senames = con.read_parquet("../raw/raw_tables/crsp_stksecurityinfohist.parquet")
-    ccmxpf_lnkhist = con.read_parquet("../raw/raw_tables/crsp_ccmxpf_lnkhist.parquet")
+    senames = con.read_parquet(paths.raw_tables_dir / "crsp_stksecurityinfohist.parquet")
+    ccmxpf_lnkhist = con.read_parquet(paths.raw_tables_dir / "crsp_ccmxpf_lnkhist.parquet")
 
     # ---------- CIZ name mapping by frequency ----------
     if freq == "m":
@@ -753,7 +767,11 @@ def download_wrds_table(
 
 @measure_time
 def download_raw_data_tables(
-    username: str, password: str, end_date: date | None = None, persistent_connection: bool = False
+    paths: DataPaths,
+    username: str,
+    password: str,
+    end_date: date | None = None,
+    persistent_connection: bool = False,
 ) -> None:
     """
     Description:
@@ -844,7 +862,7 @@ def download_raw_data_tables(
                     con,
                     "wrds",
                     table,
-                    "../raw/raw_tables/" + table.replace(".", "_") + ".parquet",
+                    str(paths.raw_tables_dir / (table.replace(".", "_") + ".parquet")),
                     date_column=date_columns.get(table),
                     end_date=end_date,
                 )
@@ -857,7 +875,7 @@ def download_raw_data_tables(
                 wrds_session_data,
                 con,
                 table,
-                "../raw/raw_tables/" + table.replace(".", "_") + ".parquet",
+                str(paths.raw_tables_dir / (table.replace(".", "_") + ".parquet")),
                 date_column=date_columns.get(table),
                 end_date=end_date,
             )
@@ -866,7 +884,7 @@ def download_raw_data_tables(
 
 
 @measure_time
-def aug_msf_v2():
+def aug_msf_v2(paths: DataPaths):
     """
     Description:
         Add month-level high/low transaction-price fields to the CRSP CIZ monthly file (msf_v2)
@@ -888,8 +906,8 @@ def aug_msf_v2():
         plus mthaskhi and mthbidlo.
     """
     con = ibis.duckdb.connect(threads=os.cpu_count())
-    msf = con.read_parquet("../raw/raw_tables/crsp_msf_v2.parquet")
-    dsf = con.read_parquet("../raw/raw_tables/crsp_dsf_v2.parquet")
+    msf = con.read_parquet(paths.raw_tables_dir / "crsp_msf_v2.parquet")
+    dsf = con.read_parquet(paths.raw_tables_dir / "crsp_dsf_v2.parquet")
 
     dt = dsf.dlycaldt.cast("date")
 
@@ -924,11 +942,11 @@ def aug_msf_v2():
         ),
     )
 
-    msf_aug.to_parquet("raw_data_dfs/crsp_msf_v2_aug.parquet")
+    msf_aug.to_parquet(paths.interim_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
 
 
 @measure_time
-def build_mcti():
+def build_mcti(paths: DataPaths):
     """
     Description:
         Build monthly t30 return raw data.
@@ -943,8 +961,8 @@ def build_mcti():
         Writes raw_data_dfs/crsp_mcti.parquet (no return value).
     """
 
-    a = pl.read_parquet("../raw/raw_tables/crsp_indmthseriesdata_ind.parquet")
-    b = pl.read_parquet("../raw/raw_tables/crsp_indseriesinfohdr_ind.parquet")
+    a = pl.read_parquet(paths.raw_tables_dir / "crsp_indmthseriesdata_ind.parquet")
+    b = pl.read_parquet(paths.raw_tables_dir / "crsp_indseriesinfohdr_ind.parquet")
 
     ab = a.join(b, on="indno", how="inner")
 
@@ -954,12 +972,12 @@ def build_mcti():
         .rename({"mthcaldt": "caldt", "mthtotret": "t30ret"})
     )
 
-    os.makedirs("raw_data_dfs", exist_ok=True)
-    out.write_parquet("raw_data_dfs/crsp_mcti.parquet")
+    (paths.interim_dir / "raw_data_dfs").mkdir(exist_ok=True)
+    out.write_parquet(paths.interim_dir / "raw_data_dfs" / "crsp_mcti.parquet")
 
 
 @measure_time
-def prepare_comp_sf(freq):
+def prepare_comp_sf(paths: DataPaths, freq):
     """
     Description:
         Prepare Compustat security-file derivatives (Comp DSF/SSF equivalents) for daily/monthly runs.
@@ -971,16 +989,22 @@ def prepare_comp_sf(freq):
     Output:
         Intermediate Comp security files written by downstream helpers (no direct return).
     """
-    populate_own("raw_data_dfs/__firm_shares1.parquet", "gvkey", "datadate", "ddate")
-    gen_comp_dsf()
+    populate_own(
+        paths,
+        paths.interim_dir / "raw_data_dfs" / "__firm_shares1.parquet",
+        "gvkey",
+        "datadate",
+        "ddate",
+    )
+    gen_comp_dsf(paths)
     if freq == "both":
-        process_comp_sf1("d")
-        process_comp_sf1("m")
+        process_comp_sf1(paths, "d")
+        process_comp_sf1(paths, "m")
     else:
-        process_comp_sf1(freq)
+        process_comp_sf1(paths, freq)
 
 
-def populate_own(inset_path, idvar, datevar, datename):
+def populate_own(paths: DataPaths, inset_path, idvar, datevar, datename):
     """
     Description:
         Expand Compustat firm-shares observations to a DAILY panel between each report
@@ -1013,10 +1037,10 @@ def populate_own(inset_path, idvar, datevar, datename):
         .select(["ddate", "gvkey", "datadate", "csho_fund", "ajex_fund"])
         .sort(["gvkey", "datadate"])
     )
-    inset.collect().write_parquet("__firm_shares2.parquet")
+    inset.collect().write_parquet(paths.interim_dir / "__firm_shares2.parquet")
 
 
-def compustat_fx():
+def compustat_fx(paths: DataPaths):
     """
     Description:
         Construct a complete daily FX (currency to USD) time series per currency, including USD=1.
@@ -1037,7 +1061,7 @@ def compustat_fx():
         .with_columns(col("datadate").str.to_date("%Y-%m-%d"))
         .lazy()
     )
-    __fx1 = pl.scan_parquet("raw_data_dfs/__fx1.parquet")
+    __fx1 = pl.scan_parquet(paths.interim_dir / "raw_data_dfs" / "__fx1.parquet")
     __fx1 = (
         pl.concat([aux, __fx1], how="vertical_relaxed")
         .sort(["curcdd", "datadate"])
@@ -1088,7 +1112,7 @@ def adj_trd_vol_NASDAQ(datevar, col_to_adjust, exchg_var, exchg_val):
     return adj_trd_vol
 
 
-def gen_comp_dsf():
+def gen_comp_dsf(paths: DataPaths):
     """
     Description:
         Build daily Compustat security data (SECD + G_SECD), convert to USD, and compute
@@ -1108,14 +1132,16 @@ def gen_comp_dsf():
     Output:
         Parquet: __comp_dsf.parquet (daily Compustat security observations in USD).
     """
-    os.system("rm -f aux_comp_dsf.ddb")
-    con = ibis.duckdb.connect("aux_comp_dsf.ddb", threads=os.cpu_count())
+    (paths.interim_dir / "aux_comp_dsf.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(str(paths.interim_dir / "aux_comp_dsf.ddb"), threads=os.cpu_count())
 
-    compustat_fx().write_parquet("fx_data.parquet")
-    con.create_table("comp_g_secd", con.read_parquet("../raw/raw_tables/comp_g_secd.parquet"))
-    con.create_table("__firm_shares2", con.read_parquet("__firm_shares2.parquet"))
-    con.create_table("comp_secd", con.read_parquet("../raw/raw_tables/comp_secd.parquet"))
-    con.create_table("fx", con.read_parquet("fx_data.parquet"))
+    compustat_fx(paths).write_parquet(paths.interim_dir / "fx_data.parquet")
+    con.create_table("comp_g_secd", con.read_parquet(paths.raw_tables_dir / "comp_g_secd.parquet"))
+    con.create_table(
+        "__firm_shares2", con.read_parquet(paths.interim_dir / "__firm_shares2.parquet")
+    )
+    con.create_table("comp_secd", con.read_parquet(paths.raw_tables_dir / "comp_secd.parquet"))
+    con.create_table("fx", con.read_parquet(paths.interim_dir / "fx_data.parquet"))
 
     con.raw_sql("""
     CREATE TABLE __comp_dsf_global AS
@@ -1194,11 +1220,11 @@ def gen_comp_dsf():
     t = con.table("__comp_dsf3").drop(
         ["div", "divd", "divsp", "fx_div", "curcddv", "prc_high_lcl", "prc_low_lcl"]
     )
-    t.to_parquet("__comp_dsf.parquet")
+    t.to_parquet(paths.interim_dir / "__comp_dsf.parquet")
     con.disconnect()
 
 
-def gen_secd_data():
+def gen_secd_data(paths: DataPaths):
     """
     Description:
         Aggregate daily Compustat (__comp_dsf) to month-end security data (SECD-like monthly),
@@ -1219,9 +1245,9 @@ def gen_secd_data():
     Output:
         Parquet: secd_data.parquet (monthly aggregates from daily Compustat pipeline).
     """
-    os.system("rm -f aux_msf.ddb")
-    con = ibis.duckdb.connect("aux_msf.ddb", threads=os.cpu_count())
-    table = con.read_parquet("__comp_dsf.parquet")
+    (paths.interim_dir / "aux_msf.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(str(paths.interim_dir / "aux_msf.ddb"), threads=os.cpu_count())
+    table = con.read_parquet(paths.interim_dir / "__comp_dsf.parquet")
     window = ibis.window(group_by=["gvkey", "iid", "eom"])
     new_table = (
         table.mutate(
@@ -1269,11 +1295,11 @@ def gen_secd_data():
         )
         .order_by(["gvkey", "iid", "eom"])
     )
-    new_table.to_parquet("secd_data.parquet")
+    new_table.to_parquet(paths.interim_dir / "secd_data.parquet")
     con.disconnect()
 
 
-def gen_secm_data():
+def gen_secm_data(paths: DataPaths):
     """
     Description:
         Build Compustat SECM-derived monthly records (direct monthly pricing),
@@ -1292,17 +1318,23 @@ def gen_secm_data():
     Output:
         Parquet: secm_data.parquet (monthly Compustat SECM-based observations in USD).
     """
-    os.system("rm -f aux_comp_secm.ddb")
-    con = ibis.duckdb.connect("aux_comp_secm.ddb", threads=os.cpu_count())
+    (paths.interim_dir / "aux_comp_secm.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(str(paths.interim_dir / "aux_comp_secm.ddb"), threads=os.cpu_count())
 
-    compustat_fx().rename({"datadate": "date"}).write_parquet("fx_data.parquet")
+    compustat_fx(paths).rename({"datadate": "date"}).write_parquet(
+        paths.interim_dir / "fx_data.parquet"
+    )
     con.create_table(
         "comp_secm",
-        con.read_parquet("../raw/raw_tables/comp_secm.parquet"),
+        con.read_parquet(paths.raw_tables_dir / "comp_secm.parquet"),
         overwrite=True,
     )
-    con.create_table("__firm_shares2", con.read_parquet("__firm_shares2.parquet"), overwrite=True)
-    con.create_table("fx", con.read_parquet("fx_data.parquet"), overwrite=True)
+    con.create_table(
+        "__firm_shares2",
+        con.read_parquet(paths.interim_dir / "__firm_shares2.parquet"),
+        overwrite=True,
+    )
+    con.create_table("fx", con.read_parquet(paths.interim_dir / "fx_data.parquet"), overwrite=True)
 
     con.raw_sql("""
         DROP TABLE IF EXISTS __comp_secm2;
@@ -1350,10 +1382,10 @@ def gen_secm_data():
         NULL::DOUBLE                       AS div_spc
         FROM base;
     """)
-    con.table("__comp_secm2").to_parquet("secm_data.parquet")
+    con.table("__comp_secm2").to_parquet(paths.interim_dir / "secm_data.parquet")
 
 
-def gen_comp_msf():
+def gen_comp_msf(paths: DataPaths):
     """
     Description:
         Merge SECD-based and SECM-based monthly datasets into a single Compustat MSF-like file.
@@ -1371,8 +1403,8 @@ def gen_comp_msf():
     Output:
         Parquet: __comp_msf.parquet (monthly Compustat security master in USD).
     """
-    gen_secd_data()
-    gen_secm_data()
+    gen_secd_data(paths)
+    gen_secm_data(paths)
     common_vars = [
         "gvkey",
         "iid",
@@ -1399,15 +1431,15 @@ def gen_comp_msf():
         "prcstd",
         "source",
     ]
-    os.system("rm -f aux_msf.ddb")
-    con = ibis.duckdb.connect("aux_msf.ddb", threads=os.cpu_count())
+    (paths.interim_dir / "aux_msf.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(str(paths.interim_dir / "aux_msf.ddb"), threads=os.cpu_count())
     secd = (
-        con.read_parquet("secd_data.parquet")
+        con.read_parquet(paths.interim_dir / "secd_data.parquet")
         .select(common_vars)
         .cast({"ajexdi": "float", "prc_local": "float"})
     )
     secm = (
-        con.read_parquet("secm_data.parquet")
+        con.read_parquet(paths.interim_dir / "secm_data.parquet")
         .select(common_vars)
         .cast({"ajexdi": "float", "prc_local": "float"})
     )
@@ -1429,11 +1461,11 @@ def gen_comp_msf():
         .filter(_._rn == 0)
         .drop("_rn")
     )
-    __comp_msf.to_parquet("__comp_msf.parquet")
+    __comp_msf.to_parquet(paths.interim_dir / "__comp_msf.parquet")
     con.disconnect()
 
 
-def comp_exchanges():
+def comp_exchanges(paths: DataPaths):
     """
     Description:
         Build an exchange→country lookup with “main exchange” flag for Compustat exchanges.
@@ -1504,8 +1536,10 @@ def comp_exchanges():
         .otherwise(pl.lit(0))
         .alias("exch_main")
     )
-    comp_r_ex_codes = pl.read_parquet("raw_data_dfs/comp_r_ex_codes.parquet")
-    __ex_country = pl.read_parquet("raw_data_dfs/__ex_country1.parquet")
+    comp_r_ex_codes = pl.read_parquet(
+        paths.interim_dir / "raw_data_dfs" / "comp_r_ex_codes.parquet"
+    )
+    __ex_country = pl.read_parquet(paths.interim_dir / "raw_data_dfs" / "__ex_country1.parquet")
     __ex_country = (
         pl.SQLContext(frame=__ex_country)
         .execute(SQL_query)
@@ -1518,7 +1552,7 @@ def comp_exchanges():
     return __ex_country
 
 
-def add_primary_sec(data_path, datevar, file_name):
+def add_primary_sec(paths: DataPaths, data_path, datevar, file_name):
     """
     Description:
         Flag primary securities by joining Compustat primary-history tables (ROW/USA/CAN)
@@ -1536,28 +1570,34 @@ def add_primary_sec(data_path, datevar, file_name):
     Output:
         Parquet at file_name with a new integer column primary_sec ∈ {0,1}.
     """
-    os.system("rm -f aux_prim_sec.ddb")
-    con = duckdb.connect("aux_prim_sec.ddb")
+    (paths.interim_dir / "aux_prim_sec.ddb").unlink(missing_ok=True)
+    con = duckdb.connect(str(paths.interim_dir / "aux_prim_sec.ddb"))
+    raw_data_dfs = paths.interim_dir / "raw_data_dfs"
+    data_path_posix = Path(data_path).as_posix()
+    prihistrow_path = (raw_data_dfs / "__prihistrow.parquet").as_posix()
+    prihistusa_path = (raw_data_dfs / "__prihistusa.parquet").as_posix()
+    prihistcan_path = (raw_data_dfs / "__prihistcan.parquet").as_posix()
+    header_path = (raw_data_dfs / "__header.parquet").as_posix()
     con.execute(f"""
         CREATE OR REPLACE TABLE __data2 AS
         WITH data AS (
-            SELECT * FROM read_parquet('{data_path}')
+            SELECT * FROM read_parquet('{data_path_posix}')
             ORDER BY gvkey, iid, datadate
         ),
         prihistrow AS (
-            SELECT * FROM read_parquet('raw_data_dfs/__prihistrow.parquet')
+            SELECT * FROM read_parquet('{prihistrow_path}')
             ORDER BY gvkey, effdate
         ),
         prihistusa AS (
-            SELECT * FROM read_parquet('raw_data_dfs/__prihistusa.parquet')
+            SELECT * FROM read_parquet('{prihistusa_path}')
             ORDER BY gvkey, effdate
         ),
         prihistcan AS (
-            SELECT * FROM read_parquet('raw_data_dfs/__prihistcan.parquet')
+            SELECT * FROM read_parquet('{prihistcan_path}')
             ORDER BY gvkey, effdate
         ),
         header AS (
-            SELECT * FROM read_parquet('raw_data_dfs/__header.parquet')
+            SELECT * FROM read_parquet('{header_path}')
             ORDER BY gvkey
         ),
         __data1 AS (
@@ -1607,10 +1647,10 @@ def add_primary_sec(data_path, datevar, file_name):
     """)
 
     con.close()
-    os.system("rm -f aux_prim_sec.ddb")
+    (paths.interim_dir / "aux_prim_sec.ddb").unlink(missing_ok=True)
 
 
-def load_rf_and_exchange_data():
+def load_rf_and_exchange_data(paths: DataPaths):
     """
     Description:
         Load auxiliary monthly T-bill returns, Fama–French RF, and exchange→country mapping.
@@ -1624,20 +1664,20 @@ def load_rf_and_exchange_data():
         Tuple of (crsp_mcti LazyFrame, ff_factors_monthly LazyFrame, exchanges DataFrame).
     """
     crsp_mcti = (
-        pl.read_parquet("raw_data_dfs/crsp_mcti_t30ret.parquet")
+        pl.read_parquet(paths.interim_dir / "raw_data_dfs" / "crsp_mcti_t30ret.parquet")
         .with_columns(merge_aux=gen_MMYY_column("caldt"))
         .drop("caldt")
     )
     ff_factors_monthly = (
-        pl.read_parquet("raw_data_dfs/ff_factors_monthly.parquet")
+        pl.read_parquet(paths.interim_dir / "raw_data_dfs" / "ff_factors_monthly.parquet")
         .with_columns(merge_aux=gen_MMYY_column("date"))
         .drop("date")
     )
-    __exchanges = comp_exchanges()
+    __exchanges = comp_exchanges(paths)
     return crsp_mcti, ff_factors_monthly, __exchanges
 
 
-def gen_returns_df(freq):
+def gen_returns_df(paths: DataPaths, freq):
     """
     Description:
         Compute returns (USD and local), return-lag gaps, and currency-switch fixes
@@ -1662,7 +1702,7 @@ def gen_returns_df(freq):
         ).cast(pl.Int64)
     )
 
-    base = pl.scan_parquet(f"__comp_{freq}sf.parquet")
+    base = pl.scan_parquet(paths.interim_dir / f"__comp_{freq}sf.parquet")
     __returns = (
         # Deterministic dedup: keep highest prcstd (Compustat data-quality ranking:
         # 3=bid/ask avg, 4=official close, 10=last available price).
@@ -1701,7 +1741,7 @@ def gen_returns_df(freq):
     return __returns.collect()
 
 
-def gen_delist_df(__returns):
+def gen_delist_df(paths: DataPaths, __returns):
     """
     Description:
         Build an gvkey,iid-level delisting date/return table from last valid return and Compustat security info.
@@ -1714,7 +1754,7 @@ def gen_delist_df(__returns):
     Output:
         DataFrame {gvkey,iid,date_delist,dlret} for use in delisting adjustments.
     """
-    __sec_info = pl.scan_parquet("raw_data_dfs/__sec_info.parquet")
+    __sec_info = pl.scan_parquet(paths.interim_dir / "raw_data_dfs" / "__sec_info.parquet")
     __delist = (
         __returns.lazy()
         .filter((col("ret_local").is_not_null()) & (col("ret_local") != 0.0))
@@ -1734,7 +1774,7 @@ def gen_delist_df(__returns):
     return __delist.collect()
 
 
-def gen_temporary_sf(freq, __returns, __delist):
+def gen_temporary_sf(paths: DataPaths, freq, __returns, __delist):
     """
     Description:
         Merge base price file with returns and delist info; apply delisting
@@ -1749,7 +1789,7 @@ def gen_temporary_sf(freq, __returns, __delist):
     Output:
         Polars LazyFrame with returns adjusted for delisting.
     """
-    base = pl.read_parquet(f"__comp_{freq}sf.parquet")
+    base = pl.read_parquet(paths.interim_dir / f"__comp_{freq}sf.parquet")
     temp_sf = (
         base.join(__returns, how="left", on=["gvkey", "iid", "datadate"])
         .join(__delist, how="left", on=["gvkey", "iid"])
@@ -1767,7 +1807,7 @@ def gen_temporary_sf(freq, __returns, __delist):
     return temp_sf
 
 
-def add_rf_and_exchange_data_to_temporary_sf(freq, temp_sf):
+def add_rf_and_exchange_data_to_temporary_sf(paths: DataPaths, freq, temp_sf):
     """
     Description:
         Append T-bill / RF and exchange metadata to the temp security file; compute excess returns.
@@ -1780,7 +1820,7 @@ def add_rf_and_exchange_data_to_temporary_sf(freq, temp_sf):
     Output:
         Polars LazyFrame temp_sf with ret_exc and exchange info attached.
     """
-    crsp_mcti, ff_factors_monthly, __exchanges = load_rf_and_exchange_data()
+    crsp_mcti, ff_factors_monthly, __exchanges = load_rf_and_exchange_data(paths)
     scale = 1 if (freq == "m") else 21
     temp_sf = (
         temp_sf.with_columns(merge_aux=gen_MMYY_column("datadate"))
@@ -1794,7 +1834,7 @@ def add_rf_and_exchange_data_to_temporary_sf(freq, temp_sf):
     return temp_sf
 
 
-def process_comp_sf1(freq):
+def process_comp_sf1(paths: DataPaths, freq):
     """
     Description:
         Full pipeline to build Compustat monthly or daily security files with returns,
@@ -1811,14 +1851,19 @@ def process_comp_sf1(freq):
     """
     # Eager mode is faster here
     if freq == "m":
-        gen_comp_msf()
-    __returns = gen_returns_df(freq)
-    __delist = gen_delist_df(__returns)
-    __comp_sf2 = gen_temporary_sf(freq, __returns, __delist)
-    __comp_sf2 = add_rf_and_exchange_data_to_temporary_sf(freq, __comp_sf2)
-    __comp_sf2.write_parquet("__comp_sf2.parquet")
+        gen_comp_msf(paths)
+    __returns = gen_returns_df(paths, freq)
+    __delist = gen_delist_df(paths, __returns)
+    __comp_sf2 = gen_temporary_sf(paths, freq, __returns, __delist)
+    __comp_sf2 = add_rf_and_exchange_data_to_temporary_sf(paths, freq, __comp_sf2)
+    __comp_sf2.write_parquet(paths.interim_dir / "__comp_sf2.parquet")
     del __comp_sf2
-    add_primary_sec("__comp_sf2.parquet", "datadate", f"comp_{freq}sf.parquet")
+    add_primary_sec(
+        paths,
+        paths.interim_dir / "__comp_sf2.parquet",
+        "datadate",
+        paths.interim_dir / f"comp_{freq}sf.parquet",
+    )
 
 
 def gen_MMYY_column(var, shift=None):
@@ -1855,7 +1900,7 @@ def add_MMYY_column_drop_original(df, var):
 
 
 @measure_time
-def prepare_crsp_sf(freq):
+def prepare_crsp_sf(paths: DataPaths, freq):
     """
     Description:
         Clean and finalize the CRSP security-file panel (monthly or daily) produced by gen_crsp_sf.
@@ -1880,7 +1925,7 @@ def prepare_crsp_sf(freq):
     merge_vars = ["permno", "merge_aux"] if (freq == "m") else ["permno", "date"]
 
     __crsp_sf = (
-        pl.scan_parquet(f"raw_data_dfs/__crsp_sf_{freq}.parquet")
+        pl.scan_parquet(paths.interim_dir / "raw_data_dfs" / f"__crsp_sf_{freq}.parquet")
         .with_columns(
             [
                 col(var).cast(pl.Float64)
@@ -1912,15 +1957,15 @@ def prepare_crsp_sf(freq):
         else [col("delistingdt").alias("date")]
     )
 
-    crsp_sedelist = pl.scan_parquet(f"raw_data_dfs/crsp_{freq}sedelist.parquet").with_columns(
-        crsp_sedelist_aux_col
-    )
+    crsp_sedelist = pl.scan_parquet(
+        paths.interim_dir / "raw_data_dfs" / f"crsp_{freq}sedelist.parquet"
+    ).with_columns(crsp_sedelist_aux_col)
 
     crsp_mcti = add_MMYY_column_drop_original(
-        pl.scan_parquet("raw_data_dfs/crsp_mcti_t30ret.parquet"), "caldt"
+        pl.scan_parquet(paths.interim_dir / "raw_data_dfs" / "crsp_mcti_t30ret.parquet"), "caldt"
     )
     ff_factors_monthly = add_MMYY_column_drop_original(
-        pl.scan_parquet("raw_data_dfs/ff_factors_monthly.parquet"), "date"
+        pl.scan_parquet(paths.interim_dir / "raw_data_dfs" / "ff_factors_monthly.parquet"), "date"
     )
 
     c1 = col("delret").is_null()
@@ -2011,11 +2056,11 @@ def prepare_crsp_sf(freq):
         .sort(["permno", "date"])
     )
 
-    __crsp_sf.collect().write_parquet(f"crsp_{freq}sf.parquet")
+    __crsp_sf.collect().write_parquet(paths.interim_dir / f"crsp_{freq}sf.parquet")
 
 
 @measure_time
-def combine_crsp_comp_sf() -> None:
+def combine_crsp_comp_sf(paths: DataPaths) -> None:
     """
     Description:
         Create unified monthly and daily security datasets by combining CRSP and Compustat,
@@ -2049,11 +2094,17 @@ def combine_crsp_comp_sf() -> None:
     Output:
         '__msf_world.parquet' and 'world_dsf.parquet' ready for downstream processing.
     """
-    Path("aux_combine_sf.ddb").unlink(missing_ok=True)
-    con = duckdb.connect("aux_combine_sf.ddb")
+    (paths.interim_dir / "aux_combine_sf.ddb").unlink(missing_ok=True)
+    con = duckdb.connect(str(paths.interim_dir / "aux_combine_sf.ddb"))
+    crsp_msf_path = (paths.interim_dir / "crsp_msf.parquet").as_posix()
+    comp_msf_path = (paths.interim_dir / "comp_msf.parquet").as_posix()
+    crsp_dsf_path = (paths.interim_dir / "crsp_dsf.parquet").as_posix()
+    comp_dsf_path = (paths.interim_dir / "comp_dsf.parquet").as_posix()
+    msf_world_out = (paths.interim_dir / "__msf_world.parquet").as_posix()
+    world_dsf_out = (paths.interim_dir / "world_dsf.parquet").as_posix()
     try:
         # Monthly: normalize CRSP/Comp, UNION ALL, compute ret_exc_lead1m
-        con.execute("""
+        con.execute(f"""
             CREATE TABLE sf_world_m AS
             WITH crsp_msf_norm AS (
                 SELECT
@@ -2085,7 +2136,7 @@ def combine_crsp_comp_sf() -> None:
                     NULL::DOUBLE AS div_cash,
                     NULL::DOUBLE AS div_spc,
                     1 AS source_crsp
-                FROM read_parquet('crsp_msf.parquet')
+                FROM read_parquet('{crsp_msf_path}')
             ),
             comp_msf_norm AS (
                 SELECT
@@ -2121,7 +2172,7 @@ def combine_crsp_comp_sf() -> None:
                     ret_lag_dif::BIGINT AS ret_lag_dif,
                     div_tot, div_cash, div_spc,
                     0 AS source_crsp
-                FROM read_parquet('comp_msf.parquet')
+                FROM read_parquet('{comp_msf_path}')
             )
             SELECT *,
                 CASE
@@ -2158,7 +2209,7 @@ def combine_crsp_comp_sf() -> None:
         """)
 
         # Write monthly output with deterministic dedup (prefer CRSP)
-        con.execute("""
+        con.execute(f"""
             COPY (
                 SELECT
                     id, permno, permco, gvkey, iid, excntry, exch_main, common,
@@ -2181,14 +2232,14 @@ def combine_crsp_comp_sf() -> None:
                 ) ranked
                 WHERE _rn = 1
                 ORDER BY id, eom
-            ) TO '__msf_world.parquet' (FORMAT PARQUET)
+            ) TO '{msf_world_out}' (FORMAT PARQUET)
         """)
 
         # Free monthly table memory; keep obs_main for daily step
         con.execute("DROP TABLE sf_world_m")
 
         # Daily: normalize CRSP/Comp, UNION ALL, join obs_main, dedup, write
-        con.execute("""
+        con.execute(f"""
             COPY (
                 WITH crsp_dsf_norm AS (
                     SELECT
@@ -2211,7 +2262,7 @@ def combine_crsp_comp_sf() -> None:
                         ret, ret_exc,
                         1::BIGINT AS ret_lag_dif,
                         1 AS source_crsp
-                    FROM read_parquet('crsp_dsf.parquet')
+                    FROM read_parquet('{crsp_dsf_path}')
                 ),
                 comp_dsf_norm AS (
                     SELECT
@@ -2239,7 +2290,7 @@ def combine_crsp_comp_sf() -> None:
                         ret_local, ret, ret_exc,
                         ret_lag_dif::BIGINT AS ret_lag_dif,
                         0 AS source_crsp
-                    FROM read_parquet('comp_dsf.parquet')
+                    FROM read_parquet('{comp_dsf_path}')
                 ),
                 sf_world_d AS (
                     SELECT * FROM crsp_dsf_norm
@@ -2263,15 +2314,15 @@ def combine_crsp_comp_sf() -> None:
                 FROM ranked
                 WHERE _rn = 1
                 ORDER BY id, date
-            ) TO 'world_dsf.parquet' (FORMAT PARQUET)
+            ) TO '{world_dsf_out}' (FORMAT PARQUET)
         """)
     finally:
         con.close()
-        Path("aux_combine_sf.ddb").unlink(missing_ok=True)
+        (paths.interim_dir / "aux_combine_sf.ddb").unlink(missing_ok=True)
 
 
 @measure_time
-def crsp_industry():
+def crsp_industry(paths: DataPaths):
     """
     Description:
         Generate a daily panel of CRSP SIC/NAICS codes per permno based on name-date spans.
@@ -2284,7 +2335,7 @@ def crsp_industry():
     Output:
         Parquet crsp_ind.parquet with {permno,permco,date,sic,naics}.
     """
-    permno0 = pl.scan_parquet("raw_data_dfs/permno0.parquet")
+    permno0 = pl.scan_parquet(paths.interim_dir / "raw_data_dfs" / "permno0.parquet")
     permno0 = (
         permno0.with_columns(
             sic=pl.when(col("sic") == 0).then(pl.lit(None).cast(pl.Int64)).otherwise(col("sic"))
@@ -2295,10 +2346,10 @@ def crsp_industry():
         .unique(["permno", "date"])
         .sort(["permno", "date"])
     )
-    permno0.collect().write_parquet("crsp_ind.parquet")
+    permno0.collect().write_parquet(paths.interim_dir / "crsp_ind.parquet")
 
 
-def comp_hgics(lib):
+def comp_hgics(paths: DataPaths, lib):
     """
     Description:
         Expand Compustat GICS history (national/global) to a daily panel with forward-filled
@@ -2313,14 +2364,18 @@ def comp_hgics(lib):
     Output:
         Parquet with {gvkey,date,gics} expanded to daily frequency.
     """
-    paths = {
+    raw_data_dfs = paths.interim_dir / "raw_data_dfs"
+    file_paths = {
         "raw data": {
-            "national": "raw_data_dfs/comp_hgics_na.parquet",
-            "global": "raw_data_dfs/comp_hgics_gl.parquet",
+            "national": raw_data_dfs / "comp_hgics_na.parquet",
+            "global": raw_data_dfs / "comp_hgics_gl.parquet",
         },
-        "output": {"national": "na_hgics.parquet", "global": "g_hgics.parquet"},
+        "output": {
+            "national": paths.interim_dir / "na_hgics.parquet",
+            "global": paths.interim_dir / "g_hgics.parquet",
+        },
     }
-    data = pl.read_parquet(paths["raw data"][lib])  # .sort(['gvkey', 'indfrom'])
+    data = pl.read_parquet(file_paths["raw data"][lib])  # .sort(['gvkey', 'indfrom'])
     data = data.with_columns(
         gics=pl.when(col("gics").is_null()).then(-999).otherwise(col("gics")),
         n=pl.len().over("gvkey"),
@@ -2340,10 +2395,10 @@ def comp_hgics(lib):
         .unique(subset=["gvkey", "date"])
         .sort(["gvkey", "date"])
     )
-    data.write_parquet(paths["output"][lib])
+    data.write_parquet(file_paths["output"][lib])
 
 
-def hgics_join():
+def hgics_join(paths: DataPaths):
     """
     Description:
         Merge national and global GICS daily panels, preferring local (national) where available.
@@ -2356,20 +2411,20 @@ def hgics_join():
     Output:
         Parquet comp_hgics.parquet with consolidated GICS per (gvkey,date).
     """
-    comp_hgics("global")
-    comp_hgics("national")
-    global_data = pl.scan_parquet("g_hgics.parquet")
-    local_data = pl.scan_parquet("na_hgics.parquet")
+    comp_hgics(paths, "global")
+    comp_hgics(paths, "national")
+    global_data = pl.scan_parquet(paths.interim_dir / "g_hgics.parquet")
+    local_data = pl.scan_parquet(paths.interim_dir / "na_hgics.parquet")
     gjoin = local_data.join(global_data, on=["gvkey", "date"], how="full", coalesce=True)
     gjoin = (
         gjoin.select(["gvkey", "date", pl.coalesce(["gics", "gics_right"]).alias("gics")])
         .unique(["gvkey", "date"])
         .sort(["gvkey", "date"])
     )
-    gjoin.collect().write_parquet("comp_hgics.parquet")
+    gjoin.collect().write_parquet(paths.interim_dir / "comp_hgics.parquet")
 
 
-def comp_sic_naics():
+def comp_sic_naics(paths: DataPaths):
     """
     Description:
         Combine and reconcile Compustat SIC/NAICS from US and Global datasets into a
@@ -2386,8 +2441,14 @@ def comp_sic_naics():
         Parquet comp_other.parquet with daily SIC/NAICS per gvkey.
     """
     con = ibis.duckdb.connect(threads=os.cpu_count())
-    con.create_table("sic_naics_na", con.read_parquet("raw_data_dfs/sic_naics_na.parquet"))
-    con.create_table("sic_naics_gl", con.read_parquet("raw_data_dfs/sic_naics_gl.parquet"))
+    con.create_table(
+        "sic_naics_na",
+        con.read_parquet(paths.interim_dir / "raw_data_dfs" / "sic_naics_na.parquet"),
+    )
+    con.create_table(
+        "sic_naics_gl",
+        con.read_parquet(paths.interim_dir / "raw_data_dfs" / "sic_naics_gl.parquet"),
+    )
     con.raw_sql("""
                 CREATE TABLE comp2 AS
                 SELECT *
@@ -2464,12 +2525,12 @@ def comp_sic_naics():
         .unique(["gvkey", "date"])
         .sort(["gvkey", "date"])
     )
-    comp.collect().write_parquet("comp_other.parquet")
+    comp.collect().write_parquet(paths.interim_dir / "comp_other.parquet")
     con.disconnect()
 
 
 @measure_time
-def comp_industry():
+def comp_industry(paths: DataPaths):
     """
     Description:
         Merge daily GICS and SIC/NAICS into a single daily Compustat industry file,
@@ -2484,12 +2545,12 @@ def comp_industry():
     Output:
         Parquet comp_ind.parquet with {gvkey,date,gics,sic,naics} daily.
     """
-    comp_sic_naics()
-    hgics_join()
-    os.system("rm -f aux_comp_ind.ddb")
-    con = ibis.duckdb.connect("aux_comp_ind.ddb", threads=os.cpu_count())
-    con.create_table("comp_other", con.read_parquet("comp_other.parquet"))
-    con.create_table("comp_gics", con.read_parquet("comp_hgics.parquet"))
+    comp_sic_naics(paths)
+    hgics_join(paths)
+    (paths.interim_dir / "aux_comp_ind.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(str(paths.interim_dir / "aux_comp_ind.ddb"), threads=os.cpu_count())
+    con.create_table("comp_other", con.read_parquet(paths.interim_dir / "comp_other.parquet"))
+    con.create_table("comp_gics", con.read_parquet(paths.interim_dir / "comp_hgics.parquet"))
     con.raw_sql("""
                 DROP TABLE IF EXISTS join_table;
                 CREATE TABLE join_table AS
@@ -2542,7 +2603,7 @@ def comp_industry():
                 FROM merged_data
                 ORDER BY (gvkey, date);
     """)
-    con.table("comp_industry").to_parquet("comp_ind.parquet")
+    con.table("comp_industry").to_parquet(paths.interim_dir / "comp_ind.parquet")
     con.disconnect()
 
 
@@ -2589,7 +2650,7 @@ def _parse_siccodes_file(filename: str, label: str) -> pl.DataFrame:
 
 
 @measure_time
-def ff_ind_class(data_path: str) -> None:
+def ff_ind_class(paths: DataPaths, data_path: str) -> None:
     """
     Description:
         Assign Fama-French 49 industry classification based on SIC codes.
@@ -2609,11 +2670,13 @@ def ff_ind_class(data_path: str) -> None:
 
     mapping = _parse_siccodes_file(str(get_siccodes_path()), label="ff49").lazy()
     data = pl.scan_parquet(data_path)
-    data.join(mapping, on="sic", how="left").collect().write_parquet("__msf_world3.parquet")
+    data.join(mapping, on="sic", how="left").collect().write_parquet(
+        paths.interim_dir / "__msf_world3.parquet"
+    )
 
 
 @measure_time
-def nyse_size_cutoffs(data_path):
+def nyse_size_cutoffs(paths: DataPaths, data_path):
     """
     Description:
         Compute NYSE market equity cutoffs (1%,20%,50%,80%) by month.
@@ -2645,11 +2708,11 @@ def nyse_size_cutoffs(data_path):
             GROUP BY eom
             ORDER BY eom
             """)
-    nyse_sf.sink_parquet("nyse_cutoffs.parquet")
+    nyse_sf.sink_parquet(paths.interim_dir / "nyse_cutoffs.parquet")
 
 
 @measure_time
-def classify_stocks_size_groups():
+def classify_stocks_size_groups(paths: DataPaths):
     """
     Description:
         Join world MSF with NYSE size cutoffs and classify stocks into size buckets.
@@ -2662,8 +2725,8 @@ def classify_stocks_size_groups():
     Output:
         Writes 'world_msf.parquet' with size_grp per row.
     """
-    nyse_cutoffs = pl.scan_parquet("nyse_cutoffs.parquet")
-    __msf_world = pl.scan_parquet("__msf_world3.parquet")
+    nyse_cutoffs = pl.scan_parquet(paths.interim_dir / "nyse_cutoffs.parquet")
+    __msf_world = pl.scan_parquet(paths.interim_dir / "__msf_world3.parquet")
     world_msf = (
         __msf_world.join(nyse_cutoffs, how="left", on="eom")
         .with_columns(
@@ -2683,11 +2746,11 @@ def classify_stocks_size_groups():
         )
         .drop([i for i in nyse_cutoffs.collect_schema().names() if i not in ["eom"]])
     )
-    world_msf.collect().write_parquet("world_msf.parquet")
+    world_msf.collect().write_parquet(paths.interim_dir / "world_msf.parquet")
 
 
 @measure_time
-def return_cutoffs(freq, crsp_only):
+def return_cutoffs(paths: DataPaths, freq, crsp_only):
     """
     Description:
         Compute return percentile cutoffs by period (monthly or daily), optionally CRSP-only.
@@ -2702,8 +2765,12 @@ def return_cutoffs(freq, crsp_only):
         Writes 'return_cutoffs.parquet' (monthly) or 'return_cutoffs_daily.parquet' (daily).
     """
     group_vars = "eom"
-    res_path = "return_cutoffs.parquet" if freq == "m" else "return_cutoffs_daily.parquet"
-    data = pl.scan_parquet(f"world_{freq}sf.parquet").filter(
+    res_path = (
+        paths.interim_dir / "return_cutoffs.parquet"
+        if freq == "m"
+        else paths.interim_dir / "return_cutoffs_daily.parquet"
+    )
+    data = pl.scan_parquet(paths.interim_dir / f"world_{freq}sf.parquet").filter(
         (col("common") == 1)
         & (col("obs_main") == 1)
         & (col("exch_main") == 1)
@@ -2748,7 +2815,9 @@ def return_cutoffs(freq, crsp_only):
 
 
 @measure_time
-def add_ret_exc_wins(freq: str, lower: float = 0.001, upper: float = 0.999) -> None:
+def add_ret_exc_wins(
+    paths: DataPaths, freq: str, lower: float = 0.001, upper: float = 0.999
+) -> None:
     """
     Description:
         Add a winsorized excess return column (ret_exc_wins) to the world security file.
@@ -2788,8 +2857,12 @@ def add_ret_exc_wins(freq: str, lower: float = 0.001, upper: float = 0.999) -> N
     lower_col = percentile_to_column[lower]
     upper_col = percentile_to_column[upper]
 
-    data_path = f"world_{freq}sf.parquet"
-    cutoffs_path = "return_cutoffs.parquet" if freq == "m" else "return_cutoffs_daily.parquet"
+    data_path = paths.interim_dir / f"world_{freq}sf.parquet"
+    cutoffs_path = (
+        paths.interim_dir / "return_cutoffs.parquet"
+        if freq == "m"
+        else paths.interim_dir / "return_cutoffs_daily.parquet"
+    )
     group_vars = ["eom"] if freq == "m" else ["year", "month"]
 
     data = pl.scan_parquet(data_path)
@@ -2990,7 +3063,7 @@ def drop_non_trading_days(df, n_col, dt_col, over_vars, thresh_fraction):
 
 
 @measure_time
-def market_returns(data_path, freq, wins_comp, wins_data_path, nyse_cutoffs_path):
+def market_returns(paths: DataPaths, data_path, freq, wins_comp, wins_data_path, nyse_cutoffs_path):
     """
     Description:
         Build country-level market returns (daily or monthly), optional winsorization, and save to disk.
@@ -3032,7 +3105,7 @@ def market_returns(data_path, freq, wins_comp, wins_data_path, nyse_cutoffs_path
             __common_stocks, "stocks", dt_col, ["excntry", "eom"], 0.25
         )
     __common_stocks.sort(["excntry", dt_col]).collect().write_parquet(
-        f"market_returns{path_aux}.parquet"
+        paths.interim_dir / f"market_returns{path_aux}.parquet"
     )
 
 
@@ -3266,7 +3339,7 @@ def load_mkt_equity_data(filename, alias=True):
 
 @measure_time
 def standardized_accounting_data(
-    coverage, convert_to_usd, me_data_path, include_helpers_vars, start_date
+    paths: DataPaths, coverage, convert_to_usd, me_data_path, include_helpers_vars, start_date
 ):
     """
     Description:
@@ -3287,9 +3360,11 @@ def standardized_accounting_data(
         Two Parquet files: 'acc_std_ann.parquet' (annual) and 'acc_std_qtr.parquet' (quarterly) standardized accounting data.
     """
     g_fundq_cols = (
-        pl.scan_parquet("../raw/raw_tables/comp_g_fundq.parquet").collect_schema().names()
+        pl.scan_parquet(paths.raw_tables_dir / "comp_g_fundq.parquet").collect_schema().names()
     )
-    fundq_cols = pl.scan_parquet("../raw/raw_tables/comp_fundq.parquet").collect_schema().names()
+    fundq_cols = (
+        pl.scan_parquet(paths.raw_tables_dir / "comp_fundq.parquet").collect_schema().names()
+    )
     # Compustat Accounting Vars to Extract
     avars_inc = [
         "sale",
@@ -3398,7 +3473,7 @@ def standardized_accounting_data(
         vars_not_in_query = ["gp", "pstkrv", "pstkl", "itcb", "xad", "txbcof", "ni"]
         query_vars = [var for var in (avars + avars_other) if var not in vars_not_in_query]
         g_funda = load_raw_fund_table_and_filter(
-            "../raw/raw_tables/comp_g_funda.parquet", start_date, "GLOBAL", 1
+            paths.raw_tables_dir / "comp_g_funda.parquet", start_date, "GLOBAL", 1
         )
         __gfunda = (
             g_funda.with_columns(
@@ -3429,7 +3504,7 @@ def standardized_accounting_data(
         ]
         query_vars = [var for var in qvars if var not in vars_not_in_query]
         g_fundq = load_raw_fund_table_and_filter(
-            "../raw/raw_tables/comp_g_fundq.parquet", start_date, "GLOBAL", 1
+            paths.raw_tables_dir / "comp_g_fundq.parquet", start_date, "GLOBAL", 1
         )
         __gfundq = (
             g_fundq.with_columns(
@@ -3473,7 +3548,7 @@ def standardized_accounting_data(
         vars_not_in_query = ["wcapt", "ltdch", "purtshr"]
         query_vars = [var for var in (avars + avars_other) if var not in vars_not_in_query]
         funda = load_raw_fund_table_and_filter(
-            "../raw/raw_tables/comp_funda.parquet", start_date, "NA", 2
+            paths.raw_tables_dir / "comp_funda.parquet", start_date, "NA", 2
         )
         __funda = funda.select(
             ["gvkey", "datadate", "n", "curcd", "source"]
@@ -3492,7 +3567,7 @@ def standardized_accounting_data(
         ]
         query_vars = [var for var in qvars if var not in vars_not_in_query]
         fundq = load_raw_fund_table_and_filter(
-            "../raw/raw_tables/comp_fundq.parquet", start_date, "NA", 2
+            paths.raw_tables_dir / "comp_fundq.parquet", start_date, "NA", 2
         )
         __fundq = fundq.select(
             ["gvkey", "datadate", "n", "fyr", "fyearq", "fqtr", "curcdq", "source"]
@@ -3524,7 +3599,7 @@ def standardized_accounting_data(
         aname, qname = __wfunda, __wfundq
 
     if convert_to_usd == 1:
-        fx = compustat_fx().lazy()
+        fx = compustat_fx(paths).lazy()
         __compa = add_fx_and_convert_vars(aname, fx, avars, "annual")
         __compq = add_fx_and_convert_vars(qname, fx, qvars, "quarterly")
     else:
@@ -3693,15 +3768,15 @@ def standardized_accounting_data(
     )
 
     if include_helpers_vars == 1:
-        __compq = add_helper_vars(__compq)
-        __compa = add_helper_vars(__compa)
+        __compq = add_helper_vars(paths, __compq)
+        __compa = add_helper_vars(paths, __compa)
 
     __compa.unique(["gvkey", "datadate"]).drop("n").sort(
         ["gvkey", "datadate"]
-    ).collect().write_parquet("acc_std_ann.parquet")
+    ).collect().write_parquet(paths.interim_dir / "acc_std_ann.parquet")
     __compq.unique(["gvkey", "datadate"]).drop("n").sort(
         ["gvkey", "datadate"]
-    ).collect().write_parquet("acc_std_qtr.parquet")
+    ).collect().write_parquet(paths.interim_dir / "acc_std_qtr.parquet")
 
 
 def expand(data, id_vars, start_date, end_date, freq="day", new_date_name="date"):
@@ -3773,7 +3848,7 @@ def sub_sas(col1, col2):
     )
 
 
-def add_helper_vars(data):
+def add_helper_vars(paths: DataPaths, data):
     """
     Description:
         Generate monthly-complete accounting panels per (gvkey,curcd), join originals, and compute a rich set of helper *_x variables.
@@ -3788,8 +3863,10 @@ def add_helper_vars(data):
     Output:
         LazyFrame with monthly-complete panel and standardized helper variables (…_x) for downstream ratios/factors.
     """
-    os.system("rm -f aux_add_helpers.ddb")
-    con = ibis.duckdb.connect("aux_add_helpers.ddb", threads=os.cpu_count())
+    (paths.interim_dir / "aux_add_helpers.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(
+        str(paths.interim_dir / "aux_add_helpers.ddb"), threads=os.cpu_count()
+    )
     con.create_table("data", data.rename({"at": "at_var"}).collect(), overwrite=True)
     con.raw_sql("""
         CREATE OR REPLACE TABLE comp_dates1 AS
@@ -4743,7 +4820,7 @@ def chg_var1_to_var2(df, name, var1, var2, horizon):
     return df
 
 
-def compute_earnings_persistence(data_path, __n, __min):
+def compute_earnings_persistence(paths: DataPaths, data_path, __n, __min):
     """
     Description:
         Earnings persistence: AR(1) of NI/AT (annual steps) with rolling cohorts.
@@ -4759,7 +4836,9 @@ def compute_earnings_persistence(data_path, __n, __min):
     """
 
     months = 12 * __n
-    con = ibis.duckdb.connect("aux_earnings_pers.ddb", threads=os.cpu_count())
+    con = ibis.duckdb.connect(
+        str(paths.interim_dir / "aux_earnings_pers.ddb"), threads=os.cpu_count()
+    )
     con.create_table(
         "raw_table",
         pl.scan_parquet(data_path).select(["gvkey", "curcd", "datadate", "ni_x", "at_x"]).collect(),
@@ -4858,9 +4937,9 @@ def compute_earnings_persistence(data_path, __n, __min):
     HAVING COUNT(*) >= {__min}
     ORDER BY gvkey, curcd, calc_date;
     """)
-    con.table("reg_results").to_parquet("ni_ar_res.parquet")
+    con.table("reg_results").to_parquet(paths.interim_dir / "ni_ar_res.parquet")
     con.disconnect()
-    os.system("rm -f aux_earnings_pers.ddb")
+    (paths.interim_dir / "aux_earnings_pers.ddb").unlink(missing_ok=True)
 
 
 def scale_me(var):
@@ -5183,7 +5262,7 @@ def emp_gr(path):
     Output:
         Polars expression 'emp_gr1'.
     """
-    if path == "acc_std_qtr.parquet":
+    if Path(path).name == "acc_std_qtr.parquet":
         col_expr = fl_none().alias("emp_gr1")
     else:
         c1 = col("count") > 12
@@ -5489,7 +5568,7 @@ def add_profit_scaled_by_lagged_vars(df):
     return df
 
 
-def add_earnings_persistence_and_expand(df, data_path, lag_to_pub, max_lag):
+def add_earnings_persistence_and_expand(paths: DataPaths, df, data_path, lag_to_pub, max_lag):
     """
     Description:
         Attach AR(1) earnings persistence (ni_ar1, ni_ivol) and expand to public dates.
@@ -5503,8 +5582,8 @@ def add_earnings_persistence_and_expand(df, data_path, lag_to_pub, max_lag):
     Output:
         Expanded DataFrame keyed by (gvkey, public_date) with persistence fields.
     """
-    compute_earnings_persistence(data_path, 5, 5)
-    earnings_pers = pl.scan_parquet("ni_ar_res.parquet")
+    compute_earnings_persistence(paths, data_path, 5, 5)
+    earnings_pers = pl.scan_parquet(paths.interim_dir / "ni_ar_res.parquet")
     df = (
         df.join(earnings_pers, on=["gvkey", "curcd", "datadate"], how="left")
         .filter(col("data_available") == 1)
@@ -5673,7 +5752,7 @@ def rename_cols_and_select_keep_vars(df, rename_dict, vars_to_keep, suffix):
         return df.rename({i: (i + suffix) for i in vars_to_keep})
 
 
-def convert_raw_vars_to_usd(df):
+def convert_raw_vars_to_usd(paths: DataPaths, df):
     """
     Description:
         Convert select raw variables to USD using FX at (curcd, public_date).
@@ -5686,7 +5765,7 @@ def convert_raw_vars_to_usd(df):
     Output:
         DataFrame with key fundamentals in USD.
     """
-    fx = compustat_fx().rename({"datadate": "date"}).lazy()
+    fx = compustat_fx(paths).rename({"datadate": "date"}).lazy()
     cols_for_new_df = df.collect_schema().names()
     df = (
         df.join(
@@ -5764,6 +5843,7 @@ def financial_soundness_and_misc_ratios_exps():
 
 @measure_time
 def create_acc_chars(
+    paths: DataPaths,
     data_path,
     output_path,
     lag_to_public,
@@ -5901,12 +5981,12 @@ def create_acc_chars(
         )
         .pipe(add_accounting_misc_cols_2)
         .pipe(
-            add_earnings_persistence_and_expand,
+            functools.partial(add_earnings_persistence_and_expand, paths),
             data_path=data_path,
             lag_to_pub=lag_to_public,
             max_lag=max_data_lag,
         )
-        .pipe(convert_raw_vars_to_usd)
+        .pipe(functools.partial(convert_raw_vars_to_usd, paths))
         .pipe(add_me_data_and_compute_me_mev_mat_eqdur_vars, me_df=me_data)
     )
 
@@ -5937,7 +6017,7 @@ def create_acc_chars(
 
 
 @measure_time
-def combine_ann_qtr_chars(ann_df_path, qtr_df_path, char_vars, q_suffix):
+def combine_ann_qtr_chars(paths: DataPaths, ann_df_path, qtr_df_path, char_vars, q_suffix):
     """
     Description:
         Combine annual and quarterly characteristic panels, preferring fresher quarterly values at the same public_date.
@@ -5950,8 +6030,8 @@ def combine_ann_qtr_chars(ann_df_path, qtr_df_path, char_vars, q_suffix):
     Output:
         Writes 'acc_chars_world.parquet' merged panel.
     """
-    os.system("rm -f aux_aqtr_chars.ddb")
-    con = ibis.duckdb.connect("aux_aqtr_chars.ddb", threads=os.cpu_count())
+    (paths.interim_dir / "aux_aqtr_chars.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(str(paths.interim_dir / "aux_aqtr_chars.ddb"), threads=os.cpu_count())
     con.create_table(
         "ann",
         con.read_parquet(ann_df_path).mutate(n1=ibis.row_number()),
@@ -5991,9 +6071,9 @@ def combine_ann_qtr_chars(ann_df_path, qtr_df_path, char_vars, q_suffix):
         .drop(["n1", "n2"])
         .order_by(["gvkey", "public_date"])
     )
-    combined.to_parquet("acc_chars_world.parquet")
+    combined.to_parquet(paths.interim_dir / "acc_chars_world.parquet")
     con.disconnect()
-    os.system("rm -f aux_aqtr_chars.ddb")
+    (paths.interim_dir / "aux_aqtr_chars.ddb").unlink(missing_ok=True)
 
 
 def seasonality(data, ret_x, start_year, end_year):
@@ -6124,7 +6204,7 @@ def div_cols(i, spc=False):
 
 
 @measure_time
-def market_chars_monthly(data_path, market_ret_path, local_currency=False):
+def market_chars_monthly(paths: DataPaths, data_path, market_ret_path, local_currency=False):
     """
     Description:
         Build monthly market characteristics per security: dividends, issuance, momentum/reversal, seasonality.
@@ -6248,11 +6328,11 @@ def market_chars_monthly(data_path, market_ret_path, local_currency=False):
         .sort(["id", "eom"])
     )
 
-    data.collect(streaming=True).write_parquet("market_chars_m.parquet")
+    data.collect(streaming=True).write_parquet(paths.interim_dir / "market_chars_m.parquet")
 
 
 @measure_time
-def firm_age(data_path):
+def firm_age(paths: DataPaths, data_path):
     """
     Description:
         Compute firm age in months using earliest of CRSP, Compustat accounting, or Compustat returns dates.
@@ -6267,11 +6347,11 @@ def firm_age(data_path):
     """
     con = ibis.duckdb.connect(threads=os.cpu_count())
     data = con.read_parquet(data_path).select(["gvkey", "permco", "id", "eom"])
-    comp_secm = con.read_parquet("../raw/raw_tables/comp_secm.parquet").select(
+    comp_secm = con.read_parquet(paths.raw_tables_dir / "comp_secm.parquet").select(
         ["gvkey", "datadate"]
     )
     comp_gsecm = (
-        con.read_parquet("../raw/raw_tables/comp_g_secd.parquet")
+        con.read_parquet(paths.raw_tables_dir / "comp_g_secd.parquet")
         .filter(_.monthend == 1)
         .select(["gvkey", "datadate"])
     )
@@ -6285,10 +6365,10 @@ def firm_age(data_path):
             ).cast("date")
         )
     )
-    comp_funda = con.read_parquet("../raw/raw_tables/comp_funda.parquet").select(
+    comp_funda = con.read_parquet(paths.raw_tables_dir / "comp_funda.parquet").select(
         ["gvkey", "datadate"]
     )
-    comp_gfunda = con.read_parquet("../raw/raw_tables/comp_g_funda.parquet").select(
+    comp_gfunda = con.read_parquet(paths.raw_tables_dir / "comp_g_funda.parquet").select(
         ["gvkey", "datadate"]
     )
     comp_acc_age = (
@@ -6302,7 +6382,7 @@ def firm_age(data_path):
         )
     )
     crsp_age = (
-        con.read_parquet("raw_data_dfs/crsp_msf_v2_aug.parquet")
+        con.read_parquet(paths.interim_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
         .group_by("permco")
         .agg(crsp_first=_.mthcaldt.min())
     )
@@ -6334,7 +6414,7 @@ def firm_age(data_path):
                     ORDER BY id, eom;
     """
     con.raw_sql(sql_query)
-    con.table("age3").to_parquet("firm_age.parquet")
+    con.table("age3").to_parquet(paths.interim_dir / "firm_age.parquet")
     con.disconnect()
 
 
@@ -6439,6 +6519,7 @@ def sort_ff_style(char, min_stocks_bp, min_stocks_pf, date_col, data, sf):
 
 @measure_time
 def ap_factors(
+    paths: DataPaths,
     output_path,
     freq,
     sf_path,
@@ -6576,7 +6657,9 @@ def ap_factors(
     output.write_parquet(output_path)
 
 
-def prep_data_factor_regs(data_path, fcts_path, lower: float = 0.001, upper: float = 0.999):
+def prep_data_factor_regs(
+    paths: DataPaths, data_path, fcts_path, lower: float = 0.001, upper: float = 0.999
+):
     """
     Description:
         Prepare monthly panel for factor regressions (join data with factors, filter, winsorize).
@@ -6590,17 +6673,21 @@ def prep_data_factor_regs(data_path, fcts_path, lower: float = 0.001, upper: flo
         DuckDB connection containing tables '__msf2' (ready for rolling regs).
     """
 
-    os.system("rm -f aux_factor_regs.ddb")
-    con = ibis.duckdb.connect("aux_factor_regs.ddb", threads=os.cpu_count())
+    (paths.interim_dir / "aux_factor_regs.ddb").unlink(missing_ok=True)
+    con = ibis.duckdb.connect(
+        str(paths.interim_dir / "aux_factor_regs.ddb"), threads=os.cpu_count()
+    )
 
+    data_path_posix = Path(data_path).as_posix()
+    fcts_path_posix = Path(fcts_path).as_posix()
     con.raw_sql(f"""
     CREATE OR REPLACE VIEW data_msf AS
     SELECT *
-    FROM read_parquet('{data_path}');
+    FROM read_parquet('{data_path_posix}');
 
     CREATE OR REPLACE VIEW fcts AS
     SELECT *
-    FROM read_parquet('{fcts_path}');
+    FROM read_parquet('{fcts_path_posix}');
 
     CREATE OR REPLACE TABLE __msf2 AS
     WITH __msf1 AS (
@@ -6645,7 +6732,7 @@ def prep_data_factor_regs(data_path, fcts_path, lower: float = 0.001, upper: flo
 
 
 @measure_time
-def market_beta(output_path, data_path, fcts_path, __n, __min):
+def market_beta(paths: DataPaths, output_path, data_path, fcts_path, __n, __min):
     """
     Description:
         Estimate rolling CAPM betas and idiosyncratic vol for each stock.
@@ -6658,7 +6745,7 @@ def market_beta(output_path, data_path, fcts_path, __n, __min):
     Output:
         Parquet at output_path with [id, eom, beta_{__n}m, ivol_capm_{__n}m].
     """
-    con = prep_data_factor_regs(data_path, fcts_path)
+    con = prep_data_factor_regs(paths, data_path, fcts_path)
     base_data = con.table("__msf2").to_polars().lazy()
     aux_maps = gen_aux_maps(__n)
     df = pl.concat(
@@ -6691,7 +6778,7 @@ def market_beta(output_path, data_path, fcts_path, __n, __min):
 
 
 @measure_time
-def residual_momentum(output_path, data_path, fcts_path, __n, __min, incl, skip):
+def residual_momentum(paths: DataPaths, output_path, data_path, fcts_path, __n, __min, incl, skip):
     """
     Description:
         Compute residual momentum from FF3 regressions with rolling windows and skip/inclusion rules.
@@ -6703,7 +6790,7 @@ def residual_momentum(output_path, data_path, fcts_path, __n, __min, incl, skip)
     Output:
         Parquet '{output_path}_{incl}_{skip}.parquet' with [id, eom, resff3_{incl}_{skip}].
     """
-    con = prep_data_factor_regs(data_path, fcts_path)
+    con = prep_data_factor_regs(paths, data_path, fcts_path)
     base_data = con.table("__msf2").to_polars().lazy()
     aux_maps = gen_aux_maps(__n)
     df = pl.concat(
@@ -6727,12 +6814,12 @@ def residual_momentum(output_path, data_path, fcts_path, __n, __min, incl, skip)
         .select(["id", "eom", f"resff3_{incl}_{skip}"])
         .sort(["id", "eom"])
     )
-    res.write_parquet(output_path + f"_{incl}_{skip}.parquet")
+    res.write_parquet(paths.interim_dir / f"{output_path}_{incl}_{skip}.parquet")
     con.disconnect()
 
 
 @measure_time
-def prepare_daily(data_path, fcts_path):
+def prepare_daily(paths: DataPaths, data_path, fcts_path):
     """
     Description:
         Build daily dataset: align returns with factors, shrink dtypes, and create helpers.
@@ -6786,10 +6873,12 @@ def prepare_daily(data_path, fcts_path):
             pl.all().shrink_dtype()
         )  # For computers without enough memory, use this line to apply dtype shrinking
     )
-    dsf1.collect().write_parquet("dsf1.parquet")
+    dsf1.collect().write_parquet(paths.interim_dir / "dsf1.parquet")
 
-    id_int_key = pl.scan_parquet("dsf1.parquet").select(["id", "id_int"]).unique()
-    id_int_key.collect().write_parquet("id_int_key.parquet")
+    id_int_key = (
+        pl.scan_parquet(paths.interim_dir / "dsf1.parquet").select(["id", "id_int"]).unique()
+    )
+    id_int_key.collect().write_parquet(paths.interim_dir / "id_int_key.parquet")
 
     mkt_lead_lag = (
         fcts.select(["excntry", "date", "mktrf", col("date").dt.month_end().alias("eom")])
@@ -6801,10 +6890,10 @@ def prepare_daily(data_path, fcts_path):
         .select(pl.all().shrink_dtype())
         .sort(["excntry", "date"])
     )
-    mkt_lead_lag.collect().write_parquet("mkt_lead_lag.parquet")
+    mkt_lead_lag.collect().write_parquet(paths.interim_dir / "mkt_lead_lag.parquet")
 
     corr_data = (
-        pl.scan_parquet("dsf1.parquet")
+        pl.scan_parquet(paths.interim_dir / "dsf1.parquet")
         .select(["ret_exc", "id_int", "date", "mktrf", "eom", "zero_obs"])
         .sort(["id_int", "date"])
         .with_columns(
@@ -6824,7 +6913,7 @@ def prepare_daily(data_path, fcts_path):
         .select(pl.all().shrink_dtype())
         .sort(["id_int", "eom"])
     )
-    corr_data.collect().write_parquet("corr_data.parquet")
+    corr_data.collect().write_parquet(paths.interim_dir / "corr_data.parquet")
 
 
 def gen_ranks_and_normalize(df, id_vars, geo_vars, time_vars, desc_flag, var, min_stks):
@@ -6878,7 +6967,7 @@ def gen_misp_exp(var_list, min_fcts):
 
 
 @measure_time
-def mispricing_factors(data_path, min_stks, min_fcts=3, output_path="mp_factors.parquet"):
+def mispricing_factors(paths: DataPaths, data_path, min_stks, min_fcts=3, output_path=None):
     """
     Description:
         Compute two mispricing composites (management & performance) from ranked inputs.
@@ -6892,6 +6981,8 @@ def mispricing_factors(data_path, min_stks, min_fcts=3, output_path="mp_factors.
     Output:
         '{output_path}' with [id, eom, mispricing_perf, mispricing_mgmt].
     """
+    if output_path is None:
+        output_path = paths.interim_dir / "mp_factors.parquet"
     vars_mgmt = [
         "chcsho_12m",
         "eqnpo_12m",
@@ -7126,7 +7217,7 @@ def compute_bidask_spread(df, __min_obs):
 
 
 @measure_time
-def bidask_hl(output_path, data_path, market_returns_daily_path, __min_obs):
+def bidask_hl(paths: DataPaths, output_path, data_path, market_returns_daily_path, __min_obs):
     """
     Description:
         End-to-end HL-based bid-ask and volatility factors from daily prices and market returns.
@@ -7157,7 +7248,7 @@ def bidask_hl(output_path, data_path, market_returns_daily_path, __min_obs):
 
 @measure_time
 def create_world_data_prelim(
-    msf_path, market_chars_monthly_path, acc_chars_world_path, output_path
+    paths: DataPaths, msf_path, market_chars_monthly_path, acc_chars_world_path, output_path
 ):
     """
     Description:
@@ -7537,7 +7628,7 @@ def acc_chars_list():
 
 
 @measure_time
-def finish_daily_chars(output_path):
+def finish_daily_chars(paths: DataPaths, output_path):
     """
     Description:
         Combine bid-ask spread and roll-based daily metrics into a final daily chars file.
@@ -7551,8 +7642,10 @@ def finish_daily_chars(output_path):
     Output:
         '{output_path}' parquet with final daily characteristics.
     """
-    bidask = pl.scan_parquet("corwin_schultz.parquet")
-    r1 = pl.scan_parquet("roll_apply_daily.parquet").with_columns(col("id").cast(pl.Int64))
+    bidask = pl.scan_parquet(paths.interim_dir / "corwin_schultz.parquet")
+    r1 = pl.scan_parquet(paths.interim_dir / "roll_apply_daily.parquet").with_columns(
+        col("id").cast(pl.Int64)
+    )
     daily_chars = bidask.join(r1, how="outer_coalesce", on=["id", "eom"])
     daily_chars = daily_chars.with_columns(
         betabab_1260d=col("corr_1260d") * col("rvol_252d") / col("__mktvol_252d"),
@@ -7585,7 +7678,7 @@ def z_ranks(data, var, __min, sort):
 
 
 @measure_time
-def quality_minus_junk(data_path, min_stks):
+def quality_minus_junk(paths: DataPaths, data_path, min_stks):
     """
     Description:
         Compute standardized within-country z-scores for a variable.
@@ -7696,7 +7789,7 @@ def quality_minus_junk(data_path, min_stks):
     )
     __qmj = z_ranks(qmj, "__qmj", min_stks, "ascending").rename({"z___qmj": "qmj"})
     qmj = qmj.join(__qmj, how="left", on=["excntry", "id", "eom"]).drop("__qmj")
-    qmj.write_parquet("qmj.parquet")
+    qmj.write_parquet(paths.interim_dir / "qmj.parquet")
 
 
 def _main_filter_expr() -> pl.Expr:
@@ -7705,7 +7798,7 @@ def _main_filter_expr() -> pl.Expr:
 
 
 @measure_time
-def filter_dsf():
+def filter_dsf(paths: DataPaths):
     """
     Description:
         Filter world_dsf to main securities.
@@ -7718,13 +7811,13 @@ def filter_dsf():
     Output:
         'world_dsf_output.parquet'.
     """
-    pl.scan_parquet("world_dsf.parquet").filter(_main_filter_expr()).sink_parquet(
-        "world_dsf_output.parquet"
-    )
+    pl.scan_parquet(paths.interim_dir / "world_dsf.parquet").filter(
+        _main_filter_expr()
+    ).sink_parquet(paths.interim_dir / "world_dsf_output.parquet")
 
 
 @measure_time
-def filter_msf():
+def filter_msf(paths: DataPaths):
     """
     Description:
         Filter world_msf to main securities.
@@ -7737,13 +7830,13 @@ def filter_msf():
     Output:
         'world_msf_output.parquet'.
     """
-    pl.scan_parquet("world_msf.parquet").filter(_main_filter_expr()).sink_parquet(
-        "world_msf_output.parquet"
-    )
+    pl.scan_parquet(paths.interim_dir / "world_msf.parquet").filter(
+        _main_filter_expr()
+    ).sink_parquet(paths.interim_dir / "world_msf_output.parquet")
 
 
 @measure_time
-def filter_world():
+def filter_world(paths: DataPaths):
     """
     Description:
         Filter world_data to main securities.
@@ -7756,9 +7849,9 @@ def filter_world():
     Output:
         'world_data_output.parquet'.
     """
-    pl.scan_parquet("world_data.parquet").filter(_main_filter_expr()).sink_parquet(
-        "world_data_output.parquet"
-    )
+    pl.scan_parquet(paths.interim_dir / "world_data.parquet").filter(
+        _main_filter_expr()
+    ).sink_parquet(paths.interim_dir / "world_data_output.parquet")
 
 
 @measure_time
@@ -7774,9 +7867,11 @@ def save_main_data(paths: DataPaths) -> None:
     Output:
         'world_data_output.parquet' and 'characteristics/{country}.parquet'.
     """
+    world_data_output = paths.interim_dir / "world_data_output.parquet"
+    world_data_output_temp = paths.interim_dir / "world_data_output_temp.parquet"
     months_exp = (col("eom").dt.year() * 12 + col("eom").dt.month()).cast(pl.Int64)
     data = (
-        pl.scan_parquet("world_data_output.parquet")
+        pl.scan_parquet(world_data_output)
         .with_columns(dif_aux=months_exp)
         .sort(["id", "eom"])
         .with_columns(
@@ -7788,16 +7883,14 @@ def save_main_data(paths: DataPaths) -> None:
         )
         .drop("dif_aux")
     )
-    data.select(pl.all().shrink_dtype()).sink_parquet("world_data_output_temp.parquet")
-    os.replace("world_data_output_temp.parquet", "world_data_output.parquet")
+    data.select(pl.all().shrink_dtype()).sink_parquet(world_data_output_temp)
+    os.replace(world_data_output_temp, world_data_output)
 
-    os.chdir(paths.processed_dir)
-
-    OUT_DIR = "characteristics"
+    out_dir = paths.processed_dir / "characteristics"
     con = duckdb.connect()
     con.execute(f"""
-    COPY (SELECT * FROM read_parquet('../interim/world_data_output.parquet'))
-    TO '{OUT_DIR}'
+    COPY (SELECT * FROM read_parquet('{world_data_output.as_posix()}'))
+    TO '{out_dir.as_posix()}'
     ( FORMAT PARQUET,
       COMPRESSION ZSTD,
       PARTITION_BY (excntry),
@@ -7806,22 +7899,17 @@ def save_main_data(paths: DataPaths) -> None:
       );
     """)
     con.close()
-    os.system(f"""
-    for d in {OUT_DIR}/excntry=*; do
-        if [ -d "$d" ]; then
-            country="${{d#*=}}"   # strip "excntry="
-            partfile=$(find "$d" -type f -name "*.parquet" | head -n1)
-            if [ -n "$partfile" ]; then
-                mv "$partfile" "{OUT_DIR}/${{country}}.parquet"
-            fi
-            rm -rf "$d"
-        fi
-    done
-    """)
+    for d in out_dir.glob("excntry=*"):
+        if d.is_dir():
+            country = d.name[len("excntry=") :]
+            part_files = sorted(d.glob("*.parquet"))
+            if part_files:
+                part_files[0].rename(out_dir / f"{country}.parquet")
+            shutil.rmtree(d)
 
 
 @measure_time
-def save_output_files():
+def save_output_files(paths: DataPaths):
     """
     Description:
         Copy main market returns and cutoff files to Output folder.
@@ -7834,17 +7922,23 @@ def save_output_files():
     Output:
         Files copied into 'other_output/' directory.
     """
-    os.system("cp ../interim/market_returns.parquet other_output/")
-    os.system("cp ../interim/market_returns_daily.parquet other_output/")
-    os.system("cp ../interim/nyse_cutoffs.parquet other_output/")
-    os.system("cp ../interim/return_cutoffs.parquet other_output/")
-    os.system("cp ../interim/return_cutoffs_daily.parquet other_output/")
-    os.system("cp ../interim/ap_factors_monthly.parquet other_output/")
-    os.system("cp ../interim/ap_factors_daily.parquet other_output/")
+    import shutil
+
+    other_output = paths.processed_dir / "other_output"
+    for name in (
+        "market_returns.parquet",
+        "market_returns_daily.parquet",
+        "nyse_cutoffs.parquet",
+        "return_cutoffs.parquet",
+        "return_cutoffs_daily.parquet",
+        "ap_factors_monthly.parquet",
+        "ap_factors_daily.parquet",
+    ):
+        shutil.copy2(paths.interim_dir / name, other_output / name)
 
 
 @measure_time
-def save_daily_ret():
+def save_daily_ret(paths: DataPaths):
     """
     Description:
         Export daily returns split by country.
@@ -7858,7 +7952,7 @@ def save_daily_ret():
         'return_data/daily_rets_by_country/{country}.parquet' files for all countries.
     """
     data = (
-        pl.scan_parquet("../interim/world_dsf_output.parquet")
+        pl.scan_parquet(paths.interim_dir / "world_dsf_output.parquet")
         .select(["excntry", "id", "date", "me", "ret", "ret_exc", "ret_exc_wins"])
         .with_columns(
             excntry=pl.when(col("excntry").is_null())
@@ -7866,13 +7960,14 @@ def save_daily_ret():
             .otherwise(col("excntry"))
         )
     )
-    data.collect(engine="streaming").write_parquet("../interim/daily_returns_temp.parquet")
+    daily_returns_temp = paths.interim_dir / "daily_returns_temp.parquet"
+    data.collect(engine="streaming").write_parquet(daily_returns_temp)
 
-    OUT_DIR = "return_data/daily_rets_by_country"
+    out_dir = paths.processed_dir / "return_data" / "daily_rets_by_country"
     con = duckdb.connect()
     con.execute(f"""
-    COPY (SELECT * FROM read_parquet('../interim/daily_returns_temp.parquet'))
-    TO '{OUT_DIR}'
+    COPY (SELECT * FROM read_parquet('{daily_returns_temp.as_posix()}'))
+    TO '{out_dir.as_posix()}'
     ( FORMAT PARQUET,
       COMPRESSION ZSTD,
       PARTITION_BY (excntry),
@@ -7880,22 +7975,17 @@ def save_daily_ret():
       );
     """)
     con.close()
-    os.system(f"""
-    for d in {OUT_DIR}/excntry=*; do
-        if [ -d "$d" ]; then
-            country="${{d#*=}}"   # strip "excntry="
-            partfile=$(find "$d" -type f -name "*.parquet" | head -n1)
-            if [ -n "$partfile" ]; then
-                mv "$partfile" "{OUT_DIR}/${{country}}.parquet"
-            fi
-            rm -rf "$d"
-        fi
-    done
-    """)
+    for d in out_dir.glob("excntry=*"):
+        if d.is_dir():
+            country = d.name[len("excntry=") :]
+            part_files = sorted(d.glob("*.parquet"))
+            if part_files:
+                part_files[0].rename(out_dir / f"{country}.parquet")
+            shutil.rmtree(d)
 
 
 @measure_time
-def save_accounting_data():
+def save_accounting_data(paths: DataPaths):
     """
     Description:
         Export quarterly and annual accounting datasets.
@@ -7908,16 +7998,16 @@ def save_accounting_data():
     Output:
         'accounting_data/quarterly.parquet' and 'accounting_data/annual.parquet'.
     """
-    pl.scan_parquet("../interim/acc_std_qtr.parquet").filter(
+    pl.scan_parquet(paths.interim_dir / "acc_std_qtr.parquet").filter(
         col("source").is_not_null()
-    ).collect().write_parquet("accounting_data/quarterly.parquet")
-    pl.scan_parquet("../interim/acc_std_ann.parquet").filter(
+    ).collect().write_parquet(paths.processed_dir / "accounting_data" / "quarterly.parquet")
+    pl.scan_parquet(paths.interim_dir / "acc_std_ann.parquet").filter(
         col("source").is_not_null()
-    ).collect().write_parquet("accounting_data/annual.parquet")
+    ).collect().write_parquet(paths.processed_dir / "accounting_data" / "annual.parquet")
 
 
 @measure_time
-def save_full_files_and_cleanup(clear_interim=True):
+def save_full_files_and_cleanup(paths: DataPaths, clear_interim=True):
     """
     Description:
         Save full datasets and remove temporary files.
@@ -7929,18 +8019,27 @@ def save_full_files_and_cleanup(clear_interim=True):
     Output:
         Compressed parquet files in return_data/ and characteristics/, cleanup of temp files.
     """
-    pl.scan_parquet("../interim/world_dsf_output.parquet").select(
+    pl.scan_parquet(paths.interim_dir / "world_dsf_output.parquet").select(
         pl.all().shrink_dtype()
-    ).sink_parquet("return_data/world_dsf.parquet")
-    pl.scan_parquet("../interim/world_data_output.parquet").select(
+    ).sink_parquet(paths.processed_dir / "return_data" / "world_dsf.parquet")
+    pl.scan_parquet(paths.interim_dir / "world_data_output.parquet").select(
         pl.all().shrink_dtype()
-    ).sink_parquet("characteristics/world_data.parquet")
+    ).sink_parquet(paths.processed_dir / "characteristics" / "world_data.parquet")
     if clear_interim:
-        os.system("rm -rf ../interim/* ../raw/*")
+        for child in paths.interim_dir.iterdir():
+            if child.is_dir():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+        for child in paths.raw_dir.iterdir():
+            if child.is_dir():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
 
 
 @measure_time
-def save_monthly_ret():
+def save_monthly_ret(paths: DataPaths):
     """
     Description:
         Save monthly returns for world securities.
@@ -7953,16 +8052,16 @@ def save_monthly_ret():
     Output:
         Parquet file with monthly returns by country/security.
     """
-    data = pl.scan_parquet("../interim/world_msf_output.parquet").select(
+    data = pl.scan_parquet(paths.interim_dir / "world_msf_output.parquet").select(
         ["excntry", "id", "source_crsp", "eom", "me", "ret_exc", "ret", "ret_local", "ret_exc_wins"]
     )
     data.select(pl.all().shrink_dtype()).collect().write_parquet(
-        "return_data/world_ret_monthly.parquet"
+        paths.processed_dir / "return_data" / "world_ret_monthly.parquet"
     )
 
 
 @measure_time
-def merge_roll_apply_daily_results():
+def merge_roll_apply_daily_results(paths: DataPaths):
     """
     Description:
         Merge rolling regression daily results into one dataset.
@@ -7989,11 +8088,13 @@ def merge_roll_apply_daily_results():
         col("eom").str.strptime(pl.Date, "%Y-%m-%d").dt.month_end().alias("eom"),
         col("aux_date").cast(pl.Int64),
     )
-    df_id = pl.scan_parquet("id_int_key.parquet")
-    file_paths = sorted(i for i in os.listdir() if i.startswith("__roll"))
+    df_id = pl.scan_parquet(paths.interim_dir / "id_int_key.parquet")
+    file_paths = sorted(
+        p for p in paths.interim_dir.iterdir() if p.is_file() and p.name.startswith("__roll")
+    )
     if not file_paths:
         raise FileNotFoundError(
-            "No '__roll*' parquet files found in current directory; "
+            f"No '__roll*' parquet files found in {paths.interim_dir}; "
             "run roll_apply_daily(...) first."
         )
     joint_file = pl.scan_parquet(file_paths[0])
@@ -8006,12 +8107,12 @@ def merge_roll_apply_daily_results():
         how="left",
         on="aux_date",
     ).join(df_id, how="left", on="id_int").drop(["aux_date", "id_int"]).collect().write_parquet(
-        "roll_apply_daily.parquet"
+        paths.interim_dir / "roll_apply_daily.parquet"
     )
 
 
 @measure_time
-def merge_world_data_prelim():
+def merge_world_data_prelim(paths: DataPaths):
     """
     Description:
         Combine preliminary world data with factor/regression outputs.
@@ -8024,13 +8125,13 @@ def merge_world_data_prelim():
     Output:
         'world_data_-1.parquet' with enriched world dataset.
     """
-    a = pl.scan_parquet("world_data_prelim.parquet")
-    b = pl.scan_parquet("beta_60m.parquet")
-    c = pl.scan_parquet("resmom_ff3_12_1.parquet")
-    d = pl.scan_parquet("resmom_ff3_6_1.parquet")
-    e = pl.scan_parquet("mp_factors.parquet")
-    f = pl.scan_parquet("market_chars_d.parquet")
-    g = pl.scan_parquet("firm_age.parquet").select(["id", "eom", "age"])
+    a = pl.scan_parquet(paths.interim_dir / "world_data_prelim.parquet")
+    b = pl.scan_parquet(paths.interim_dir / "beta_60m.parquet")
+    c = pl.scan_parquet(paths.interim_dir / "resmom_ff3_12_1.parquet")
+    d = pl.scan_parquet(paths.interim_dir / "resmom_ff3_6_1.parquet")
+    e = pl.scan_parquet(paths.interim_dir / "mp_factors.parquet")
+    f = pl.scan_parquet(paths.interim_dir / "market_chars_d.parquet")
+    g = pl.scan_parquet(paths.interim_dir / "firm_age.parquet").select(["id", "eom", "age"])
     world_data = (
         a.join(b, how="left", on=["id", "eom"])
         .join(c, how="left", on=["id", "eom"])
@@ -8039,11 +8140,11 @@ def merge_world_data_prelim():
         .join(f, how="left", on=["id", "eom"])
         .join(g, how="left", on=["id", "eom"])
     )
-    world_data.collect().write_parquet("world_data_-1.parquet")
+    world_data.collect().write_parquet(paths.interim_dir / "world_data_-1.parquet")
 
 
 @measure_time
-def merge_qmj_to_world_data():
+def merge_qmj_to_world_data(paths: DataPaths):
     """
     Description:
         Append QMJ factor to world_data.
@@ -8056,16 +8157,16 @@ def merge_qmj_to_world_data():
     Output:
         'world_data.parquet' with QMJ added.
     """
-    a = pl.scan_parquet("world_data_-1.parquet")
-    b = pl.scan_parquet("qmj.parquet")
+    a = pl.scan_parquet(paths.interim_dir / "world_data_-1.parquet")
+    b = pl.scan_parquet(paths.interim_dir / "qmj.parquet")
     result = (
         a.join(b, how="left", on=["excntry", "id", "eom"]).unique(["id", "eom"]).sort(["id", "eom"])
     )
-    result.collect().write_parquet("world_data.parquet")
+    result.collect().write_parquet(paths.interim_dir / "world_data.parquet")
 
 
 @measure_time
-def merge_industry_to_world_msf():
+def merge_industry_to_world_msf(paths: DataPaths):
     """
     Description:
         Merge industry codes into world MSF dataset.
@@ -8079,9 +8180,9 @@ def merge_industry_to_world_msf():
     Output:
         '__msf_world2.parquet' with industry codes appended.
     """
-    __msf_world = pl.scan_parquet("__msf_world.parquet")
-    comp_ind = pl.scan_parquet("comp_ind.parquet")
-    crsp_ind = pl.scan_parquet("crsp_ind.parquet").rename(
+    __msf_world = pl.scan_parquet(paths.interim_dir / "__msf_world.parquet")
+    comp_ind = pl.scan_parquet(paths.interim_dir / "comp_ind.parquet")
+    crsp_ind = pl.scan_parquet(paths.interim_dir / "crsp_ind.parquet").rename(
         {"sic": "sic_crsp", "naics": "naics_crsp"}
     )
     __msf_world = (
@@ -8098,11 +8199,11 @@ def merge_industry_to_world_msf():
         )
         .drop(["sic_crsp", "naics_crsp"])
     )
-    __msf_world.collect().write_parquet("__msf_world2.parquet")
+    __msf_world.collect().write_parquet(paths.interim_dir / "__msf_world2.parquet")
 
 
 @measure_time
-def roll_apply_daily(stats, sfx, __min):
+def roll_apply_daily(paths: DataPaths, stats, sfx, __min):
     """
     Description:
         Run rolling daily-stat calculations over grouped date windows and save results.
@@ -8118,11 +8219,13 @@ def roll_apply_daily(stats, sfx, __min):
     """
     print(f"Processing {stats} - {sfx.replace('_', '')} - {__min}", flush=True)
     aux_maps = gen_aux_maps(sfx)
-    base_data = prepare_base_data(stat=stats)
+    base_data = prepare_base_data(paths, stat=stats)
     results = pl.concat(
         [process_map_chunks(base_data, mapping, stats, sfx, __min) for mapping in aux_maps]
     )
-    results.collect(engine="streaming").write_parquet(f"__roll{sfx}_{stats}.parquet")
+    results.collect(engine="streaming").write_parquet(
+        paths.interim_dir / f"__roll{sfx}_{stats}.parquet"
+    )
 
 
 def gen_consecutive_lists(input_list, k):
@@ -8220,7 +8323,7 @@ def base_data_filter_exp(stat):
         return (col("ret_exc").is_not_null()) & (col("zero_obs") < 10)
 
 
-def prepare_base_data(stat):
+def prepare_base_data(paths: DataPaths, stat):
     """
     Description:
         Load and minimally prepare base daily dataset for a given stat.
@@ -8234,7 +8337,11 @@ def prepare_base_data(stat):
     Output:
         LazyFrame base_data ready for grouping.
     """
-    base_data_path = "corr_data.parquet" if stat == "mktcorr" else "dsf1.parquet"
+    base_data_path = (
+        paths.interim_dir / "corr_data.parquet"
+        if stat == "mktcorr"
+        else paths.interim_dir / "dsf1.parquet"
+    )
     base_data = (
         pl.scan_parquet(base_data_path)
         .with_columns(aux_date=gen_MMYY_column("eom"))
@@ -8242,7 +8349,9 @@ def prepare_base_data(stat):
     )
 
     if stat == "dimsonbeta":
-        lead_lag = pl.scan_parquet("mkt_lead_lag.parquet").drop(["eom", "mktrf"])
+        lead_lag = pl.scan_parquet(paths.interim_dir / "mkt_lead_lag.parquet").drop(
+            ["eom", "mktrf"]
+        )
         base_data = base_data.join(lead_lag, how="inner", on=["excntry", "date"])
 
     return base_data

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -1576,6 +1576,7 @@ def add_primary_sec(paths: DataPaths, data_path, datevar, file_name):
     prihistusa_path = (raw_data_dfs / "__prihistusa.parquet").as_posix()
     prihistcan_path = (raw_data_dfs / "__prihistcan.parquet").as_posix()
     header_path = (raw_data_dfs / "__header.parquet").as_posix()
+    file_name_posix = Path(file_name).as_posix()
     con.execute(f"""
         CREATE OR REPLACE TABLE __data2 AS
         WITH data AS (
@@ -1641,7 +1642,7 @@ def add_primary_sec(paths: DataPaths, data_path, datevar, file_name):
             SELECT DISTINCT ON (gvkey, iid, {datevar}) *
             FROM __data2
             ORDER BY gvkey, iid, {datevar}, primary_sec DESC
-        ) TO '{file_name}' (FORMAT parquet);
+        ) TO '{file_name_posix}' (FORMAT parquet);
     """)
 
     con.close()
@@ -3073,7 +3074,8 @@ def market_returns(paths: DataPaths, data_path, freq, wins_comp, wins_data_path,
         4) Join NYSE P80 cutoffs and compute me_cap_lag1.
         5) Apply stock filters & compute VW/EW country returns (including capped VW).
         6) If daily, drop low-coverage trading days.
-        7) Sort and write 'market_returns{_daily}.parquet'.
+        7) Sort and write to ``paths.interim_dir / f"market_returns{path_aux}.parquet"``
+           (``path_aux`` is ``""`` for monthly and ``"_daily"`` for daily).
 
     Output:
         Parquet file of country × date market returns.
@@ -6542,6 +6544,8 @@ def ap_factors(
     Output:
         Parquet factor file with columns: [excntry, date/eom, mktrf, hml, smb_ff, inv, roe, smb_hxz].
     """
+    # `paths` is retained for the path-explicit convention but not used here:
+    # all inputs and the output are passed as fully-formed absolute paths.
     date_col = "eom" if freq == "m" else "date"
     sf_cond = (col("ret_lag_dif") == 1) if freq == "m" else (col("ret_lag_dif") <= 5)
     lag_vars = [
@@ -6786,7 +6790,10 @@ def residual_momentum(paths: DataPaths, output_path, data_path, fcts_path, __n, 
         2) Join back ids/dates and keep resff3_{incl}_{skip}; sort.
 
     Output:
-        Parquet '{output_path}_{incl}_{skip}.parquet' with [id, eom, resff3_{incl}_{skip}].
+        Parquet at ``paths.interim_dir / f"{output_path}_{incl}_{skip}.parquet"``
+        with [id, eom, resff3_{incl}_{skip}]. Note: ``output_path`` is used
+        as a *stem*, not a full path — the parameter name is a holdover from
+        the pre-refactor signature.
     """
     con = prep_data_factor_regs(paths, data_path, fcts_path)
     base_data = con.table("__msf2").to_polars().lazy()
@@ -7228,7 +7235,8 @@ def bidask_hl(paths: DataPaths, output_path, data_path, market_returns_daily_pat
     Output:
         '{output_path}' with monthly [id, eom, bidaskhl_21d, rvolhl_21d].
     """
-
+    # `paths` is retained for the path-explicit convention but not used here:
+    # all inputs and the output are passed as fully-formed absolute paths.
     market_returns_daily = pl.scan_parquet(market_returns_daily_path)
     __dsf = (
         pl.scan_parquet(data_path)
@@ -7261,6 +7269,8 @@ def create_world_data_prelim(
     Output:
         '{output_path}' parquet with merged stock, market, and accounting data.
     """
+    # `paths` is retained for the path-explicit convention but not used here:
+    # all inputs and the output are passed as fully-formed absolute paths.
     a = pl.scan_parquet(msf_path)
     b = pl.scan_parquet(market_chars_monthly_path)
     c = pl.scan_parquet(acc_chars_world_path)

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -82,8 +82,6 @@ def setup_folder_structure(paths: DataPaths) -> None:
     Output:
         Folders created on disk (no return value).
     """
-    import shutil
-
     from .paths import get_data_readme_path
 
     paths.interim_dir.mkdir(parents=True, exist_ok=True)
@@ -7922,8 +7920,6 @@ def save_output_files(paths: DataPaths):
     Output:
         Files copied into 'other_output/' directory.
     """
-    import shutil
-
     other_output = paths.processed_dir / "other_output"
     for name in (
         "market_returns.parquet",

--- a/src/jkp/data/main.py
+++ b/src/jkp/data/main.py
@@ -54,102 +54,158 @@ def run_pipeline(*, persistent_connection: bool = False, output_dir: Path) -> No
     """Run the full JKP data generation pipeline."""
     paths = DataPaths(base_dir=output_dir.resolve())
     creds = get_wrds_credentials()
+
+    interim = paths.interim_dir
+
     setup_folder_structure(paths)
     download_raw_data_tables(
+        paths,
         username=creds.username,
         password=creds.password,
         end_date=END_DATE,
         persistent_connection=persistent_connection,
     )
-    gen_raw_data_dfs()
-    prepare_comp_sf("both")
-    prepare_crsp_sf("m")
-    prepare_crsp_sf("d")
-    combine_crsp_comp_sf()
-    crsp_industry()
-    comp_industry()
-    merge_industry_to_world_msf()
-    ff_ind_class("__msf_world2.parquet")
-    nyse_size_cutoffs("__msf_world3.parquet")
-    classify_stocks_size_groups()
-    return_cutoffs("m", 0)
-    return_cutoffs("d", 0)
-    add_ret_exc_wins("m")
-    add_ret_exc_wins("d")
+    gen_raw_data_dfs(paths)
+    prepare_comp_sf(paths, "both")
+    prepare_crsp_sf(paths, "m")
+    prepare_crsp_sf(paths, "d")
+    combine_crsp_comp_sf(paths)
+    crsp_industry(paths)
+    comp_industry(paths)
+    merge_industry_to_world_msf(paths)
+    ff_ind_class(paths, interim / "__msf_world2.parquet")
+    nyse_size_cutoffs(paths, interim / "__msf_world3.parquet")
+    classify_stocks_size_groups(paths)
+    return_cutoffs(paths, "m", 0)
+    return_cutoffs(paths, "d", 0)
+    add_ret_exc_wins(paths, "m")
+    add_ret_exc_wins(paths, "d")
     market_returns(
-        "world_dsf.parquet", "d", 1, "return_cutoffs_daily.parquet", "nyse_cutoffs.parquet"
+        paths,
+        interim / "world_dsf.parquet",
+        "d",
+        1,
+        interim / "return_cutoffs_daily.parquet",
+        interim / "nyse_cutoffs.parquet",
     )
-    market_returns("world_msf.parquet", "m", 1, "return_cutoffs.parquet", "nyse_cutoffs.parquet")
-    standardized_accounting_data("world", 1, "world_msf.parquet", 1, ACCOUNTING_START_DATE)
+    market_returns(
+        paths,
+        interim / "world_msf.parquet",
+        "m",
+        1,
+        interim / "return_cutoffs.parquet",
+        interim / "nyse_cutoffs.parquet",
+    )
+    standardized_accounting_data(
+        paths, "world", 1, interim / "world_msf.parquet", 1, ACCOUNTING_START_DATE
+    )
     create_acc_chars(
-        "acc_std_ann.parquet",
-        "achars_world.parquet",
+        paths,
+        interim / "acc_std_ann.parquet",
+        interim / "achars_world.parquet",
         4,
         18,
         acc_chars_list(),
-        "world_msf.parquet",
+        interim / "world_msf.parquet",
         "",
     )
     create_acc_chars(
-        "acc_std_qtr.parquet",
-        "qchars_world.parquet",
+        paths,
+        interim / "acc_std_qtr.parquet",
+        interim / "qchars_world.parquet",
         4,
         18,
         acc_chars_list(),
-        "world_msf.parquet",
+        interim / "world_msf.parquet",
         "_qitem",
     )
     combine_ann_qtr_chars(
-        "achars_world.parquet", "qchars_world.parquet", acc_chars_list(), "_qitem"
+        paths,
+        interim / "achars_world.parquet",
+        interim / "qchars_world.parquet",
+        acc_chars_list(),
+        "_qitem",
     )
-    market_chars_monthly("world_msf.parquet", "market_returns.parquet")
+    market_chars_monthly(paths, interim / "world_msf.parquet", interim / "market_returns.parquet")
     create_world_data_prelim(
-        "world_msf.parquet",
-        "market_chars_m.parquet",
-        "acc_chars_world.parquet",
-        "world_data_prelim.parquet",
+        paths,
+        interim / "world_msf.parquet",
+        interim / "market_chars_m.parquet",
+        interim / "acc_chars_world.parquet",
+        interim / "world_data_prelim.parquet",
     )
     ap_factors(
-        "ap_factors_daily.parquet",
+        paths,
+        interim / "ap_factors_daily.parquet",
         "d",
-        "world_dsf.parquet",
-        "world_data_prelim.parquet",
-        "market_returns_daily.parquet",
+        interim / "world_dsf.parquet",
+        interim / "world_data_prelim.parquet",
+        interim / "market_returns_daily.parquet",
         10,
         3,
     )
     ap_factors(
-        "ap_factors_monthly.parquet",
+        paths,
+        interim / "ap_factors_monthly.parquet",
         "m",
-        "world_msf.parquet",
-        "world_data_prelim.parquet",
-        "market_returns.parquet",
+        interim / "world_msf.parquet",
+        interim / "world_data_prelim.parquet",
+        interim / "market_returns.parquet",
         10,
         3,
     )
-    firm_age("world_msf.parquet")
-    mispricing_factors("world_data_prelim.parquet", 10, min_fcts=3)
-    market_beta("beta_60m.parquet", "world_msf.parquet", "ap_factors_monthly.parquet", 60, 36)
-    residual_momentum(
-        "resmom_ff3", "world_msf.parquet", "ap_factors_monthly.parquet", 36, 24, 12, 1
+    firm_age(paths, interim / "world_msf.parquet")
+    mispricing_factors(paths, interim / "world_data_prelim.parquet", 10, min_fcts=3)
+    market_beta(
+        paths,
+        interim / "beta_60m.parquet",
+        interim / "world_msf.parquet",
+        interim / "ap_factors_monthly.parquet",
+        60,
+        36,
     )
-    residual_momentum("resmom_ff3", "world_msf.parquet", "ap_factors_monthly.parquet", 36, 24, 6, 1)
-    bidask_hl("corwin_schultz.parquet", "world_dsf.parquet", "market_returns_daily.parquet", 10)
-    prepare_daily("world_dsf.parquet", "ap_factors_daily.parquet")
+    residual_momentum(
+        paths,
+        "resmom_ff3",
+        interim / "world_msf.parquet",
+        interim / "ap_factors_monthly.parquet",
+        36,
+        24,
+        12,
+        1,
+    )
+    residual_momentum(
+        paths,
+        "resmom_ff3",
+        interim / "world_msf.parquet",
+        interim / "ap_factors_monthly.parquet",
+        36,
+        24,
+        6,
+        1,
+    )
+    bidask_hl(
+        paths,
+        interim / "corwin_schultz.parquet",
+        interim / "world_dsf.parquet",
+        interim / "market_returns_daily.parquet",
+        10,
+    )
+    prepare_daily(paths, interim / "world_dsf.parquet", interim / "ap_factors_daily.parquet")
     for sfx, min_obs, vars_ in ROLLING_DAILY_SPECS:
         for var in vars_:
-            roll_apply_daily(var, sfx, min_obs)
-    merge_roll_apply_daily_results()
-    finish_daily_chars("market_chars_d.parquet")
-    merge_world_data_prelim()
-    quality_minus_junk("world_data_-1.parquet", 10)
-    merge_qmj_to_world_data()
-    filter_dsf()
-    filter_msf()
-    filter_world()
+            roll_apply_daily(paths, var, sfx, min_obs)
+    merge_roll_apply_daily_results(paths)
+    finish_daily_chars(paths, interim / "market_chars_d.parquet")
+    merge_world_data_prelim(paths)
+    quality_minus_junk(paths, interim / "world_data_-1.parquet", 10)
+    merge_qmj_to_world_data(paths)
+    filter_dsf(paths)
+    filter_msf(paths)
+    filter_world(paths)
     save_main_data(paths)
-    save_daily_ret()
-    save_monthly_ret()
-    save_accounting_data()
-    save_output_files()
-    save_full_files_and_cleanup(clear_interim=True)
+    save_daily_ret(paths)
+    save_monthly_ret(paths)
+    save_accounting_data(paths)
+    save_output_files(paths)
+    save_full_files_and_cleanup(paths, clear_interim=True)

--- a/tests/README.md
+++ b/tests/README.md
@@ -462,6 +462,26 @@ class TestReturnCalculations:
 
 Fixtures defined in `conftest.py` are available to all tests automatically. Fixtures defined in a test file are only available within that file.
 
+### Testing Pipeline Functions That Take `paths: DataPaths`
+
+Most filesystem-touching functions in `aux_functions.py` take a `paths: DataPaths` instance as their first argument and use it to construct absolute paths for all I/O. To test those functions, request the `test_paths` fixture from `conftest.py`:
+
+```python
+import polars as pl
+
+def test_my_pipeline_function(test_paths):
+    """Pipeline function reads inputs from interim/ and writes its output there."""
+    input_path = test_paths.interim_dir / "input.parquet"
+    pl.DataFrame({"x": [1, 2, 3]}).write_parquet(input_path)
+
+    my_pipeline_function(test_paths, input_path)
+
+    result = pl.read_parquet(test_paths.interim_dir / "output.parquet")
+    assert result.height == 3
+```
+
+`test_paths` is a `DataPaths` instance rooted at `temp_data_dir` (which is itself a per-test `tmp_path` with the pipeline subdirectory layout already created). Use this rather than constructing `DataPaths` manually or relying on `monkeypatch.chdir` — that pattern is being phased out.
+
 ## Troubleshooting
 
 ### "Module not found" errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,13 +225,25 @@ def reset_output_writer(monkeypatch: pytest.MonkeyPatch) -> None:
 def temp_data_dir(tmp_path: Path) -> Generator[Path, None, None]:
     """Provide a temporary directory for test data files.
 
-    Creates the standard subdirectory structure expected by the pipeline.
+    Creates the standard subdirectory structure expected by the pipeline,
+    matching the layout produced by ``DataPaths``.
     """
-    # Create expected subdirectories
-    (tmp_path / "raw_data_dfs").mkdir()
+    (tmp_path / "interim" / "raw_data_dfs").mkdir(parents=True)
     (tmp_path / "raw" / "raw_tables").mkdir(parents=True)
     (tmp_path / "processed" / "characteristics").mkdir(parents=True)
     (tmp_path / "processed" / "return_data").mkdir(parents=True)
     (tmp_path / "processed" / "other_output").mkdir(parents=True)
 
     yield tmp_path
+
+
+@pytest.fixture
+def test_paths(temp_data_dir: Path):
+    """Provide a ``DataPaths`` instance rooted at ``temp_data_dir``.
+
+    Tests that exercise pipeline functions taking a ``paths: DataPaths`` argument
+    should request this fixture and pass it directly.
+    """
+    from jkp.data.paths import DataPaths
+
+    return DataPaths(base_dir=temp_data_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,8 @@ import pytest
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from jkp.data.paths import DataPaths
+
 
 # =============================================================================
 # Pytest Configuration
@@ -238,7 +240,7 @@ def temp_data_dir(tmp_path: Path) -> Generator[Path, None, None]:
 
 
 @pytest.fixture
-def test_paths(temp_data_dir: Path):
+def test_paths(temp_data_dir: Path) -> DataPaths:
     """Provide a ``DataPaths`` instance rooted at ``temp_data_dir``.
 
     Tests that exercise pipeline functions taking a ``paths: DataPaths`` argument

--- a/tests/unit/test_aug_msf_v2.py
+++ b/tests/unit/test_aug_msf_v2.py
@@ -14,6 +14,7 @@ import polars as pl
 import pytest
 
 from jkp.data.aux_functions import aug_msf_v2
+from jkp.data.paths import DataPaths
 
 
 def _write_aug_msf_fixtures(raw_tables: Path) -> None:
@@ -45,52 +46,45 @@ class TestAugMsfV2:
     """Tests for aug_msf_v2()."""
 
     @pytest.fixture(autouse=True)
-    def _setup(
-        self,
-        temp_data_dir: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Set up fixtures and chdir for all tests in this class."""
-        raw_tables = temp_data_dir / "raw" / "raw_tables"
-        self.code_dir = temp_data_dir / "code"
-        self.code_dir.mkdir()
-        (self.code_dir / "raw_data_dfs").mkdir()
-        _write_aug_msf_fixtures(raw_tables)
-        monkeypatch.chdir(self.code_dir)
+    def _setup(self, test_paths: DataPaths) -> None:
+        """Set up fixtures for all tests in this class."""
+        self.paths = test_paths
+        _write_aug_msf_fixtures(test_paths.raw_tables_dir)
+        self.output_path = test_paths.interim_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet"
 
     def test_output_has_askhi_bidlo_columns(self) -> None:
         """aug_msf_v2() output should contain mthaskhi and mthbidlo columns."""
-        aug_msf_v2()
+        aug_msf_v2(self.paths)
 
-        result = pl.read_parquet(self.code_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
+        result = pl.read_parquet(self.output_path)
         assert "mthaskhi" in result.columns
         assert "mthbidlo" in result.columns
 
     def test_askhi_bidlo_values_for_tr_rows(self) -> None:
         """For TR-flagged months, mthaskhi/mthbidlo should reflect daily high/low."""
-        aug_msf_v2()
+        aug_msf_v2(self.paths)
 
-        result = pl.read_parquet(self.code_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
+        result = pl.read_parquet(self.output_path)
         tr_row = result.filter(pl.col("mthprcflg") == "TR")
         assert tr_row["mthaskhi"][0] == 105.0  # max of 95, 105, 100
         assert tr_row["mthbidlo"][0] == 95.0  # min of 95, 105, 100
 
     def test_askhi_bidlo_null_for_non_tr_rows(self) -> None:
         """For non-TR months, mthaskhi/mthbidlo should be null."""
-        aug_msf_v2()
+        aug_msf_v2(self.paths)
 
-        result = pl.read_parquet(self.code_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
+        result = pl.read_parquet(self.output_path)
         ba_row = result.filter(pl.col("mthprcflg") == "BA")
         assert ba_row["mthaskhi"][0] is None
         assert ba_row["mthbidlo"][0] is None
 
     def test_idempotent_on_rerun(self) -> None:
         """Running aug_msf_v2() twice should produce identical output (fix for #56)."""
-        aug_msf_v2()
-        first_run = pl.read_parquet(self.code_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
+        aug_msf_v2(self.paths)
+        first_run = pl.read_parquet(self.output_path)
 
-        aug_msf_v2()
-        second_run = pl.read_parquet(self.code_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
+        aug_msf_v2(self.paths)
+        second_run = pl.read_parquet(self.output_path)
 
         assert first_run.columns == second_run.columns, (
             f"Column mismatch between runs: {first_run.columns} vs {second_run.columns}"
@@ -100,10 +94,10 @@ class TestAugMsfV2:
 
     def test_preserves_original_columns(self) -> None:
         """aug_msf_v2() should preserve all original msf_v2 columns in the output."""
-        original = pl.read_parquet("../raw/raw_tables/crsp_msf_v2.parquet")
+        original = pl.read_parquet(self.paths.raw_tables_dir / "crsp_msf_v2.parquet")
 
-        aug_msf_v2()
+        aug_msf_v2(self.paths)
 
-        result = pl.read_parquet(self.code_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet")
+        result = pl.read_parquet(self.output_path)
         for col_name in original.columns:
             assert col_name in result.columns, f"Original column {col_name!r} missing from output"

--- a/tests/unit/test_aux_functions.py
+++ b/tests/unit/test_aux_functions.py
@@ -75,7 +75,8 @@ def _write_sf_fixture(raw_tables: Path, freq: str) -> tuple[date, date]:
                 "mthbidlo": [9.5, 10.5],
             }
         )
-        raw_data_dfs = raw_tables.parent.parent / "code" / "raw_data_dfs"
+        # raw_tables is paths.raw_tables_dir, so interim is its grandparent + interim.
+        raw_data_dfs = raw_tables.parent.parent / "interim" / "raw_data_dfs"
         raw_data_dfs.mkdir(parents=True, exist_ok=True)
         msf_df.write_parquet(raw_data_dfs / "crsp_msf_v2_aug.parquet")
         return matched_date, unmatched_date
@@ -100,22 +101,14 @@ def _write_sf_fixture(raw_tables: Path, freq: str) -> tuple[date, date]:
 
 
 @pytest.mark.parametrize("freq", ["m", "d"])
-def test_gen_crsp_sf_exposes_ticker_after_senames_join(
-    freq: str,
-    temp_data_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_gen_crsp_sf_exposes_ticker_after_senames_join(freq: str, test_paths) -> None:
     """gen_crsp_sf() should keep ticker in the final output for monthly and daily data."""
-    raw_tables = temp_data_dir / "raw" / "raw_tables"
-    code_dir = temp_data_dir / "code"
-    code_dir.mkdir()
+    raw_tables = test_paths.raw_tables_dir
 
     _write_lookup_tables(raw_tables)
     matched_date, unmatched_date = _write_sf_fixture(raw_tables, freq)
 
-    monkeypatch.chdir(code_dir)
-
-    result = gen_crsp_sf(freq)
+    result = gen_crsp_sf(test_paths, freq)
     assert "ticker" in result.columns, f"Expected ticker in schema, got {result.columns}"
 
     df = result.to_polars().sort("date")
@@ -161,23 +154,13 @@ def _write_aug_msf_v2_fixtures(raw_tables: Path) -> None:
     ).write_parquet(raw_tables / "crsp_dsf_v2.parquet")
 
 
-def test_aug_msf_v2_writes_augmented_file_and_is_idempotent(
-    temp_data_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_aug_msf_v2_writes_augmented_file_and_is_idempotent(test_paths) -> None:
     """aug_msf_v2() should produce the augmented parquet and be safe to re-run."""
-    raw_tables = temp_data_dir / "raw" / "raw_tables"
-    code_dir = temp_data_dir / "code"
-    code_dir.mkdir()
-    (code_dir / "raw_data_dfs").mkdir()
+    _write_aug_msf_v2_fixtures(test_paths.raw_tables_dir)
 
-    _write_aug_msf_v2_fixtures(raw_tables)
+    aug_msf_v2(test_paths)
 
-    monkeypatch.chdir(code_dir)
-
-    aug_msf_v2()
-
-    output_path = code_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet"
+    output_path = test_paths.interim_dir / "raw_data_dfs" / "crsp_msf_v2_aug.parquet"
     assert output_path.exists(), f"Expected augmented file at {output_path}"
 
     schema = pl.scan_parquet(output_path).collect_schema().names()
@@ -185,20 +168,16 @@ def test_aug_msf_v2_writes_augmented_file_and_is_idempotent(
     assert "mthbidlo" in schema, f"Expected mthbidlo column in {schema}"
 
     # Idempotency: a second invocation must not raise.
-    aug_msf_v2()
+    aug_msf_v2(test_paths)
 
 
-def test_merge_roll_apply_daily_results_writes_once_with_deterministic_order(
-    temp_data_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_merge_roll_apply_daily_results_writes_once_with_deterministic_order(test_paths) -> None:
     """merge_roll_apply_daily_results() must produce a single output with deterministic
     column ordering (sorted by source __roll* filename) and be re-run safe."""
-    code_dir = temp_data_dir / "code"
-    code_dir.mkdir(exist_ok=True)
+    interim = test_paths.interim_dir
 
     pl.DataFrame({"id_int": [1, 2], "id": [10001, 10002]}).write_parquet(
-        code_dir / "id_int_key.parquet"
+        interim / "id_int_key.parquet"
     )
 
     # Use the function's hardcoded start index (23113) so this test stays
@@ -214,19 +193,18 @@ def test_merge_roll_apply_daily_results_writes_once_with_deterministic_order(
             "aux_date": [aux_date_val, aux_date_val],
             "rmax": [0.5, 0.6],
         }
-    ).write_parquet(code_dir / "__roll_b_rmax.parquet")
+    ).write_parquet(interim / "__roll_b_rmax.parquet")
     pl.DataFrame(
         {
             "id_int": [1, 2],
             "aux_date": [aux_date_val, aux_date_val],
             "rvol": [0.1, 0.2],
         }
-    ).write_parquet(code_dir / "__roll_a_rvol.parquet")
+    ).write_parquet(interim / "__roll_a_rvol.parquet")
 
-    monkeypatch.chdir(code_dir)
-    merge_roll_apply_daily_results()
+    merge_roll_apply_daily_results(test_paths)
 
-    out = code_dir / "roll_apply_daily.parquet"
+    out = interim / "roll_apply_daily.parquet"
     assert out.exists(), f"Expected output at {out}"
 
     df = pl.read_parquet(out)
@@ -243,12 +221,12 @@ def test_merge_roll_apply_daily_results_writes_once_with_deterministic_order(
     assert set(df["id"].to_list()) == {10001, 10002}
 
     # Re-run must produce identical content (idempotent + single-write safety).
-    merge_roll_apply_daily_results()
+    merge_roll_apply_daily_results(test_paths)
     df2 = pl.read_parquet(out)
     assert df.equals(df2)
 
 
-def test_dsf1_unique_id_int_date(temp_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dsf1_unique_id_int_date(test_paths) -> None:
     """dsf1.parquet (post-prepare_daily) must be unique on (id_int, date).
 
     prc_to_high's within-group sort_by('date').last() is well-defined only under this
@@ -256,10 +234,6 @@ def test_dsf1_unique_id_int_date(temp_data_dir: Path, monkeypatch: pytest.Monkey
     (id, date) (locked by test_no_duplicates_daily); this test locks the property
     after prepare_daily.
     """
-    code_dir = temp_data_dir / "code"
-    code_dir.mkdir(exist_ok=True)
-    monkeypatch.chdir(code_dir)
-
     # Synthetic world_dsf with two ids across three dates each.
     rows = []
     for id_val in [101, 202]:
@@ -281,9 +255,11 @@ def test_dsf1_unique_id_int_date(temp_data_dir: Path, monkeypatch: pytest.Monkey
                     "ret_local": 0.01,
                 }
             )
-    pl.DataFrame(rows).write_parquet(code_dir / "world_dsf.parquet")
+    world_dsf_path = test_paths.interim_dir / "world_dsf.parquet"
+    pl.DataFrame(rows).write_parquet(world_dsf_path)
 
     # Synthetic ap_factors_daily — unique on (excntry, date).
+    ap_factors_path = test_paths.interim_dir / "ap_factors_daily.parquet"
     pl.DataFrame(
         {
             "excntry": ["USA"] * 3,
@@ -295,10 +271,10 @@ def test_dsf1_unique_id_int_date(temp_data_dir: Path, monkeypatch: pytest.Monkey
             "roe": [0.0, 0.0, 0.0],
             "smb_hxz": [0.0, 0.0, 0.0],
         }
-    ).write_parquet(code_dir / "ap_factors_daily.parquet")
+    ).write_parquet(ap_factors_path)
 
-    prepare_daily("world_dsf.parquet", "ap_factors_daily.parquet")
+    prepare_daily(test_paths, world_dsf_path, ap_factors_path)
 
-    dsf1 = pl.read_parquet(code_dir / "dsf1.parquet")
+    dsf1 = pl.read_parquet(test_paths.interim_dir / "dsf1.parquet")
     dup_count = dsf1.select(["id_int", "date"]).is_duplicated().sum()
     assert dup_count == 0, f"dsf1 has {dup_count} duplicate (id_int, date) rows"

--- a/tests/unit/test_combine_crsp_comp_sf.py
+++ b/tests/unit/test_combine_crsp_comp_sf.py
@@ -531,18 +531,28 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
 # ---------------------------------------------------------------------------
 
 
-def _duckdb_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]:
-    """Run the DuckDB implementation and return (monthly_df, daily_df)."""
-    from jkp.data.aux_functions import combine_crsp_comp_sf
+def _make_test_layout(tmp_path: Path) -> Path:
+    """Create the DataPaths layout under tmp_path and return its interim dir."""
+    interim = tmp_path / "interim"
+    interim.mkdir(exist_ok=True)
+    (tmp_path / "raw" / "raw_tables").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "processed").mkdir(exist_ok=True)
+    return interim
 
-    orig_dir = os.getcwd()
-    os.chdir(str(tmp))
-    try:
-        combine_crsp_comp_sf()
-        msf = pl.read_parquet(str(tmp / "__msf_world.parquet"))
-        dsf = pl.read_parquet(str(tmp / "world_dsf.parquet"))
-    finally:
-        os.chdir(orig_dir)
+
+def _duckdb_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Run the DuckDB implementation and return (monthly_df, daily_df).
+
+    ``tmp`` is the interim directory; the function constructs a DataPaths whose
+    base_dir is ``tmp.parent`` (so that ``paths.interim_dir == tmp``).
+    """
+    from jkp.data.aux_functions import combine_crsp_comp_sf
+    from jkp.data.paths import DataPaths
+
+    paths = DataPaths(base_dir=tmp.parent)
+    combine_crsp_comp_sf(paths)
+    msf = pl.read_parquet(str(tmp / "__msf_world.parquet"))
+    dsf = pl.read_parquet(str(tmp / "world_dsf.parquet"))
     return msf, dsf
 
 
@@ -553,10 +563,18 @@ def _duckdb_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
 
 @pytest.fixture(scope="module")
 def toy_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Create HUGE toy datasets once for the whole module."""
-    tmp = tmp_path_factory.mktemp("combine_sf")
-    _write_all_fixtures(tmp)
-    return tmp
+    """Create HUGE toy datasets once for the whole module.
+
+    Returns the *interim* directory (where pipeline fixtures live and where
+    pipeline writes go); the pipeline base directory is ``interim.parent``.
+    """
+    base = tmp_path_factory.mktemp("combine_sf")
+    interim = base / "interim"
+    interim.mkdir()
+    (base / "raw" / "raw_tables").mkdir(parents=True)
+    (base / "processed").mkdir()
+    _write_all_fixtures(interim)
+    return interim
 
 
 @pytest.fixture(scope="module")
@@ -1124,12 +1142,13 @@ class TestDedupDeterminism:
                 "eom": pl.Date,
                 "ret_lag_dif": pl.Int64,
             }
-        ).write_parquet(tmp_path / "comp_msf.parquet")
-        _make_crsp_msf(tmp_path, n_permnos=0)
-        _make_crsp_dsf(tmp_path, n_permnos=1)
-        _make_comp_dsf(tmp_path, n_gvkeys=0)
+        ).write_parquet(_make_test_layout(tmp_path) / "comp_msf.parquet")
+        interim = _make_test_layout(tmp_path)
+        _make_crsp_msf(interim, n_permnos=0)
+        _make_crsp_dsf(interim, n_permnos=1)
+        _make_comp_dsf(interim, n_gvkeys=0)
 
-        msf, _ = _duckdb_combine_crsp_comp_sf(tmp_path)
+        msf, _ = _duckdb_combine_crsp_comp_sf(interim)
         # id construction: '1' || gvkey || iid[0:2] = '1' || '999000' || '07'
         expected_id = 199900007
         survivor = msf.filter((pl.col("id") == expected_id) & (pl.col("eom") == date(2020, 6, 30)))
@@ -1175,12 +1194,13 @@ class TestDedupDeterminism:
                 "datadate": pl.Date,
                 "ret_lag_dif": pl.Int64,
             }
-        ).write_parquet(tmp_path / "comp_dsf.parquet")
-        _make_crsp_msf(tmp_path, n_permnos=1)
-        _make_comp_msf(tmp_path, n_gvkeys=0)
-        _make_crsp_dsf(tmp_path, n_permnos=0)
+        ).write_parquet(_make_test_layout(tmp_path) / "comp_dsf.parquet")
+        interim = _make_test_layout(tmp_path)
+        _make_crsp_msf(interim, n_permnos=1)
+        _make_comp_msf(interim, n_gvkeys=0)
+        _make_crsp_dsf(interim, n_permnos=0)
 
-        _, dsf = _duckdb_combine_crsp_comp_sf(tmp_path)
+        _, dsf = _duckdb_combine_crsp_comp_sf(interim)
         expected_id = 199900007
         survivor = dsf.filter((pl.col("id") == expected_id) & (pl.col("date") == date(2020, 6, 15)))
         assert survivor.height == 1, f"expected single survivor, got {survivor.height}"
@@ -1322,12 +1342,13 @@ class TestEdgeCases:
 
     def test_empty_compustat_files(self, tmp_path: Path) -> None:
         """Pipeline works when comp files have zero rows."""
-        _make_crsp_msf(tmp_path, n_permnos=5)
-        _make_crsp_dsf(tmp_path, n_permnos=5)
+        interim = _make_test_layout(tmp_path)
+        _make_crsp_msf(interim, n_permnos=5)
+        _make_crsp_dsf(interim, n_permnos=5)
         # Create empty comp parquets with correct schema
-        _make_comp_msf(tmp_path, n_gvkeys=0)
-        _make_comp_dsf(tmp_path, n_gvkeys=0)
-        msf, dsf = _duckdb_combine_crsp_comp_sf(tmp_path)
+        _make_comp_msf(interim, n_gvkeys=0)
+        _make_comp_dsf(interim, n_gvkeys=0)
+        msf, dsf = _duckdb_combine_crsp_comp_sf(interim)
         assert msf.height > 0
         assert dsf.height > 0
         assert (msf["source_crsp"] == 1).all()
@@ -1335,11 +1356,12 @@ class TestEdgeCases:
 
     def test_single_row_inputs(self, tmp_path: Path) -> None:
         """Pipeline works with 1-row input files."""
-        _make_crsp_msf(tmp_path, n_permnos=1)
-        _make_comp_msf(tmp_path, n_gvkeys=1)
-        _make_crsp_dsf(tmp_path, n_permnos=1)
-        _make_comp_dsf(tmp_path, n_gvkeys=1)
-        msf, dsf = _duckdb_combine_crsp_comp_sf(tmp_path)
+        interim = _make_test_layout(tmp_path)
+        _make_crsp_msf(interim, n_permnos=1)
+        _make_comp_msf(interim, n_gvkeys=1)
+        _make_crsp_dsf(interim, n_permnos=1)
+        _make_comp_dsf(interim, n_gvkeys=1)
+        msf, dsf = _duckdb_combine_crsp_comp_sf(interim)
         assert msf.height >= 1
         assert dsf.height >= 1
 
@@ -1380,12 +1402,13 @@ class TestEdgeCases:
                 "date": pl.Date,
             }
         )
-        df.write_parquet(tmp_path / "crsp_msf.parquet")
-        _make_comp_msf(tmp_path, n_gvkeys=0)
-        _make_crsp_dsf(tmp_path, n_permnos=1)
-        _make_comp_dsf(tmp_path, n_gvkeys=0)
+        interim = _make_test_layout(tmp_path)
+        df.write_parquet(interim / "crsp_msf.parquet")
+        _make_comp_msf(interim, n_gvkeys=0)
+        _make_crsp_dsf(interim, n_permnos=1)
+        _make_comp_dsf(interim, n_gvkeys=0)
 
-        msf, _ = _duckdb_combine_crsp_comp_sf(tmp_path)
+        msf, _ = _duckdb_combine_crsp_comp_sf(interim)
         eoms = msf.sort("date")["eom"].to_list()
         assert eoms[0] == date(2019, 2, 28)  # Non-leap year
         assert eoms[1] == date(2020, 2, 29)  # Leap year
@@ -1439,10 +1462,11 @@ class TestEdgeCases:
                 "ret_lag_dif": pl.Int64,
             }
         )
-        df.write_parquet(tmp_path / "comp_msf.parquet")
-        _make_crsp_msf(tmp_path, n_permnos=0)
-        _make_crsp_dsf(tmp_path, n_permnos=1)
-        _make_comp_dsf(tmp_path, n_gvkeys=0)
+        interim = _make_test_layout(tmp_path)
+        df.write_parquet(interim / "comp_msf.parquet")
+        _make_crsp_msf(interim, n_permnos=0)
+        _make_crsp_dsf(interim, n_permnos=1)
+        _make_comp_dsf(interim, n_gvkeys=0)
 
-        msf, _ = _duckdb_combine_crsp_comp_sf(tmp_path)
+        msf, _ = _duckdb_combine_crsp_comp_sf(interim)
         assert msf["ret_exc_lead1m"].is_null().all()

--- a/tests/unit/test_combine_crsp_comp_sf.py
+++ b/tests/unit/test_combine_crsp_comp_sf.py
@@ -1130,6 +1130,7 @@ class TestDedupDeterminism:
             "div_cash": None,
             "div_spc": None,
         }
+        interim = _make_test_layout(tmp_path)
         pl.DataFrame([{**base, "primary_sec": 0}, {**base, "primary_sec": 1}]).cast(
             {
                 "gvkey": pl.Utf8,
@@ -1142,8 +1143,7 @@ class TestDedupDeterminism:
                 "eom": pl.Date,
                 "ret_lag_dif": pl.Int64,
             }
-        ).write_parquet(_make_test_layout(tmp_path) / "comp_msf.parquet")
-        interim = _make_test_layout(tmp_path)
+        ).write_parquet(interim / "comp_msf.parquet")
         _make_crsp_msf(interim, n_permnos=0)
         _make_crsp_dsf(interim, n_permnos=1)
         _make_comp_dsf(interim, n_gvkeys=0)
@@ -1184,6 +1184,7 @@ class TestDedupDeterminism:
             "ret_exc": 0.005,
             "ret_lag_dif": 1,
         }
+        interim = _make_test_layout(tmp_path)
         pl.DataFrame([{**base, "primary_sec": 0}, {**base, "primary_sec": 1}]).cast(
             {
                 "gvkey": pl.Utf8,
@@ -1194,8 +1195,7 @@ class TestDedupDeterminism:
                 "datadate": pl.Date,
                 "ret_lag_dif": pl.Int64,
             }
-        ).write_parquet(_make_test_layout(tmp_path) / "comp_dsf.parquet")
-        interim = _make_test_layout(tmp_path)
+        ).write_parquet(interim / "comp_dsf.parquet")
         _make_crsp_msf(interim, n_permnos=1)
         _make_comp_msf(interim, n_gvkeys=0)
         _make_crsp_dsf(interim, n_permnos=0)

--- a/tests/unit/test_comp_hgics.py
+++ b/tests/unit/test_comp_hgics.py
@@ -23,6 +23,7 @@ import pytest
 
 import jkp.data.aux_functions as aux_functions
 from jkp.data.aux_functions import comp_hgics
+from jkp.data.paths import DataPaths
 
 
 def _write_minimal_hgics_fixture(raw_data_dfs: Path) -> None:
@@ -64,7 +65,7 @@ class TestCompHgics:
 
     @pytest.mark.regression
     def test_independent_of_wall_clock(
-        self, temp_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, test_paths: DataPaths, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """comp_hgics output must be identical regardless of `date.today()`.
 
@@ -73,19 +74,19 @@ class TestCompHgics:
         because their patched "today" values differ by 6 years — a difference that
         would show up as ~2,200 extra exploded daily rows per open-ended record.
         """
-        raw_data_dfs = temp_data_dir / "raw_data_dfs"
+        raw_data_dfs = test_paths.interim_dir / "raw_data_dfs"
         _write_minimal_hgics_fixture(raw_data_dfs)
-        monkeypatch.chdir(temp_data_dir)
+        output_path = test_paths.interim_dir / "na_hgics.parquet"
 
         monkeypatch.setattr(aux_functions, "date", _date_subclass_returning(_dt.date(2024, 1, 15)))
-        comp_hgics("national")
-        first = pl.read_parquet(temp_data_dir / "na_hgics.parquet")
+        comp_hgics(test_paths, "national")
+        first = pl.read_parquet(output_path)
 
-        (temp_data_dir / "na_hgics.parquet").unlink()
+        output_path.unlink()
 
         monkeypatch.setattr(aux_functions, "date", _date_subclass_returning(_dt.date(2030, 7, 15)))
-        comp_hgics("national")
-        second = pl.read_parquet(temp_data_dir / "na_hgics.parquet")
+        comp_hgics(test_paths, "national")
+        second = pl.read_parquet(output_path)
 
         assert first.equals(second), (
             "comp_hgics output must not depend on the wall-clock date; "

--- a/tests/unit/test_deterministic_dedup.py
+++ b/tests/unit/test_deterministic_dedup.py
@@ -11,7 +11,6 @@ using economically meaningful tie-breaking rules (issue #69):
 from __future__ import annotations
 
 from datetime import date
-from pathlib import Path
 
 import polars as pl
 import pytest
@@ -22,10 +21,11 @@ class TestAddPrimarySecDedup:
     fan-out produces conflicting classifications."""
 
     @pytest.fixture()
-    def work_dir(self, tmp_path: Path) -> Path:
-        """Set up minimal parquet files for add_primary_sec()."""
-        raw = tmp_path / "raw_data_dfs"
-        raw.mkdir()
+    def setup_paths(self, test_paths):
+        """Set up minimal parquet files for add_primary_sec() under DataPaths layout."""
+        raw_data_dfs = test_paths.interim_dir / "raw_data_dfs"
+        # raw_data_dfs is created by the temp_data_dir fixture; ensure exists.
+        raw_data_dfs.mkdir(parents=True, exist_ok=True)
 
         # Input security file: two securities for one company
         input_df = pl.DataFrame(
@@ -41,7 +41,8 @@ class TestAddPrimarySecDedup:
                 "prc": [10.0, 11.0, 20.0, 21.0],
             }
         )
-        input_df.write_parquet(tmp_path / "input.parquet")
+        input_path = test_paths.interim_dir / "input.parquet"
+        input_df.write_parquet(input_path)
 
         # prihistrow: TWO overlapping ranges for gvkey 001000
         # Range 1 says prihistrow="01", range 2 says prihistrow="02"
@@ -53,7 +54,7 @@ class TestAddPrimarySecDedup:
                 "effdate": [date(2023, 1, 1), date(2024, 1, 1)],
                 "thrudate": [date(2024, 6, 30), date(2024, 12, 31)],
             }
-        ).write_parquet(raw / "__prihistrow.parquet")
+        ).write_parquet(raw_data_dfs / "__prihistrow.parquet")
 
         # prihistusa / prihistcan: empty (no matches)
         for name in ["__prihistusa", "__prihistcan"]:
@@ -64,7 +65,7 @@ class TestAddPrimarySecDedup:
                     "effdate": pl.Series([], dtype=pl.Date),
                     "thrudate": pl.Series([], dtype=pl.Date),
                 }
-            ).write_parquet(raw / f"{name}.parquet")
+            ).write_parquet(raw_data_dfs / f"{name}.parquet")
 
         # header: fallback values (won't matter since prihistrow matches)
         pl.DataFrame(
@@ -74,24 +75,19 @@ class TestAddPrimarySecDedup:
                 "priusa": pl.Series([None], dtype=pl.Utf8),
                 "prican": pl.Series([None], dtype=pl.Utf8),
             }
-        ).write_parquet(raw / "__header.parquet")
+        ).write_parquet(raw_data_dfs / "__header.parquet")
 
-        return tmp_path
+        return test_paths, input_path, test_paths.interim_dir / "output.parquet"
 
-    def test_primary_sec_prefers_one(self, work_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_primary_sec_prefers_one(self, setup_paths) -> None:
         """When overlapping ranges produce both primary_sec=0 and primary_sec=1,
         the output should deterministically keep primary_sec=1."""
-        monkeypatch.chdir(work_dir)
-
         from jkp.data.aux_functions import add_primary_sec
 
-        add_primary_sec(
-            str(work_dir / "input.parquet"),
-            "datadate",
-            str(work_dir / "output.parquet"),
-        )
+        paths, input_path, output_path = setup_paths
+        add_primary_sec(paths, input_path, "datadate", output_path)
 
-        result = pl.read_parquet(work_dir / "output.parquet")
+        result = pl.read_parquet(output_path)
 
         # iid="01" should be primary (matches prihistrow="01" from range 1)
         iid01 = result.filter(pl.col("iid") == "01")
@@ -103,23 +99,16 @@ class TestAddPrimarySecDedup:
         key_counts = result.group_by(["gvkey", "iid", "datadate"]).len()
         assert key_counts["len"].max() == 1, "No duplicate rows should remain"
 
-    def test_non_primary_stays_zero(self, work_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_non_primary_stays_zero(self, setup_paths) -> None:
         """Securities that don't match any prihist record should get primary_sec=0."""
-        monkeypatch.chdir(work_dir)
-
         from jkp.data.aux_functions import add_primary_sec
 
-        add_primary_sec(
-            str(work_dir / "input.parquet"),
-            "datadate",
-            str(work_dir / "output.parquet"),
-        )
+        paths, input_path, output_path = setup_paths
+        add_primary_sec(paths, input_path, "datadate", output_path)
 
-        result = pl.read_parquet(work_dir / "output.parquet")
+        result = pl.read_parquet(output_path)
 
         # iid="02" matches prihistrow="02" from range 2, so it IS primary
-        # But from range 1, prihistrow="01" != "02", so that gives primary_sec=0
-        # The dedup should prefer primary_sec=1
         iid02 = result.filter(pl.col("iid") == "02")
         assert iid02["primary_sec"].to_list() == [1, 1], (
             "iid='02' matches prihistrow='02' from range 2, so primary_sec=1 should win"
@@ -130,11 +119,9 @@ class TestGenReturnsDfDedup:
     """Test that gen_returns_df() keeps the row with the highest prcstd
     when duplicates exist for the same {gvkey, iid, datadate}."""
 
-    def test_keeps_highest_prcstd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_keeps_highest_prcstd(self, test_paths) -> None:
         """When two rows share {gvkey, iid, datadate} but differ in prcstd,
         the row with higher prcstd should survive."""
-        monkeypatch.chdir(tmp_path)
-
         # Build a minimal __comp_msf.parquet with duplicate rows
         df = pl.DataFrame(
             {
@@ -158,11 +145,11 @@ class TestGenReturnsDfDedup:
                 "curcdd": ["USD", "USD", "USD", "USD"],
             }
         )
-        df.write_parquet(tmp_path / "__comp_msf.parquet")
+        df.write_parquet(test_paths.interim_dir / "__comp_msf.parquet")
 
         from jkp.data.aux_functions import gen_returns_df
 
-        result = gen_returns_df("m")
+        result = gen_returns_df(test_paths, "m")
 
         # Should have 3 rows (duplicate resolved)
         assert len(result) == 3, f"Expected 3 rows after dedup, got {len(result)}"
@@ -180,10 +167,8 @@ class TestGenReturnsDfDedup:
             f"got {actual_ret}, expected {expected_ret}"
         )
 
-    def test_no_duplicates_unchanged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_duplicates_unchanged(self, test_paths) -> None:
         """When no duplicates exist, the output should be the same as before."""
-        monkeypatch.chdir(tmp_path)
-
         df = pl.DataFrame(
             {
                 "gvkey": ["001", "001", "001"],
@@ -196,11 +181,11 @@ class TestGenReturnsDfDedup:
                 "curcdd": ["USD", "USD", "USD"],
             }
         )
-        df.write_parquet(tmp_path / "__comp_msf.parquet")
+        df.write_parquet(test_paths.interim_dir / "__comp_msf.parquet")
 
         from jkp.data.aux_functions import gen_returns_df
 
-        result = gen_returns_df("m")
+        result = gen_returns_df(test_paths, "m")
         assert len(result) == 3
 
         feb_ret = result.filter(pl.col("datadate") == date(2024, 2, 29))["ret"][0]

--- a/tests/unit/test_download_and_config.py
+++ b/tests/unit/test_download_and_config.py
@@ -324,8 +324,14 @@ class TestDownloadRawDataTables:
             mock_duckdb.connect.return_value = mock_conn
 
             from jkp.data.aux_functions import download_raw_data_tables
+            from jkp.data.paths import DataPaths
 
-            download_raw_data_tables("user", "pass", end_date=date(2025, 12, 31))
+            download_raw_data_tables(
+                DataPaths(base_dir=Path("/tmp")),
+                "user",
+                "pass",
+                end_date=date(2025, 12, 31),
+            )
             yield mock_download.call_args_list
 
     def test_date_filtered_tables_get_date_column(self, captured_calls):
@@ -411,29 +417,15 @@ class TestSaveMainData:
             f"save_main_data should accept 'paths' parameter, got: {list(sig.parameters)}"
         )
 
-    def _run_save_main_data(self, tmp_path: Path) -> None:
-        """Chdir to tmp_path, run save_main_data, and restore cwd."""
-        import os
-
+    def _run_save_main_data(self, paths) -> None:
+        """Run save_main_data with DuckDB mocked; the parquet read/write is what we test."""
         from jkp.data.aux_functions import save_main_data
-        from jkp.data.paths import DataPaths
 
-        paths = DataPaths(base_dir=tmp_path)
+        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
+            mock_duckdb.connect.return_value = MagicMock()
+            save_main_data(paths)
 
-        original_cwd = os.getcwd()
-        os.chdir(str(tmp_path))
-        try:
-            with (
-                patch("jkp.data.aux_functions.os.chdir"),
-                patch("jkp.data.aux_functions.os.system"),
-                patch("jkp.data.aux_functions.duckdb") as mock_duckdb,
-            ):
-                mock_duckdb.connect.return_value = MagicMock()
-                save_main_data(paths)
-        finally:
-            os.chdir(original_cwd)
-
-    def test_all_rows_pass_through(self, tmp_path):
+    def test_all_rows_pass_through(self, test_paths):
         """save_main_data should not filter — all rows should appear in output."""
         world_data = pl.DataFrame(
             {
@@ -447,13 +439,14 @@ class TestSaveMainData:
                 "excntry": ["USA"] * 4,
             }
         )
-        world_data.write_parquet(tmp_path / "world_data_output.parquet")
-        self._run_save_main_data(tmp_path)
+        out_path = test_paths.interim_dir / "world_data_output.parquet"
+        world_data.write_parquet(out_path)
+        self._run_save_main_data(test_paths)
 
-        output = pl.read_parquet(tmp_path / "world_data_output.parquet")
+        output = pl.read_parquet(out_path)
         assert len(output) == 4, f"Expected all 4 rows (no filtering), got {len(output)}"
 
-    def test_no_eom_date_filter(self, tmp_path):
+    def test_no_eom_date_filter(self, test_paths):
         """All dates should pass through — there should be no eom <= end_date filter."""
         world_data = pl.DataFrame(
             {
@@ -467,13 +460,14 @@ class TestSaveMainData:
                 "excntry": ["USA"] * 2,
             }
         )
-        world_data.write_parquet(tmp_path / "world_data_output.parquet")
-        self._run_save_main_data(tmp_path)
+        out_path = test_paths.interim_dir / "world_data_output.parquet"
+        world_data.write_parquet(out_path)
+        self._run_save_main_data(test_paths)
 
-        output = pl.read_parquet(tmp_path / "world_data_output.parquet")
+        output = pl.read_parquet(out_path)
         assert len(output) == 2, f"Expected both rows (no date filter), got {len(output)}"
 
-    def test_me_lag1_computed(self, tmp_path):
+    def test_me_lag1_computed(self, test_paths):
         """save_main_data should add me_lag1 column with lagged market equity."""
         world_data = pl.DataFrame(
             {
@@ -487,10 +481,11 @@ class TestSaveMainData:
                 "excntry": ["USA"] * 3,
             }
         )
-        world_data.write_parquet(tmp_path / "world_data_output.parquet")
-        self._run_save_main_data(tmp_path)
+        out_path = test_paths.interim_dir / "world_data_output.parquet"
+        world_data.write_parquet(out_path)
+        self._run_save_main_data(test_paths)
 
-        output = pl.read_parquet(tmp_path / "world_data_output.parquet").sort("eom")
+        output = pl.read_parquet(out_path).sort("eom")
         assert "me_lag1" in output.columns, "me_lag1 column should be present"
         assert output["me_lag1"][0] is None or output["me_lag1"][0] != output["me_lag1"][0]
         assert output["me_lag1"][1] == pytest.approx(100.0)
@@ -526,102 +521,79 @@ class TestFilterFunctions:
             }
         )
 
-    def _run_filter(self, tmp_path: Path, func_name: str, source: str, output: str) -> pl.DataFrame:
+    def _run_filter(self, paths, func_name: str, source: str, output: str) -> pl.DataFrame:
         """Write test data, run a filter function, and return the result."""
-        import os
-
         import jkp.data.aux_functions as aux_functions
 
         data = self._make_test_data()
-        data.write_parquet(tmp_path / source)
+        data.write_parquet(paths.interim_dir / source)
 
-        original_cwd = os.getcwd()
-        os.chdir(str(tmp_path))
-        try:
-            getattr(aux_functions, func_name)()
-        finally:
-            os.chdir(original_cwd)
+        getattr(aux_functions, func_name)(paths)
 
-        return pl.read_parquet(tmp_path / output)
+        return pl.read_parquet(paths.interim_dir / output)
 
-    def test_filter_dsf_keeps_only_passing_rows(self, tmp_path):
+    def test_filter_dsf_keeps_only_passing_rows(self, test_paths):
         """filter_dsf should keep only rows where all four filter columns are 1."""
         result = self._run_filter(
-            tmp_path, "filter_dsf", "world_dsf.parquet", "world_dsf_output.parquet"
+            test_paths, "filter_dsf", "world_dsf.parquet", "world_dsf_output.parquet"
         )
         assert len(result) == 1, f"Expected 1 passing row, got {len(result)}"
         assert result["id"][0] == "A"
 
-    def test_filter_msf_keeps_only_passing_rows(self, tmp_path):
+    def test_filter_msf_keeps_only_passing_rows(self, test_paths):
         """filter_msf should keep only rows where all four filter columns are 1."""
         result = self._run_filter(
-            tmp_path, "filter_msf", "world_msf.parquet", "world_msf_output.parquet"
+            test_paths, "filter_msf", "world_msf.parquet", "world_msf_output.parquet"
         )
         assert len(result) == 1, f"Expected 1 passing row, got {len(result)}"
         assert result["id"][0] == "A"
 
-    def test_filter_world_keeps_only_passing_rows(self, tmp_path):
+    def test_filter_world_keeps_only_passing_rows(self, test_paths):
         """filter_world should keep only rows where all four filter columns are 1."""
         result = self._run_filter(
-            tmp_path, "filter_world", "world_data.parquet", "world_data_output.parquet"
+            test_paths, "filter_world", "world_data.parquet", "world_data_output.parquet"
         )
         assert len(result) == 1, f"Expected 1 passing row, got {len(result)}"
         assert result["id"][0] == "A"
 
-    def test_filter_preserves_all_columns(self, tmp_path):
+    def test_filter_preserves_all_columns(self, test_paths):
         """Filtered output should retain all original columns."""
         original_cols = set(self._make_test_data().columns)
         result = self._run_filter(
-            tmp_path, "filter_world", "world_data.parquet", "world_data_output.parquet"
+            test_paths, "filter_world", "world_data.parquet", "world_data_output.parquet"
         )
         assert set(result.columns) == original_cols, (
             f"Column mismatch: expected {original_cols}, got {set(result.columns)}"
         )
 
-    def test_filter_does_not_modify_source(self, tmp_path):
+    def test_filter_does_not_modify_source(self, test_paths):
         """Source file should be unchanged after filtering."""
-        import os
-
         import jkp.data.aux_functions as aux_functions
 
         data = self._make_test_data()
-        data.write_parquet(tmp_path / "world_data.parquet")
+        data.write_parquet(test_paths.interim_dir / "world_data.parquet")
 
-        original_cwd = os.getcwd()
-        os.chdir(str(tmp_path))
-        try:
-            aux_functions.filter_world()
-        finally:
-            os.chdir(original_cwd)
+        aux_functions.filter_world(test_paths)
 
-        source = pl.read_parquet(tmp_path / "world_data.parquet")
+        source = pl.read_parquet(test_paths.interim_dir / "world_data.parquet")
         assert len(source) == 5, f"Source should be unchanged (5 rows), got {len(source)}"
 
-    def test_filter_is_idempotent(self, tmp_path):
+    def test_filter_is_idempotent(self, test_paths):
         """Running filter twice should produce the same result."""
-        import os
-
         import jkp.data.aux_functions as aux_functions
 
         data = self._make_test_data()
-        data.write_parquet(tmp_path / "world_data.parquet")
+        data.write_parquet(test_paths.interim_dir / "world_data.parquet")
 
-        original_cwd = os.getcwd()
-        os.chdir(str(tmp_path))
-        try:
-            aux_functions.filter_world()
-            first_run = pl.read_parquet(tmp_path / "world_data_output.parquet")
-            aux_functions.filter_world()
-            second_run = pl.read_parquet(tmp_path / "world_data_output.parquet")
-        finally:
-            os.chdir(original_cwd)
+        aux_functions.filter_world(test_paths)
+        first_run = pl.read_parquet(test_paths.interim_dir / "world_data_output.parquet")
+        aux_functions.filter_world(test_paths)
+        second_run = pl.read_parquet(test_paths.interim_dir / "world_data_output.parquet")
 
         assert first_run.equals(second_run), "Second run should produce identical output"
 
-    def test_filter_all_pass(self, tmp_path):
+    def test_filter_all_pass(self, test_paths):
         """When all rows pass the filter, all should be retained."""
-        import os
-
         import jkp.data.aux_functions as aux_functions
 
         data = pl.DataFrame(
@@ -637,22 +609,15 @@ class TestFilterFunctions:
                 "excntry": ["USA"] * 2,
             }
         )
-        data.write_parquet(tmp_path / "world_data.parquet")
+        data.write_parquet(test_paths.interim_dir / "world_data.parquet")
 
-        original_cwd = os.getcwd()
-        os.chdir(str(tmp_path))
-        try:
-            aux_functions.filter_world()
-        finally:
-            os.chdir(original_cwd)
+        aux_functions.filter_world(test_paths)
 
-        result = pl.read_parquet(tmp_path / "world_data_output.parquet")
+        result = pl.read_parquet(test_paths.interim_dir / "world_data_output.parquet")
         assert len(result) == 2, f"Expected both rows to pass, got {len(result)}"
 
-    def test_filter_none_pass(self, tmp_path):
+    def test_filter_none_pass(self, test_paths):
         """When no rows pass the filter, output should be empty."""
-        import os
-
         import jkp.data.aux_functions as aux_functions
 
         data = pl.DataFrame(
@@ -668,14 +633,9 @@ class TestFilterFunctions:
                 "excntry": ["USA"],
             }
         )
-        data.write_parquet(tmp_path / "world_data.parquet")
+        data.write_parquet(test_paths.interim_dir / "world_data.parquet")
 
-        original_cwd = os.getcwd()
-        os.chdir(str(tmp_path))
-        try:
-            aux_functions.filter_world()
-        finally:
-            os.chdir(original_cwd)
+        aux_functions.filter_world(test_paths)
 
-        result = pl.read_parquet(tmp_path / "world_data_output.parquet")
+        result = pl.read_parquet(test_paths.interim_dir / "world_data_output.parquet")
         assert len(result) == 0, f"Expected 0 rows, got {len(result)}"

--- a/tests/unit/test_download_and_config.py
+++ b/tests/unit/test_download_and_config.py
@@ -14,7 +14,6 @@ Paper Reference: Jensen, Kelly, Pedersen (2023), "Is There a Replication Crisis 
 from __future__ import annotations
 
 from datetime import date
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import polars as pl
@@ -313,7 +312,7 @@ class TestDownloadRawDataTables:
     """
 
     @pytest.fixture()
-    def captured_calls(self):
+    def captured_calls(self, test_paths):
         """Run download_raw_data_tables and capture all download_wrds_table calls."""
         with (
             patch("jkp.data.aux_functions.gen_wrds_connection_info", return_value="host=test"),
@@ -324,10 +323,9 @@ class TestDownloadRawDataTables:
             mock_duckdb.connect.return_value = mock_conn
 
             from jkp.data.aux_functions import download_raw_data_tables
-            from jkp.data.paths import DataPaths
 
             download_raw_data_tables(
-                DataPaths(base_dir=Path("/tmp")),
+                test_paths,
                 "user",
                 "pass",
                 end_date=date(2025, 12, 31),

--- a/tests/unit/test_ff_ind_class.py
+++ b/tests/unit/test_ff_ind_class.py
@@ -82,67 +82,69 @@ class TestFFIndClass:
     """Tests for ff_ind_class()."""
 
     @pytest.fixture(autouse=True)
-    def _setup_workdir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        """Set working directory to temp path for parquet output."""
-        monkeypatch.chdir(tmp_path)
-        self._tmp = tmp_path
+    def _setup(self, test_paths):
+        """Provide a DataPaths-rooted layout for output."""
+        from jkp.data.paths import DataPaths
+
+        self.paths: DataPaths = test_paths
+        self.output_path = self.paths.interim_dir / "__msf_world3.parquet"
 
     def test_mapped_sic_gets_classification(self):
         """A known SIC code should receive FF classification values."""
         input_df = pl.DataFrame({"sic": [2011], "dummy": [1.0]})
-        input_path = str(self._tmp / "input.parquet")
+        input_path = self.paths.interim_dir / "input.parquet"
         input_df.write_parquet(input_path)
 
-        ff_ind_class(input_path)
+        ff_ind_class(self.paths, input_path)
 
-        result = pl.read_parquet("__msf_world3.parquet")
+        result = pl.read_parquet(self.output_path)
         row = result.row(0, named=True)
         assert row["ff49"] == 2  # Food Products
 
     def test_unmapped_sic_gets_null(self):
         """A SIC code not in any mapping should have null ff49."""
         input_df = pl.DataFrame({"sic": [50], "dummy": [1.0]})
-        input_path = str(self._tmp / "input.parquet")
+        input_path = self.paths.interim_dir / "input.parquet"
         input_df.write_parquet(input_path)
 
-        ff_ind_class(input_path)
+        ff_ind_class(self.paths, input_path)
 
-        result = pl.read_parquet("__msf_world3.parquet")
+        result = pl.read_parquet(self.output_path)
         row = result.row(0, named=True)
         assert row["ff49"] is None
 
     def test_null_sic_gets_null(self):
         """A null SIC should result in null ff49."""
         input_df = pl.DataFrame({"sic": [None]}, schema={"sic": pl.Int64})
-        input_path = str(self._tmp / "input.parquet")
+        input_path = self.paths.interim_dir / "input.parquet"
         input_df.write_parquet(input_path)
 
-        ff_ind_class(input_path)
+        ff_ind_class(self.paths, input_path)
 
-        result = pl.read_parquet("__msf_world3.parquet")
+        result = pl.read_parquet(self.output_path)
         row = result.row(0, named=True)
         assert row["ff49"] is None
 
     def test_preserves_all_input_rows(self):
         """Output should have the same number of rows as input."""
         input_df = pl.DataFrame({"sic": [100, 2011, 50, None, 3714]})
-        input_path = str(self._tmp / "input.parquet")
+        input_path = self.paths.interim_dir / "input.parquet"
         input_df.write_parquet(input_path)
 
-        ff_ind_class(input_path)
+        ff_ind_class(self.paths, input_path)
 
-        result = pl.read_parquet("__msf_world3.parquet")
+        result = pl.read_parquet(self.output_path)
         assert len(result) == len(input_df)
 
     def test_preserves_existing_columns(self):
         """Non-FF columns from input should be retained."""
         input_df = pl.DataFrame({"sic": [2011], "price": [42.5], "ticker": ["ACME"]})
-        input_path = str(self._tmp / "input.parquet")
+        input_path = self.paths.interim_dir / "input.parquet"
         input_df.write_parquet(input_path)
 
-        ff_ind_class(input_path)
+        ff_ind_class(self.paths, input_path)
 
-        result = pl.read_parquet("__msf_world3.parquet")
+        result = pl.read_parquet(self.output_path)
         assert "price" in result.columns
         assert "ticker" in result.columns
         assert result["price"][0] == 42.5

--- a/tests/unit/test_ret_exc_wins.py
+++ b/tests/unit/test_ret_exc_wins.py
@@ -10,7 +10,6 @@ are left unchanged.
 from __future__ import annotations
 
 from datetime import date
-from pathlib import Path
 
 import polars as pl
 import pytest
@@ -19,42 +18,33 @@ from jkp.data.aux_functions import add_ret_exc_wins
 
 
 @pytest.fixture()
-def data_dir(tmp_path, monkeypatch):
-    """Set working directory to tmp_path and return it."""
-    monkeypatch.chdir(tmp_path)
-    return tmp_path
+def data_dir(test_paths):
+    """Provide the paths object's interim directory for fixture writes."""
+    return test_paths
 
 
-def _make_world_msf(path: Path, rows: list[dict]) -> None:
+def _make_world_msf(path, rows: list[dict]) -> None:
     """Write a minimal world_msf parquet with the given rows."""
-    pl.DataFrame(rows).write_parquet(path / "world_msf.parquet")
+    pl.DataFrame(rows).write_parquet(path.interim_dir / "world_msf.parquet")
 
 
-def _make_world_dsf(path: Path, rows: list[dict]) -> None:
+def _make_world_dsf(path, rows: list[dict]) -> None:
     """Write a minimal world_dsf parquet with the given rows."""
-    pl.DataFrame(rows).write_parquet(path / "world_dsf.parquet")
+    pl.DataFrame(rows).write_parquet(path.interim_dir / "world_dsf.parquet")
 
 
-def _make_cutoffs_monthly(path: Path, rows: list[dict]) -> None:
-    """Write a minimal return_cutoffs.parquet with the given rows.
-
-    Each row should have an `eom` and any of the cutoff columns
-    (ret_exc_0_1, ret_exc_1, ret_exc_99, ret_exc_99_9).
-    """
-    pl.DataFrame(rows).write_parquet(path / "return_cutoffs.parquet")
+def _make_cutoffs_monthly(path, rows: list[dict]) -> None:
+    """Write a minimal return_cutoffs.parquet with the given rows."""
+    pl.DataFrame(rows).write_parquet(path.interim_dir / "return_cutoffs.parquet")
 
 
-def _make_cutoffs_daily(path: Path, rows: list[dict]) -> None:
-    """Write a minimal return_cutoffs_daily.parquet with the given rows.
-
-    Each row should have `year`, `month`, and any of the cutoff columns
-    (ret_exc_0_1, ret_exc_1, ret_exc_99, ret_exc_99_9).
-    """
-    pl.DataFrame(rows).write_parquet(path / "return_cutoffs_daily.parquet")
+def _make_cutoffs_daily(path, rows: list[dict]) -> None:
+    """Write a minimal return_cutoffs_daily.parquet with the given rows."""
+    pl.DataFrame(rows).write_parquet(path.interim_dir / "return_cutoffs_daily.parquet")
 
 
-def _read_result(path: Path, freq: str) -> pl.DataFrame:
-    return pl.read_parquet(path / f"world_{freq}sf.parquet")
+def _read_result(path, freq: str) -> pl.DataFrame:
+    return pl.read_parquet(path.interim_dir / f"world_{freq}sf.parquet")
 
 
 class TestAddRetExcWinsMonthly:
@@ -72,7 +62,7 @@ class TestAddRetExcWinsMonthly:
             data_dir,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
 
         result = _read_result(data_dir, "m")
         assert "ret_exc_wins" in result.columns
@@ -90,7 +80,7 @@ class TestAddRetExcWinsMonthly:
             data_dir,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
 
         result = _read_result(data_dir, "m")
         assert result["ret_exc_wins"].to_list() == result["ret_exc"].to_list()
@@ -105,7 +95,7 @@ class TestAddRetExcWinsMonthly:
             data_dir,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.05}],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
 
         result = _read_result(data_dir, "m")
         outlier = result.filter(pl.col("id") == 200001)
@@ -121,7 +111,7 @@ class TestAddRetExcWinsMonthly:
             data_dir,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.05, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
 
         result = _read_result(data_dir, "m")
         outlier = result.filter(pl.col("id") == 200001)
@@ -138,7 +128,7 @@ class TestAddRetExcWinsMonthly:
             data_dir,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
 
         result = _read_result(data_dir, "m")
         null_row = result.filter(pl.col("id") == 100001)
@@ -155,9 +145,9 @@ class TestAddRetExcWinsMonthly:
             data_dir,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
         first = _read_result(data_dir, "m")
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
         second = _read_result(data_dir, "m")
 
         assert first["ret_exc_wins"].to_list() == second["ret_exc_wins"].to_list()
@@ -174,7 +164,7 @@ class TestAddRetExcWinsMonthly:
             data_dir,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.05}],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
 
         result = _read_result(data_dir, "m")
         crsp_row = result.filter(pl.col("source_crsp") == 1)
@@ -198,7 +188,7 @@ class TestAddRetExcWinsMonthly:
                 {"eom": date(2020, 2, 29), "ret_exc_0_1": -0.20, "ret_exc_99_9": 0.15},
             ],
         )
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
 
         result = _read_result(data_dir, "m").sort("eom")
         assert result["ret_exc_wins"].to_list() == pytest.approx([0.05, 0.15])
@@ -223,13 +213,13 @@ class TestAddRetExcWinsMonthly:
         )
 
         # 1% / 99% cutoffs (ret_exc_99 = 0.04)
-        add_ret_exc_wins("m", lower=0.01, upper=0.99)
+        add_ret_exc_wins(data_dir, "m", lower=0.01, upper=0.99)
         wide = _read_result(data_dir, "m")
         assert wide["ret_exc_wins"][0] == pytest.approx(0.04)
 
         # Re-create source data and run with the default 0.1% / 99.9% (ret_exc_99_9 = 0.08)
         _make_world_msf(data_dir, rows)
-        add_ret_exc_wins("m")
+        add_ret_exc_wins(data_dir, "m")
         default = _read_result(data_dir, "m")
         assert default["ret_exc_wins"][0] == pytest.approx(0.08)
 
@@ -260,7 +250,7 @@ class TestAddRetExcWinsDaily:
             data_dir,
             [{"year": 2020, "month": 1, "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins("d")
+        add_ret_exc_wins(data_dir, "d")
 
         result = _read_result(data_dir, "d")
         assert "ret_exc_wins" in result.columns
@@ -284,7 +274,7 @@ class TestAddRetExcWinsDaily:
             data_dir,
             [{"year": 2020, "month": 1, "ret_exc_0_1": -0.05, "ret_exc_99_9": 0.05}],
         )
-        add_ret_exc_wins("d")
+        add_ret_exc_wins(data_dir, "d")
 
         result = _read_result(data_dir, "d")
         outlier = result.filter(pl.col("id") == 200001)
@@ -297,19 +287,19 @@ class TestAddRetExcWinsValidation:
     def test_lower_negative_raises(self, data_dir):
         """A negative lower bound should raise ValueError."""
         with pytest.raises(ValueError, match="0 <= lower < upper <= 1"):
-            add_ret_exc_wins("m", lower=-0.1, upper=0.999)
+            add_ret_exc_wins(data_dir, "m", lower=-0.1, upper=0.999)
 
     def test_upper_above_one_raises(self, data_dir):
         """An upper bound > 1 should raise ValueError."""
         with pytest.raises(ValueError, match="0 <= lower < upper <= 1"):
-            add_ret_exc_wins("m", lower=0.001, upper=1.1)
+            add_ret_exc_wins(data_dir, "m", lower=0.001, upper=1.1)
 
     def test_lower_gte_upper_raises(self, data_dir):
         """lower >= upper should raise ValueError."""
         with pytest.raises(ValueError, match="0 <= lower < upper <= 1"):
-            add_ret_exc_wins("m", lower=0.5, upper=0.4)
+            add_ret_exc_wins(data_dir, "m", lower=0.5, upper=0.4)
 
     def test_unsupported_percentile_raises(self, data_dir):
         """A percentile not in the precomputed cutoffs should raise ValueError."""
         with pytest.raises(ValueError, match="must be one of"):
-            add_ret_exc_wins("m", lower=0.005, upper=0.999)
+            add_ret_exc_wins(data_dir, "m", lower=0.005, upper=0.999)

--- a/tests/unit/test_ret_exc_wins.py
+++ b/tests/unit/test_ret_exc_wins.py
@@ -17,12 +17,6 @@ import pytest
 from jkp.data.aux_functions import add_ret_exc_wins
 
 
-@pytest.fixture()
-def data_dir(test_paths):
-    """Provide the paths object's interim directory for fixture writes."""
-    return test_paths
-
-
 def _make_world_msf(path, rows: list[dict]) -> None:
     """Write a minimal world_msf parquet with the given rows."""
     pl.DataFrame(rows).write_parquet(path.interim_dir / "world_msf.parquet")
@@ -50,129 +44,129 @@ def _read_result(path, freq: str) -> pl.DataFrame:
 class TestAddRetExcWinsMonthly:
     """Tests for monthly frequency."""
 
-    def test_crsp_stocks_unchanged(self, data_dir):
+    def test_crsp_stocks_unchanged(self, test_paths):
         """CRSP stocks (source_crsp == 1) should have ret_exc_wins == ret_exc."""
         rows = [
             {"id": 10001, "source_crsp": 1, "eom": date(2020, 1, 31), "ret_exc": 0.05},
             {"id": 10002, "source_crsp": 1, "eom": date(2020, 1, 31), "ret_exc": -0.03},
             {"id": 10003, "source_crsp": 1, "eom": date(2020, 1, 31), "ret_exc": 99.0},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
 
-        result = _read_result(data_dir, "m")
+        result = _read_result(test_paths, "m")
         assert "ret_exc_wins" in result.columns
         assert result["ret_exc_wins"].to_list() == result["ret_exc"].to_list()
 
-    def test_compustat_normal_unchanged(self, data_dir):
+    def test_compustat_normal_unchanged(self, test_paths):
         """Compustat stocks within bounds should have ret_exc_wins == ret_exc."""
         rows = [
             {"id": 100001, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 0.01},
             {"id": 100002, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 0.02},
             {"id": 100003, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 0.03},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
 
-        result = _read_result(data_dir, "m")
+        result = _read_result(test_paths, "m")
         assert result["ret_exc_wins"].to_list() == result["ret_exc"].to_list()
 
-    def test_compustat_outlier_clipped_high(self, data_dir):
+    def test_compustat_outlier_clipped_high(self, test_paths):
         """Compustat stock above the upper cutoff should be clipped to the cutoff."""
         rows = [
             {"id": 200001, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 99.0},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.05}],
         )
-        add_ret_exc_wins(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
 
-        result = _read_result(data_dir, "m")
+        result = _read_result(test_paths, "m")
         outlier = result.filter(pl.col("id") == 200001)
         assert outlier["ret_exc_wins"][0] == pytest.approx(0.05)
 
-    def test_compustat_outlier_clipped_low(self, data_dir):
+    def test_compustat_outlier_clipped_low(self, test_paths):
         """Compustat stock below the lower cutoff should be clipped to the cutoff."""
         rows = [
             {"id": 200001, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": -99.0},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.05, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
 
-        result = _read_result(data_dir, "m")
+        result = _read_result(test_paths, "m")
         outlier = result.filter(pl.col("id") == 200001)
         assert outlier["ret_exc_wins"][0] == pytest.approx(-0.05)
 
-    def test_null_ret_exc_stays_null(self, data_dir):
+    def test_null_ret_exc_stays_null(self, test_paths):
         """Null ret_exc should produce null ret_exc_wins."""
         rows = [
             {"id": 100001, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": None},
             {"id": 100002, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 0.05},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
 
-        result = _read_result(data_dir, "m")
+        result = _read_result(test_paths, "m")
         null_row = result.filter(pl.col("id") == 100001)
         assert null_row["ret_exc_wins"][0] is None
 
-    def test_idempotent(self, data_dir):
+    def test_idempotent(self, test_paths):
         """Running add_ret_exc_wins twice should produce the same result."""
         rows = [
             {"id": 10001, "source_crsp": 1, "eom": date(2020, 1, 31), "ret_exc": 0.05},
             {"id": 100001, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 0.03},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins(data_dir, "m")
-        first = _read_result(data_dir, "m")
-        add_ret_exc_wins(data_dir, "m")
-        second = _read_result(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
+        first = _read_result(test_paths, "m")
+        add_ret_exc_wins(test_paths, "m")
+        second = _read_result(test_paths, "m")
 
         assert first["ret_exc_wins"].to_list() == second["ret_exc_wins"].to_list()
         assert first.columns == second.columns
 
-    def test_source_crsp_boundary(self, data_dir):
+    def test_source_crsp_boundary(self, test_paths):
         """Two rows with the same out-of-bounds ret_exc: only the Compustat row is clipped."""
         rows = [
             {"id": 10001, "source_crsp": 1, "eom": date(2020, 1, 31), "ret_exc": 99.0},
             {"id": 100001, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 99.0},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [{"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.05}],
         )
-        add_ret_exc_wins(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
 
-        result = _read_result(data_dir, "m")
+        result = _read_result(test_paths, "m")
         crsp_row = result.filter(pl.col("source_crsp") == 1)
         comp_row = result.filter(pl.col("source_crsp") == 0)
         assert crsp_row["ret_exc_wins"][0] == pytest.approx(99.0)
         assert comp_row["ret_exc_wins"][0] == pytest.approx(0.05)
 
-    def test_multiple_eom_periods(self, data_dir):
+    def test_multiple_eom_periods(self, test_paths):
         """Each row uses cutoffs from its own period."""
         rows = [
             # Jan: outlier clipped to Jan's cutoff
@@ -180,27 +174,27 @@ class TestAddRetExcWinsMonthly:
             # Feb: outlier clipped to Feb's (different) cutoff
             {"id": 100001, "source_crsp": 0, "eom": date(2020, 2, 29), "ret_exc": 99.0},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [
                 {"eom": date(2020, 1, 31), "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.05},
                 {"eom": date(2020, 2, 29), "ret_exc_0_1": -0.20, "ret_exc_99_9": 0.15},
             ],
         )
-        add_ret_exc_wins(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m")
 
-        result = _read_result(data_dir, "m").sort("eom")
+        result = _read_result(test_paths, "m").sort("eom")
         assert result["ret_exc_wins"].to_list() == pytest.approx([0.05, 0.15])
 
-    def test_custom_percentiles(self, data_dir):
+    def test_custom_percentiles(self, test_paths):
         """Custom lower/upper arguments should select the corresponding cutoff columns."""
         rows = [
             {"id": 100001, "source_crsp": 0, "eom": date(2020, 1, 31), "ret_exc": 99.0},
         ]
-        _make_world_msf(data_dir, rows)
+        _make_world_msf(test_paths, rows)
         _make_cutoffs_monthly(
-            data_dir,
+            test_paths,
             [
                 {
                     "eom": date(2020, 1, 31),
@@ -213,21 +207,21 @@ class TestAddRetExcWinsMonthly:
         )
 
         # 1% / 99% cutoffs (ret_exc_99 = 0.04)
-        add_ret_exc_wins(data_dir, "m", lower=0.01, upper=0.99)
-        wide = _read_result(data_dir, "m")
+        add_ret_exc_wins(test_paths, "m", lower=0.01, upper=0.99)
+        wide = _read_result(test_paths, "m")
         assert wide["ret_exc_wins"][0] == pytest.approx(0.04)
 
         # Re-create source data and run with the default 0.1% / 99.9% (ret_exc_99_9 = 0.08)
-        _make_world_msf(data_dir, rows)
-        add_ret_exc_wins(data_dir, "m")
-        default = _read_result(data_dir, "m")
+        _make_world_msf(test_paths, rows)
+        add_ret_exc_wins(test_paths, "m")
+        default = _read_result(test_paths, "m")
         assert default["ret_exc_wins"][0] == pytest.approx(0.08)
 
 
 class TestAddRetExcWinsDaily:
     """Tests for daily frequency."""
 
-    def test_crsp_stocks_unchanged(self, data_dir):
+    def test_crsp_stocks_unchanged(self, test_paths):
         """CRSP stocks should have ret_exc_wins == ret_exc for daily data."""
         rows = [
             {
@@ -245,20 +239,20 @@ class TestAddRetExcWinsDaily:
                 "ret_exc": -0.003,
             },
         ]
-        _make_world_dsf(data_dir, rows)
+        _make_world_dsf(test_paths, rows)
         _make_cutoffs_daily(
-            data_dir,
+            test_paths,
             [{"year": 2020, "month": 1, "ret_exc_0_1": -0.10, "ret_exc_99_9": 0.10}],
         )
-        add_ret_exc_wins(data_dir, "d")
+        add_ret_exc_wins(test_paths, "d")
 
-        result = _read_result(data_dir, "d")
+        result = _read_result(test_paths, "d")
         assert "ret_exc_wins" in result.columns
         assert "year" not in result.columns
         assert "month" not in result.columns
         assert result["ret_exc_wins"].to_list() == result["ret_exc"].to_list()
 
-    def test_compustat_outlier_clipped(self, data_dir):
+    def test_compustat_outlier_clipped(self, test_paths):
         """Compustat daily outlier should be clipped to the daily cutoff."""
         rows = [
             {
@@ -269,14 +263,14 @@ class TestAddRetExcWinsDaily:
                 "ret_exc": 99.0,
             },
         ]
-        _make_world_dsf(data_dir, rows)
+        _make_world_dsf(test_paths, rows)
         _make_cutoffs_daily(
-            data_dir,
+            test_paths,
             [{"year": 2020, "month": 1, "ret_exc_0_1": -0.05, "ret_exc_99_9": 0.05}],
         )
-        add_ret_exc_wins(data_dir, "d")
+        add_ret_exc_wins(test_paths, "d")
 
-        result = _read_result(data_dir, "d")
+        result = _read_result(test_paths, "d")
         outlier = result.filter(pl.col("id") == 200001)
         assert outlier["ret_exc_wins"][0] == pytest.approx(0.05)
 
@@ -284,22 +278,22 @@ class TestAddRetExcWinsDaily:
 class TestAddRetExcWinsValidation:
     """Tests for input validation of lower/upper percentile parameters."""
 
-    def test_lower_negative_raises(self, data_dir):
+    def test_lower_negative_raises(self, test_paths):
         """A negative lower bound should raise ValueError."""
         with pytest.raises(ValueError, match="0 <= lower < upper <= 1"):
-            add_ret_exc_wins(data_dir, "m", lower=-0.1, upper=0.999)
+            add_ret_exc_wins(test_paths, "m", lower=-0.1, upper=0.999)
 
-    def test_upper_above_one_raises(self, data_dir):
+    def test_upper_above_one_raises(self, test_paths):
         """An upper bound > 1 should raise ValueError."""
         with pytest.raises(ValueError, match="0 <= lower < upper <= 1"):
-            add_ret_exc_wins(data_dir, "m", lower=0.001, upper=1.1)
+            add_ret_exc_wins(test_paths, "m", lower=0.001, upper=1.1)
 
-    def test_lower_gte_upper_raises(self, data_dir):
+    def test_lower_gte_upper_raises(self, test_paths):
         """lower >= upper should raise ValueError."""
         with pytest.raises(ValueError, match="0 <= lower < upper <= 1"):
-            add_ret_exc_wins(data_dir, "m", lower=0.5, upper=0.4)
+            add_ret_exc_wins(test_paths, "m", lower=0.5, upper=0.4)
 
-    def test_unsupported_percentile_raises(self, data_dir):
+    def test_unsupported_percentile_raises(self, test_paths):
         """A percentile not in the precomputed cutoffs should raise ValueError."""
         with pytest.raises(ValueError, match="must be one of"):
-            add_ret_exc_wins(data_dir, "m", lower=0.005, upper=0.999)
+            add_ret_exc_wins(test_paths, "m", lower=0.005, upper=0.999)

--- a/tests/unit/test_rolling_daily_metrics.py
+++ b/tests/unit/test_rolling_daily_metrics.py
@@ -1618,11 +1618,9 @@ class TestPrepareDailyCorr:
     is present in prepare_daily, guaranteeing null-free corr_data.parquet output.
     """
 
-    def test_corr_data_null_free_and_zero_obs_filtered(self, temp_data_dir, monkeypatch):
+    def test_corr_data_null_free_and_zero_obs_filtered(self, test_paths):
         """corr_data.parquet has zero nulls and no zero_obs column."""
         from jkp.data.aux_functions import prepare_daily
-
-        monkeypatch.chdir(temp_data_dir)
 
         # id "A": 5 consecutive days, all ret_exc non-null → all rows survive.
         # id "B": day1 ret_exc null → 3l-sums on days 1-3 null → those days filtered.
@@ -1678,7 +1676,7 @@ class TestPrepareDailyCorr:
         )
 
         dsf = pl.concat([df_a, df_b, df_c], how="diagonal")
-        dsf_path = str(temp_data_dir / "dsf.parquet")
+        dsf_path = test_paths.interim_dir / "dsf.parquet"
         dsf.write_parquet(dsf_path)
 
         # --- build synthetic factors parquet ---
@@ -1692,12 +1690,12 @@ class TestPrepareDailyCorr:
                 "hml": [0.001] * len(all_dates),
             }
         )
-        fcts_path = str(temp_data_dir / "fcts.parquet")
+        fcts_path = test_paths.interim_dir / "fcts.parquet"
         fcts.write_parquet(fcts_path)
 
-        prepare_daily(dsf_path, fcts_path)
+        prepare_daily(test_paths, dsf_path, fcts_path)
 
-        corr = pl.read_parquet(str(temp_data_dir / "corr_data.parquet"))
+        corr = pl.read_parquet(test_paths.interim_dir / "corr_data.parquet")
 
         # No nulls in ret_exc_3l or mkt_exc_3l
         assert corr["ret_exc_3l"].null_count() == 0, "ret_exc_3l has nulls"

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -77,13 +77,13 @@ class TestDownloadRawDataTablesBranching:
             mock_conn.execute.return_value = mock_result
             yield mock, mock_conn
 
-    def test_persistent_connection_false_uses_postgres_scan(self, mock_duckdb):
+    def test_persistent_connection_false_uses_postgres_scan(self, mock_duckdb, test_paths):
         """When persistent_connection=False, should use postgres_scan()."""
         from jkp.data.aux_functions import download_raw_data_tables
 
         mock, mock_conn = mock_duckdb
 
-        download_raw_data_tables("user", "pass", persistent_connection=False)
+        download_raw_data_tables(test_paths, "user", "pass", persistent_connection=False)
 
         executed_sql = [
             str(c[0][0])
@@ -95,13 +95,13 @@ class TestDownloadRawDataTablesBranching:
         assert "postgres_scan" in sql_joined
         assert "ATTACH" not in sql_joined
 
-    def test_persistent_connection_true_uses_attach(self, mock_duckdb):
+    def test_persistent_connection_true_uses_attach(self, mock_duckdb, test_paths):
         """When persistent_connection=True, should use ATTACH."""
         from jkp.data.aux_functions import download_raw_data_tables
 
         mock, mock_conn = mock_duckdb
 
-        download_raw_data_tables("user", "pass", persistent_connection=True)
+        download_raw_data_tables(test_paths, "user", "pass", persistent_connection=True)
 
         executed_sql = [
             str(c[0][0])
@@ -114,13 +114,13 @@ class TestDownloadRawDataTablesBranching:
         assert "DETACH" in sql_joined
         assert "wrds." in sql_joined
 
-    def test_persistent_connection_true_single_attach(self, mock_duckdb):
+    def test_persistent_connection_true_single_attach(self, mock_duckdb, test_paths):
         """Persistent connection should only ATTACH once for all tables."""
         from jkp.data.aux_functions import download_raw_data_tables
 
         mock, mock_conn = mock_duckdb
 
-        download_raw_data_tables("user", "pass", persistent_connection=True)
+        download_raw_data_tables(test_paths, "user", "pass", persistent_connection=True)
 
         executed_sql = [
             str(c[0][0])
@@ -134,18 +134,18 @@ class TestDownloadRawDataTablesBranching:
         assert attach_count == 1, f"Expected 1 ATTACH, got {attach_count}"
         assert detach_count == 1, f"Expected 1 DETACH, got {detach_count}"
 
-    def test_connection_closed_after_download(self, mock_duckdb):
+    def test_connection_closed_after_download(self, mock_duckdb, test_paths):
         """Connection should be closed after download completes."""
         from jkp.data.aux_functions import download_raw_data_tables
 
         mock, mock_conn = mock_duckdb
 
-        download_raw_data_tables("user", "pass", persistent_connection=False)
+        download_raw_data_tables(test_paths, "user", "pass", persistent_connection=False)
         mock_conn.close.assert_called_once()
 
         mock_conn.reset_mock()
 
-        download_raw_data_tables("user", "pass", persistent_connection=True)
+        download_raw_data_tables(test_paths, "user", "pass", persistent_connection=True)
         mock_conn.close.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

The pipeline previously called `os.chdir` twice — once to anchor writes under `interim_dir`, again to anchor writes under `processed_dir` — and relied on a chain of `os.system("rm -f ...")`, `os.system("cp ...")`, and embedded shell loops anchored to the cwd those chdirs established. Library code shouldn't mutate process-global cwd: it silently breaks callers that depend on cwd, leaves cwd corrupt on exception, and makes the functions un-runnable in parallel.

This PR replaces the cwd-anchored model with explicit, absolute paths derived from the user's output directory at the `run_pipeline` entry point. Both `os.chdir` calls and every `os.system` invocation are removed.

Closes #99.
Closes #100.

## Change Type

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [x] Infrastructure change (CI, config, dependencies)
- [ ] Documentation only
- [ ] Performance-impacting change

## Methodological Impact

None. Calculations are unchanged; only the path-resolution mechanism changes (cwd-anchored relative → explicit absolute).

## Data Impact

No meaningful change. We ran four comparison experiments on Yale HPC to confirm this:

1. **This branch vs main, same WRDS data.** On 2026-05-13 we kicked off two pipeline jobs in parallel — one on this branch (job 684186) and one on main (job 684185). Both jobs downloaded their WRDS data at the same time, so the inputs they got were the same. The outputs differ only by float noise. USA's biggest difference is on `tvol`, around 1.8e-4; the others are smaller. A few countries also have hundreds to a few thousand more (or fewer) null values in `gics` — about 0.05% of rows. The same columns drift every time (`tvol`, `dolvol*`, `zero_trades*`); they all flow from parallel `SUM` aggregations in `gen_secd_data`. The magnitudes are consistent with non-deterministic combine order in parallel float reductions — we haven't proven that's the sole mechanism, but the standalone repeat-run experiment in (2) below shows the noise originates in the engine layer, not in any code change from this PR.

2. **Where that float noise comes from.** A standalone experiment (job 571844) ran `gen_secd_data` twice on the same input file inside a single Slurm job, and the output differed by the same kind of float noise as in (1). That tells us the noise originates in the engine layer (DuckDB / Polars), not in any code change from this PR.

3. **WRDS data isn't stable between downloads.** We ran main a second time (job 684694) nine hours after job 684185, with its own fresh WRDS download. The diff was much larger than the refactor-vs-main diff in (1) — USA `naics` was off by 556,178 on the largest row, GBR `qmj` was off by 0.3. When we diffed the two raw download dumps, WRDS had added 15,586 rows to `comp_secd` and quietly changed values in `comp_secm`. Compustat data gets corrected continuously upstream. The takeaway: any fair comparison has to use the same WRDS snapshot.

4. **What the pipeline does on its own.** Jobs 706519 and 706520 (2026-05-14/15) ran main twice against the same locked raw input — both jobs read from a shared hardlinked snapshot of an earlier WRDS download, so neither one re-fetched anything. Same code, same data, no WRDS drift. The outputs still differ — USA `tvol` by 0.002, GBR `iskew_ff3_21d` by 0.02, `gics` null counts off by hundreds to thousands per country. These differences are the same size or larger than the refactor-vs-main diff in (1). So the pipeline is non-deterministic on its own, and this PR doesn't add anything to that.

A pre-existing wall-clock bug in `comp_hgics` (it was calling `date.today()` to fill open-ended industry record end dates) came up during this work and was fixed separately in #133 (issue #131). Not part of this PR.

For the factor portfolio outputs (`portfolios/`), the same picture holds. This branch matches main as closely as main matches itself between two runs — about 8e-5 on US equal-weighted returns, much smaller for other countries. In some country-months a single stock crosses a percentile threshold differently between any two runs (so `n_stocks` differs by 1); this shows up identically in both the refactor-vs-main comparison and the main-vs-main comparison, so it's pre-existing pipeline behavior rather than a refactor effect.

## Breaking Changes

None for users invoking the public CLI (`jkp build`, `jkp portfolio`, `jkp connect`).

Internal API: every function in `aux_functions.py` that touches the filesystem now takes `paths: DataPaths` as its first parameter. External callers of the underlying functions would need to update; there are no known external callers today.

## Tests

- `tests/conftest.py`: `temp_data_dir` creates the `DataPaths` directory layout (`raw/`, `interim/`, `processed/`). New `test_paths` fixture returns a `DataPaths` instance rooted there.
- 10 test files updated to use `test_paths` instead of monkey-patching cwd: `test_aug_msf_v2.py`, `test_aux_functions.py`, `test_combine_crsp_comp_sf.py`, `test_comp_hgics.py`, `test_deterministic_dedup.py`, `test_download_and_config.py`, `test_ff_ind_class.py`, `test_ret_exc_wins.py`, `test_rolling_daily_metrics.py`, `test_wrds_download.py`.
- All 480 unit tests pass on the rebased branch. (Test count grew during the rebase as PR #140's regression suite and PR #119's golden fixtures landed in main.)
- End-to-end Yale HPC validation: see "Data Impact" above. The earlier run on the original branch (Slurm job 564781) is superseded by the chain there.

## Checklist

- [x] I have run the tests locally (`pytest`)
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [x] I have verified the pipeline runs successfully after my changes — full Yale HPC end-to-end run plus targeted determinism investigation (see "Data Impact" above)
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations — see "Data Impact" above

## Additional Notes

Concrete changes:

- Add `paths: DataPaths` as the first parameter of every `aux_functions.py` function that touches the filesystem (~70 functions). Helper functions called via Polars `.pipe()` keep `paths` first via `functools.partial` so the convention holds uniformly.
- Convert every bare relative path inside those functions to its absolute form, e.g. `pl.scan_parquet("foo.parquet")` → `pl.scan_parquet(paths.interim_dir / "foo.parquet")`. DuckDB SQL strings interpolate `Path.as_posix()` rather than relying on the process cwd.
- Replace `os.system` shell calls with `pathlib`/`shutil` equivalents using absolute paths: `Path.unlink(missing_ok=True)`, `shutil.copy2`, `Path.glob` + `Path.rename` + `shutil.rmtree` for the directory-cleanup loops.
- Replace `os.makedirs("raw_data_dfs", ...)` with `(paths.interim_dir / "raw_data_dfs").mkdir(...)`.
- Update `main.py`'s `run_pipeline` to pass `paths` and absolute path arguments to every aux_functions call.