### PR TITLE
Move roll_apply_daily window specs into config

### DIFF
--- a/src/jkp/data/config.py
+++ b/src/jkp/data/config.py
@@ -45,3 +45,13 @@ REGIONAL_COUNTRIES_MIN = 3
 # ISO-3 country codes excluded from regional aggregation (extreme
 # inflation / hyperinflation regimes that distort returns).
 REGIONAL_COUNTRY_EXCL = ("ZWE", "VEN")
+
+# (window_suffix, min_obs, variables) triples driving roll_apply_daily.
+# min_obs is the per-group minimum observation count for each window.
+# Variables can repeat across windows (e.g. zero_trades runs at 21d/126d/252d).
+ROLLING_DAILY_SPECS: list[tuple[str, int, list[str]]] = [
+    ("_21d", 15, ["rvol", "rmax", "skew", "capm_ext", "ff3", "hxz4", "dimsonbeta", "zero_trades"]),
+    ("_126d", 60, ["zero_trades", "turnover", "dolvol", "ami"]),
+    ("_252d", 120, ["rvol", "capm", "downbeta", "zero_trades", "prc_to_high", "mktvol"]),
+    ("_1260d", 750, ["mktcorr"]),
+]

--- a/src/jkp/data/main.py
+++ b/src/jkp/data/main.py
@@ -45,7 +45,7 @@ from .aux_functions import (
     setup_folder_structure,
     standardized_accounting_data,
 )
-from .config import ACCOUNTING_START_DATE, END_DATE
+from .config import ACCOUNTING_START_DATE, END_DATE, ROLLING_DAILY_SPECS
 from .paths import DataPaths
 from .wrds_credentials import get_wrds_credentials
 
@@ -136,14 +136,9 @@ def run_pipeline(*, persistent_connection: bool = False, output_dir: Path) -> No
     residual_momentum("resmom_ff3", "world_msf.parquet", "ap_factors_monthly.parquet", 36, 24, 6, 1)
     bidask_hl("corwin_schultz.parquet", "world_dsf.parquet", "market_returns_daily.parquet", 10)
     prepare_daily("world_dsf.parquet", "ap_factors_daily.parquet")
-    for var in ["rvol", "rmax", "skew", "capm_ext", "ff3", "hxz4", "dimsonbeta", "zero_trades"]:
-        roll_apply_daily(var, "_21d", 15)
-    for var in ["zero_trades", "turnover", "dolvol", "ami"]:
-        roll_apply_daily(var, "_126d", 60)
-    for var in ["rvol", "capm", "downbeta", "zero_trades", "prc_to_high", "mktvol"]:
-        roll_apply_daily(var, "_252d", 120)
-    for var in ["mktcorr"]:
-        roll_apply_daily(var, "_1260d", 750)
+    for sfx, min_obs, vars_ in ROLLING_DAILY_SPECS:
+        for var in vars_:
+            roll_apply_daily(var, sfx, min_obs)
     merge_roll_apply_daily_results()
     finish_daily_chars("market_chars_d.parquet")
     merge_world_data_prelim()

--- a/tests/unit/test_download_and_config.py
+++ b/tests/unit/test_download_and_config.py
@@ -31,6 +31,7 @@ from jkp.data.config import (
     REGIONAL_COUNTRY_EXCL,
     REGIONAL_MONTHS_MIN,
     REGIONAL_STOCKS_MIN,
+    ROLLING_DAILY_SPECS,
 )
 
 # =============================================================================
@@ -127,6 +128,38 @@ class TestConfig:
         assert REGIONAL_COUNTRY_EXCL == ("ZWE", "VEN"), (
             f"REGIONAL_COUNTRY_EXCL expected ('ZWE', 'VEN'), got {REGIONAL_COUNTRY_EXCL}"
         )
+
+
+class TestRollingDailySpecs:
+    """Integrity checks for ROLLING_DAILY_SPECS."""
+
+    KNOWN_SUFFIXES = {"_21d", "_126d", "_252d", "_1260d"}
+
+    def test_is_nonempty_list(self):
+        assert isinstance(ROLLING_DAILY_SPECS, list) and ROLLING_DAILY_SPECS
+
+    def test_suffixes_are_known(self):
+        """Every sfx must be in the set gen_aux_maps recognizes natively."""
+        sfxs = [sfx for sfx, _, _ in ROLLING_DAILY_SPECS]
+        unknown = set(sfxs) - self.KNOWN_SUFFIXES
+        assert not unknown, f"Unknown suffixes: {sorted(unknown)}"
+
+    def test_suffixes_are_unique(self):
+        sfxs = [sfx for sfx, _, _ in ROLLING_DAILY_SPECS]
+        assert len(sfxs) == len(set(sfxs)), f"Duplicate suffixes: {sfxs}"
+
+    def test_min_obs_positive_int(self):
+        for sfx, min_obs, _ in ROLLING_DAILY_SPECS:
+            assert isinstance(min_obs, int) and min_obs > 0, (
+                f"{sfx}: min_obs must be positive int, got {min_obs!r}"
+            )
+
+    def test_variables_are_nonempty_str_lists(self):
+        for sfx, _, vars_ in ROLLING_DAILY_SPECS:
+            assert isinstance(vars_, list) and vars_, f"{sfx}: variables list is empty"
+            assert all(isinstance(v, str) and v for v in vars_), (
+                f"{sfx}: variables must be non-empty strings, got {vars_!r}"
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #147

## Simple explanation

This PR cleans up a messy section of run_pipeline.

Previously, the rolling daily metrics were launched through four almost identical loops embedded directly in the orchestrator. Each loop called roll_apply_daily(var, sfx, min_obs) with different window suffixes, minimum-observation thresholds, and variable lists, all hardcoded inline.

The refactor makes two changes:

* A new ROLLING_DAILY_SPECS constant in config.py centralizes the rolling metric definitions as (suffix, min_obs, variables) tuples. Adding a new rolling metric or adjusting thresholds now only requires editing a single configuration entry.
* main.py now uses a single loop that iterates through ROLLING_DAILY_SPECS and calls roll_apply_daily for every (var, sfx, min_obs) combination. The execution order and outputs remain unchanged.

The PR also adds a small TestRollingDailySpecs test suite in tests/unit/test_download_and_config.py to validate the configuration: suffixes must be recognized by gen_aux_maps, suffixes cannot be duplicated, min_obs values must be positive, and variable lists cannot be empty.

## Test plan

- [x] `uv run ruff check src/jkp/data/ tests/`
- [x] `uv run ruff format --check src/jkp/data/ tests/`
- [x] `uv run pytest tests/unit/test_download_and_config.py` — 43 passed (5 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)