### PR TITLE
Fix #184: bake Sortedness suppression into add_ecdf lazy plan

### DIFF
--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -6,7 +6,6 @@ import os
 import re
 import shutil
 import time
-import warnings
 from datetime import date
 from math import exp, sqrt
 from pathlib import Path
@@ -8977,16 +8976,14 @@ def add_ecdf(
 
     # asof-join the ECDF onto every row; rows below any bp value get null,
     # filled with 0.0 to match the convention expected downstream.
-    # Polars emits a Sortedness UserWarning on join_asof with `by` even when
-    # both sides are pre-sorted; suppress locally rather than globally.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=UserWarning, message=r"Sortedness.*by.*provided")
-        res = (
-            df.sort(sort_cols)
-            .join_asof(bp_ecdf, on="var", by=group_cols, strategy="backward")
-            .with_columns(pl.col("cdf").fill_null(0.0))
-        )
-    return res
+    # Both sides are sorted within each `by` group; skip the sortedness check
+    # (Polars can't verify it with `by` and would warn at collect time,
+    # outside any catch_warnings context).
+    return (
+        df.sort(sort_cols)
+        .join_asof(bp_ecdf, on="var", by=group_cols, strategy="backward", check_sortedness=False)
+        .with_columns(pl.col("cdf").fill_null(0.0))
+    )
 
 
 def _build_industry_daily_returns(


### PR DESCRIPTION
Fixes #184

## Simple explanation

Every `jkp portfolio` run floods stderr with the same warning, repeated once per chunked collect:

```
src/jkp/data/aux_functions.py:14414: UserWarning: Sortedness of columns cannot be checked when 'by' groups provided
  collected = pl.collect_all(chunk_ret + chunk_daily)
```

The warning is benign — Polars just can't verify per-`by`-group sort order on an asof join, and both sides are pre-sorted — but it pollutes every log and drowns out signal.

The code already *tried* to suppress it, but the suppression never worked: it wrapped a lazy operation in `warnings.catch_warnings()`, which only covers building the query plan, not running it. The warning fires later, at collect time, outside the wrapper.

This PR replaces the broken wrapper with Polars' own plan-level switch, so the warning is gone no matter where or when the frame is collected. Results are bit-identical; only logging changes.

## Technical details

`add_ecdf` (aux_functions.py:13800) computed its result like this:

```python
with warnings.catch_warnings():
    warnings.filterwarnings("ignore", category=UserWarning, message=r"Sortedness.*by.*provided")
    res = (
        df.sort(sort_cols)
        .join_asof(bp_ecdf, on="var", by=group_cols, strategy="backward")   # LAZY
        .with_columns(pl.col("cdf").fill_null(0.0))
    )
return res
```

`res` is a LazyFrame, so the `with` block exits before anything executes. The Sortedness warning is emitted by the engine at `pl.collect_all(...)` (line 14414) — outside any `catch_warnings` context — so the filter never applies. `warnings.catch_warnings()` is fundamentally the wrong tool for lazy Polars.

The fix bakes the suppression into the plan itself:

```python
return (
    df.sort(sort_cols)
    .join_asof(bp_ecdf, on="var", by=group_cols, strategy="backward", check_sortedness=False)
    .with_columns(pl.col("cdf").fill_null(0.0))
)
```

`check_sortedness=False` travels with the lazy plan, so the check (and its warning) is skipped at every collect. This mirrors the existing usage in `ff_load_world_compustat` (aux_functions.py:12014). Skipping the check is safe here: `df` is sorted by `group_cols + ["var"]` immediately before the join, and `bp_ecdf` is built with the same `.sort(sort_cols)`.

Also:

- Removed the now-unused `import warnings` (this wrapper was its only use).
- Audited `src/jkp/data/` for other lazy `join_asof(by=...)` calls relying on `catch_warnings`: none — the only other one (line 12014) already passes `check_sortedness=False`.

Targets `main`; line numbers in the issue (~13843/14414) come from the `factors_rep` branch — same code sits at 8982/9555 on `main`.

## Test plan

- [x] `PYTHONPATH=src uv run --no-sync python -m pytest tests/unit/portfolio/test_add_ecdf.py -W error::UserWarning` — 10 passed; promoting UserWarning to error proves the Sortedness warning no longer fires through collect
- [x] `PYTHONPATH=src uv run --no-sync python -m pytest tests/unit/` — 917 passed, 1 skipped
- [x] `uv run ruff check src/jkp/data/` — clean
- [x] `uv run ruff format --check src/jkp/data/` — formatted
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
