### PR TITLE
slurm: set -e so a failed jkp build aborts the job (#182)

### DIFF
--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -9,6 +9,10 @@
 #SBATCH --time=15:00:00
 #SBATCH --mail-type=ALL
 
+# Abort the job if any command fails (e.g. `jkp build`) instead of
+# proceeding to `jkp portfolio` against incomplete data.
+set -e
+
 echo '-------------------------------'
 cd "${SLURM_SUBMIT_DIR}"
 echo "${SLURM_SUBMIT_DIR}"


### PR DESCRIPTION
## Summary

Adds `set -e` to `slurm/submit_job_som_hpc.slurm` so any failed command (e.g. `jkp build`) aborts the job immediately, instead of continuing to `jkp portfolio` against incomplete data.

Without it, a crashed `jkp build` still lets `jkp portfolio` run, which dies with a misleading `FileNotFoundError: data/processed/other_output/nyse_cutoffs.parquet` — the cutoffs file was simply never produced. The secondary error obscures the real failure and wastes the scheduler allocation.

Split out of #171 (PR171) per review — unrelated to the factor-replication work there.

Fixes #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)