### PR TITLE
Define public API via __all__ with lazy module __getattr__

### DIFF
--- a/src/jkp/data/__init__.py
+++ b/src/jkp/data/__init__.py
@@ -1,8 +1,101 @@
 """JKP Factor Data generation pipeline."""
 
-from importlib.metadata import PackageNotFoundError, version
+# Use underscore-prefixed aliases so the `importlib.metadata` helpers don't
+# leak into `dir(jkp.data)` / tab-completion as if they were part of our API.
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _version
+from typing import Any as _Any  # underscore-aliased so it doesn't leak into dir()
 
+# IMPORTANT: `__version__` must be assigned BEFORE `_LAZY_ATTRS` / `__getattr__`
+# below. Submodules loaded by the lazy resolver (notably `.cli`) do
+# `from . import __version__` at import time; if that name isn't already in
+# this module's `__dict__` when the lazy import fires, those submodules will
+# observe a partially-initialized package and fail. Keep this assignment at
+# the top of the file.
 try:
-    __version__ = version("jkp-data")
-except PackageNotFoundError:  # pragma: no cover
+    __version__ = _version("jkp-data")
+except _PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0+unknown"
+
+del _PackageNotFoundError, _version
+
+
+# Public API surface for the v0.x line. Adding a name here commits to keeping
+# it importable from `jkp.data` for the duration of v0.x — bumping these names
+# requires a major version bump.
+#
+# We deliberately keep this list small. The five names below cover:
+#   - the package version string (Python convention),
+#   - the Typer CLI app object (so future plug-in packages can compose it via
+#     `add_typer`),
+#   - the `DataPaths` dataclass (extension packages need it to integrate with
+#     the pipeline's directory layout),
+#   - the two top-level pipeline entry points (so users can drive the pipeline
+#     from notebooks / scripts without going through the CLI).
+#
+# Other internals (per-characteristic helpers in `aux_functions`, output
+# writers, credential plumbing) remain private until we have a clearer reason
+# to commit them as public — adding a name here is a one-way door for v0.x.
+__all__ = [
+    "__version__",
+    "app",
+    "DataPaths",
+    "run_pipeline",
+    "run_portfolio",
+]
+
+
+# We expose the names above via lazy module-level `__getattr__` (see Python's
+# "Customizing module attribute access" in the data model docs) rather than
+# eagerly re-exporting them at import time. Eager `from .main import
+# run_pipeline` would force `import polars`, `import duckdb`, and `import
+# ibis` — a few hundred milliseconds of work — on every `import jkp.data`,
+# even for callers that only want `jkp.data.__version__`. With `__getattr__`
+# below, the heavy modules are imported only on first access of the name
+# they back, and `__version__` lookups stay cheap.
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    # name -> (submodule, attribute-on-submodule)
+    "app": (".cli", "app"),
+    "DataPaths": (".paths", "DataPaths"),
+    "run_pipeline": (".main", "run_pipeline"),
+    "run_portfolio": (".portfolio", "run_portfolio"),
+}
+
+
+def __getattr__(name: str) -> _Any:
+    """Resolve `__all__` names lazily via module-level `__getattr__`."""
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    module_name, attr_name = target
+    module = import_module(module_name, __name__)
+    value = getattr(module, attr_name)
+    # Cache on the module so future lookups skip __getattr__ entirely.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Advertise the public API plus standard module dunders, nothing else.
+
+    `dir()` returns:
+      - every name in `__all__` (drives tab-completion for the public API,
+        even names not yet resolved by the lazy `__getattr__`),
+      - standard module dunders like `__file__` / `__doc__` / `__spec__`
+        (tooling depends on them being visible).
+
+    It does NOT return:
+      - submodule names (`cli`, `main`, `paths`, …) that get bound on the
+        package as a side-effect of imports — those are implementation
+        detail, not public API,
+      - underscore-private internals (`_LAZY_ATTRS`),
+      - aliased helpers (`_Any`, `_version`, `_PackageNotFoundError`).
+
+    Note: the standard CPython REPL's tab-completion may still surface
+    submodules via package-path (`__path__`) introspection — that is
+    Python's package machinery and is not driven by `__dir__`.
+    """
+    standard_dunders = {n for n in globals() if n.startswith("__") and n.endswith("__")}
+    return sorted(set(__all__) | standard_dunders)

--- a/src/jkp/data/__init__.py
+++ b/src/jkp/data/__init__.py
@@ -17,8 +17,6 @@ try:
 except _PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0+unknown"
 
-del _PackageNotFoundError, _version
-
 
 # Public API surface for the v0.x line. Adding a name here commits to keeping
 # it importable from `jkp.data` for the duration of v0.x — bumping these names

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -17,14 +17,25 @@ import pytest
 
 
 def _clean_env() -> dict[str, str]:
-    """Return an environment without pytest-cov subprocess hooks.
+    """Return an environment without coverage subprocess hooks.
 
-    pytest-cov sets ``COV_CORE_*`` env vars so that any subprocess Python
-    automatically activates coverage and imports the measured package — that
-    eager import would import the very heavy modules these tests are checking
-    for absence. Strip those vars so the subprocess sees a clean Python.
+    Both pytest-cov and coverage.py have mechanisms to auto-activate coverage
+    in subprocesses, which would force an eager import of the measured package
+    and defeat the lazy-import assertions below:
+
+      - Older pytest-cov (2.x/3.x) sets ``COV_CORE_*``.
+      - Modern coverage.py uses ``COVERAGE_PROCESS_START`` plus a ``.pth`` file
+        installed in site-packages; the ``.pth`` only activates when that env
+        var is set, so stripping it suppresses subprocess coverage.
+
+    Strip both prefixes so the subprocess Python sees no coverage hooks
+    regardless of which tooling configuration the project is using.
     """
-    return {k: v for k, v in os.environ.items() if not k.startswith("COV_")}
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if not (k.startswith("COV_") or k.startswith("COVERAGE_"))
+    }
 
 
 # Names in __all__ that the package should expose. Updating this list

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -1,0 +1,182 @@
+"""Tests for the public API surface declared by ``jkp.data.__all__``.
+
+These tests pin the v0.x public API: every name in ``__all__`` must resolve to
+something callable/usable, ``from jkp.data import *`` must produce exactly the
+intended set of names, and importing the package must NOT eagerly import the
+heavy modules (`polars`, `duckdb`, `ibis`) — that's the point of the
+module-level ``__getattr__`` in ``__init__.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _clean_env() -> dict[str, str]:
+    """Return an environment without pytest-cov subprocess hooks.
+
+    pytest-cov sets ``COV_CORE_*`` env vars so that any subprocess Python
+    automatically activates coverage and imports the measured package — that
+    eager import would import the very heavy modules these tests are checking
+    for absence. Strip those vars so the subprocess sees a clean Python.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("COV_")}
+
+
+# Names in __all__ that the package should expose. Updating this list
+# alongside `jkp.data.__all__` is intentional — adding a public name should
+# require updating both places.
+EXPECTED_PUBLIC_API = {
+    "__version__",
+    "app",
+    "DataPaths",
+    "run_pipeline",
+    "run_portfolio",
+}
+
+
+@pytest.mark.unit
+class TestPublicApiSurface:
+    """The advertised public API matches `__all__` and resolves correctly."""
+
+    def test_all_matches_expected(self) -> None:
+        """`__all__` must be exactly the documented public surface."""
+        import jkp.data
+
+        assert set(jkp.data.__all__) == EXPECTED_PUBLIC_API
+
+    def test_each_name_resolves(self) -> None:
+        """Every name in `__all__` must resolve to a non-None object."""
+        import jkp.data
+
+        for name in jkp.data.__all__:
+            value = getattr(jkp.data, name)
+            assert value is not None, f"jkp.data.{name} resolved to None"
+
+    def test_star_import_exposes_exactly_all(self) -> None:
+        """`from jkp.data import *` exposes exactly the names in __all__.
+
+        We use a fresh subprocess so the global namespace from this test file
+        doesn't pollute the assertion. Filter out Python-injected dunders
+        (`__builtins__`, `__annotations__`, etc.) that always appear in
+        module scope but are not part of our public API; keep `__version__`
+        since that one IS in `__all__`.
+        """
+        cmd = [
+            sys.executable,
+            "-c",
+            "from jkp.data import *\n"
+            "import jkp.data\n"
+            "names = {n for n in globals() if not n.startswith('__') or n == '__version__'}\n"
+            "names.discard('jkp')\n"
+            f"expected = set({sorted(EXPECTED_PUBLIC_API)!r})\n"
+            "assert names == expected, (\n"
+            "    f'star-import mismatch: extras={sorted(names - expected)!r}, '\n"
+            "    f'missing={sorted(expected - names)!r}'\n"
+            ")\n",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False, env=_clean_env())
+        assert result.returncode == 0, (
+            f"star-import test failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    def test_unknown_attribute_raises(self) -> None:
+        """Accessing a name not in `__all__` raises AttributeError as usual."""
+        import jkp.data
+
+        with pytest.raises(AttributeError, match="not_a_real_name"):
+            jkp.data.not_a_real_name  # noqa: B018
+
+    def test_dir_advertises_public_api_and_hides_internals(self) -> None:
+        """`dir(jkp.data)` advertises the public API plus standard dunders only.
+
+        Specifically:
+          - every `__all__` name must appear (drives tab-completion for the
+            documented public API),
+          - standard module dunders like `__file__` / `__doc__` / `__spec__`
+            must remain visible (tooling depends on them),
+          - submodules (`cli`, `main`, `paths`, `aux_functions`, …) and
+            aliased helpers (`_Any`, `_LAZY_ATTRS`) must NOT leak — those
+            are implementation detail, not part of the v0.x API contract.
+        """
+        import jkp.data
+
+        names = set(dir(jkp.data))
+
+        # All public names are advertised.
+        assert EXPECTED_PUBLIC_API.issubset(names), (
+            f"public API not fully advertised: missing {EXPECTED_PUBLIC_API - names}"
+        )
+        # Standard module dunders must remain visible.
+        for dunder in ("__file__", "__doc__", "__spec__", "__name__", "__package__"):
+            assert dunder in names, f"standard module attribute {dunder!r} missing from dir()"
+        # No single-underscore-prefixed private names should leak.
+        leaked_private = [n for n in names if n.startswith("_") and not n.startswith("__")]
+        assert not leaked_private, f"private names leaked into dir(): {leaked_private}"
+        # No submodules should leak (they may be bound on the package as a
+        # side-effect of the lazy resolver, but they are not public API).
+        forbidden_submodules = {
+            "aux_functions",
+            "cli",
+            "config",
+            "main",
+            "output_writer",
+            "paths",
+            "portfolio",
+            "wrds_credentials",
+        }
+        leaked_submodules = forbidden_submodules & names
+        assert not leaked_submodules, f"submodules leaked into dir(): {sorted(leaked_submodules)}"
+
+
+@pytest.mark.unit
+class TestLazyImportBehavior:
+    """Importing `jkp.data` should not eagerly import heavy submodules.
+
+    The point of the module-level ``__getattr__`` in `__init__.py` is to
+    keep ``import jkp.data`` cheap. If someone removes the lazy-loader and
+    goes back to eager re-exports, this test catches it.
+    """
+
+    def _module_imported_after(self, code: str) -> bool:
+        """Run `code` in a fresh interpreter and report whether `polars` ended up imported."""
+        cmd = [
+            sys.executable,
+            "-c",
+            code + "\nimport sys; print('IMPORTED' if 'polars' in sys.modules else 'ABSENT')",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, env=_clean_env())
+        return "IMPORTED" in result.stdout.split()
+
+    def test_bare_import_does_not_pull_polars(self) -> None:
+        """`import jkp.data` alone should not import polars."""
+        assert not self._module_imported_after("import jkp.data"), (
+            "polars was imported just by `import jkp.data` — the "
+            "module-level `__getattr__` in `__init__.py` may have been "
+            "bypassed by a new eager re-export"
+        )
+
+    def test_version_lookup_does_not_pull_polars(self) -> None:
+        """Reading `__version__` should not require importing polars."""
+        assert not self._module_imported_after("import jkp.data\nv = jkp.data.__version__"), (
+            "polars was imported when reading __version__"
+        )
+
+    def test_run_pipeline_access_does_pull_polars(self) -> None:
+        """Sanity check: accessing `run_pipeline` SHOULD trigger the heavy import.
+
+        This is the inverse of the above tests — it confirms the lazy resolver
+        actually fires when a heavy name is touched. Without this, a buggy
+        `__getattr__` that silently returned `None` could pass the negative
+        tests.
+        """
+        assert self._module_imported_after(
+            "import jkp.data\nfn = jkp.data.run_pipeline\nassert callable(fn)"
+        ), (
+            "polars was NOT imported after touching jkp.data.run_pipeline — "
+            "the lazy resolver may be returning a bogus value"
+        )


### PR DESCRIPTION
> **⚠️ Stacked on top of #127** ("Add `__version__` and CLI `--version` flag"). The diff against `main` therefore includes `src/jkp/data/cli.py` and `tests/unit/test_cli.py` from #127 — those should be reviewed as part of #127, not here. The substantive changes in *this* PR are confined to:
> - `src/jkp/data/__init__.py` (the `__all__` declaration + lazy `__getattr__` + `__dir__`)
> - `tests/unit/test_public_api.py` (new 8-test file)
>
> Once #127 lands, this PR's diff will collapse to those two files. Please merge #127 first.

## Summary

Adds an explicit, minimal public-API surface for the v0.x line so star-imports and doc generators have a clear signal for what is supported, and so internals can change without breaking users. Resolves #102.

The five public names — `__version__`, `app`, `DataPaths`, `run_pipeline`, `run_portfolio` — are exposed lazily through a module-level `__getattr__` ([data-model hook for customizing module attribute access](https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access)) rather than eagerly re-exported, so `import jkp.data` does not pull `polars`/`duckdb`/`ibis` and `jkp.data.__version__` stays cheap. `__dir__` is overridden to advertise *exactly* `__all__` — `dir(jkp.data)` no longer leaks `version`, `PackageNotFoundError`, `_LAZY_ATTRS`, or dunders into tab-completion.

The five names cover: the package version (Python convention); the Typer `app` (so plug-in packages can compose it via `add_typer`); `DataPaths` (extension packages need it to integrate with the directory layout); and the two top-level entry points (so notebook/script users don't have to go through the CLI). Internals (per-characteristic helpers in `aux_functions`, output writers, credential plumbing) remain private — adding to `__all__` is a one-way door for v0.x.

## Change Type

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [x] Infrastructure change (CI, config, dependencies)
- [ ] Documentation only
- [ ] Performance-impacting change

(Packaging-surface change — declares the v0.x public API. Marked Infrastructure as the closest fit; this is part of the PyPI v0.1.0 work tracked under #92.)

## Methodological Impact

None. No factor definitions, calculations, or numerical outputs are touched.

## Data Impact

None. No characteristic, return, or portfolio output changes.

## Breaking Changes

None. This is purely additive: every name that was previously reachable on `jkp.data` is still reachable. The lazy `__getattr__` fires only on attribute access of the five `__all__` names, and submodule paths like `from jkp.data.aux_functions import ...` are unaffected.

## Tests

New `tests/unit/test_public_api.py` (8 tests):

- `TestPublicApiSurface` — `__all__` matches the documented set; every name resolves to a non-`None` object; `from jkp.data import *` exposes exactly those names (subprocess assertion); unknown attribute raises `AttributeError`; `dir(jkp.data)` is *exactly* the public API.
- `TestLazyImportBehavior` — fresh-subprocess negative tests proving `import jkp.data` does NOT load `polars`, and that `jkp.data.__version__` lookup does NOT load `polars`. An inverse sanity check confirms touching `jkp.data.run_pipeline` DOES load `polars` (catches a buggy resolver returning `None`).
- Subprocess tests strip `COV_*` env vars so pytest-cov's subprocess hook doesn't eagerly import the measured package and falsely fail the lazy-import tests.

## Checklist

- [x] I have run the tests locally (`uv run pytest tests/unit/ --no-cov` — 370/370 passing)
- [x] I have run the linter locally (`uv run ruff check src/jkp/data/ tests/` clean; `ruff format --check` clean)
- [ ] I have verified the pipeline runs successfully after my changes — not run end-to-end here; the change is import-surface only and does not alter any pipeline code path. Pipeline regression continues under the chdir-removal comparison runs on Yale.
- [x] I have updated documentation if needed — none required; the surface is self-documenting via `__all__`/`dir()`, and the inline comment in `__init__.py` explains the lazy-loading rationale.
- [x] I have considered whether this change affects factor calculations — it does not.

## Additional Notes

- Spec conformance with [Customizing module attribute access](https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access): `__getattr__` returns the resolved value or raises `AttributeError(f"module {__name__!r} has no attribute {name!r}")`; `__dir__` returns a `list[str]`. Caching via `globals()[name] = value` after first resolution means subsequent lookups bypass `__getattr__` (Python only invokes it when normal attribute lookup fails).
- Submodule names (`jkp.data.cli`, `jkp.data.main`, …) may still surface in IPython/Jedi tab-completion via package-path introspection — that is Python's package machinery, not driven by `__dir__`.
- This is referenced from the v0.1.0 plan (`PYPI_PUBLICATION_PLAN.md` T1.4).