### PR TITLE
perf: rewrite comp_industry chain in lazy Polars (2.5x, output-identical)

### DIFF
--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -2901,7 +2901,7 @@ def comp_hgics(paths: DataPaths, lib):
         },
     }
     data = pl.scan_parquet(file_paths["raw data"][lib])  # .sort(['gvkey', 'indfrom'])
-    if data.select(pl.len()).collect().item() == 0:
+    if data.limit(1).collect().is_empty():
         warnings.warn(
             f"comp_hgics: {lib} GICS input is empty "
             f"({file_paths['raw data'][lib]}); "

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -2900,8 +2900,8 @@ def comp_hgics(paths: DataPaths, lib):
             "global": paths.interim_dir / "g_hgics.parquet",
         },
     }
-    data = pl.read_parquet(file_paths["raw data"][lib])  # .sort(['gvkey', 'indfrom'])
-    if data.height == 0:
+    data = pl.scan_parquet(file_paths["raw data"][lib])  # .sort(['gvkey', 'indfrom'])
+    if data.select(pl.len()).collect().item() == 0:
         warnings.warn(
             f"comp_hgics: {lib} GICS input is empty "
             f"({file_paths['raw data'][lib]}); "
@@ -2914,12 +2914,7 @@ def comp_hgics(paths: DataPaths, lib):
         n=pl.len().over("gvkey"),
         n_aux=pl.cum_count("gvkey").over("gvkey"),
     )
-    max_indfrom = data[["indfrom"]].max()[0, 0]
-    indthru_date = (
-        pl.lit(max_indfrom)
-        if max_indfrom is not None and max_indfrom > END_DATE
-        else pl.lit(END_DATE)
-    )
+    indthru_date = pl.max_horizontal(pl.col("indfrom").max(), pl.lit(END_DATE))
     c1 = col("n") == col("n_aux")
     c2 = col("indthru").is_null()
     data = (
@@ -2929,7 +2924,7 @@ def comp_hgics(paths: DataPaths, lib):
         .unique(subset=["gvkey", "date"])
         .sort(["gvkey", "date"])
     )
-    data.write_parquet(file_paths["output"][lib])
+    data.sink_parquet(file_paths["output"][lib])
 
 
 def hgics_join(paths: DataPaths):
@@ -2955,7 +2950,7 @@ def hgics_join(paths: DataPaths):
         .unique(["gvkey", "date"])
         .sort(["gvkey", "date"])
     )
-    gjoin.collect().write_parquet(paths.interim_dir / "comp_hgics.parquet")
+    gjoin.sink_parquet(paths.interim_dir / "comp_hgics.parquet")
 
 
 def comp_sic_naics(paths: DataPaths):
@@ -3059,7 +3054,7 @@ def comp_sic_naics(paths: DataPaths):
         .unique(["gvkey", "date"])
         .sort(["gvkey", "date"])
     )
-    comp.collect().write_parquet(paths.interim_dir / "comp_other.parquet")
+    comp.sink_parquet(paths.interim_dir / "comp_other.parquet")
     con.disconnect()
 
 
@@ -3067,78 +3062,54 @@ def comp_sic_naics(paths: DataPaths):
 def comp_industry(paths: DataPaths):
     """
     Description:
-        Merge daily GICS and SIC/NAICS into a single daily Compustat industry file,
-        filling gaps day-by-day to ensure continuity.
+        Merge daily GICS and SIC/NAICS into a single daily Compustat industry file with a
+        continuous daily date axis; days between observations carry null industry codes.
 
     Steps:
-        1) Run comp_sic_naics() and hgics_join(); load into DuckDB.
+        1) Run comp_sic_naics() and hgics_join(); scan both panels lazily.
         2) Full-outer-join on (gvkey,date); compute aux_date = next date − 1 day to detect gaps.
-        3) Build gap ranges via generate_series and fill from gap_dates; union with continuous rows.
-        4) Select distinct first by (gvkey,date); write comp_ind.parquet.
+        3) Emit interior gap days [date+1, aux_date] with null codes (only the gap-start day
+           carries values, matching the historical SQL gap-fill behaviour).
+        4) Concatenate joined rows with gap rows; sort; sink comp_ind.parquet.
 
     Output:
         Parquet comp_ind.parquet with {gvkey,date,gics,sic,naics} daily.
     """
     comp_sic_naics(paths)
     hgics_join(paths)
-    (paths.interim_dir / "aux_comp_ind.ddb").unlink(missing_ok=True)
-    con = ibis.duckdb.connect(str(paths.interim_dir / "aux_comp_ind.ddb"), threads=os.cpu_count())
-    con.create_table("comp_other", con.read_parquet(paths.interim_dir / "comp_other.parquet"))
-    con.create_table("comp_gics", con.read_parquet(paths.interim_dir / "comp_hgics.parquet"))
-    con.raw_sql("""
-                DROP TABLE IF EXISTS join_table;
-                CREATE TABLE join_table AS
-                SELECT          *,
-                                COALESCE( LEAD(date) OVER (PARTITION BY gvkey ORDER BY date) - INTERVAL '1 day', date )::DATE AS aux_date
-                FROM            comp_gics
-                FULL OUTER JOIN comp_other
-                USING           (gvkey, date);
-
-                DROP TABLE IF EXISTS gap_dates;
-                CREATE TABLE gap_dates AS
-                SELECT *
-                FROM join_table
-                WHERE date <> aux_date;
-
-                DROP TABLE IF EXISTS gaps;
-                CREATE TABLE gaps AS
-                WITH full_span AS (
-                SELECT
-                    j.gvkey, gs.gap_date::DATE AS date,
-                    FROM gap_dates as j
-                    CROSS JOIN LATERAL
-                    generate_series(j.date, j.aux_date, INTERVAL '1 day') AS gs(gap_date)
-                    ORDER BY gvkey, date
-                )
-                SELECT
-                fs.gvkey, fs.date, gd.gics, gd.sic, gd.naics
-                FROM full_span fs
-                LEFT JOIN gap_dates gd
-                ON gd.gvkey = fs.gvkey
-                AND gd.date  = fs.date
-                ORDER BY fs.gvkey, fs.date;
-
-                DROP TABLE IF EXISTS continuous;
-                CREATE TABLE continuous AS
-                SELECT *
-                FROM join_table
-                WHERE date = aux_date;
-
-                DROP TABLE IF EXISTS merged_data;
-                CREATE TABLE merged_data AS
-                SELECT gvkey, date, gics, sic, naics FROM continuous
-                UNION
-                SELECT gvkey, date, gics, sic, naics FROM gaps;
-
-                DROP TABLE IF EXISTS comp_industry;
-                CREATE TABLE comp_industry AS
-                SELECT DISTINCT ON (gvkey, date)
-                    *
-                FROM merged_data
-                ORDER BY (gvkey, date);
-    """)
-    con.table("comp_industry").to_parquet(paths.interim_dir / "comp_ind.parquet")
-    con.disconnect()
+    comp_gics = pl.scan_parquet(paths.interim_dir / "comp_hgics.parquet")
+    comp_other = pl.scan_parquet(paths.interim_dir / "comp_other.parquet")
+    joined = (
+        comp_gics.join(comp_other, on=["gvkey", "date"], how="full", coalesce=True)
+        # Null dates (from GICS records with null indfrom) were silently dropped by the
+        # historical SQL: both `WHERE date <> aux_date` and `WHERE date = aux_date`
+        # evaluate to NULL for them, excluding the rows from every output branch.
+        .filter(pl.col("date").is_not_null())
+        .sort(["gvkey", "date"])
+        .with_columns(
+            aux_date=pl.coalesce(
+                pl.col("date").shift(-1).over("gvkey") - pl.duration(days=1),
+                pl.col("date"),
+            )
+        )
+    )
+    schema = joined.collect_schema()
+    # Interior days of each gap get null industry codes: the historical SQL left-joined
+    # gap_dates on the exact date, so only the gap-start day (already present in the
+    # joined panel) carried values.
+    gap_rows = (
+        joined.filter(pl.col("date") != pl.col("aux_date"))
+        .select(
+            "gvkey",
+            pl.date_ranges(pl.col("date") + pl.duration(days=1), "aux_date").alias("date"),
+            *[pl.lit(None, dtype=schema[c]).alias(c) for c in ["gics", "sic", "naics"]],
+        )
+        .explode("date")
+    )
+    out = pl.concat([joined.select(["gvkey", "date", "gics", "sic", "naics"]), gap_rows]).sort(
+        ["gvkey", "date"]
+    )
+    out.sink_parquet(paths.interim_dir / "comp_ind.parquet")
 
 
 def _parse_siccodes_file(filename: str, label: str) -> pl.DataFrame:

--- a/tests/unit/test_comp_industry.py
+++ b/tests/unit/test_comp_industry.py
@@ -2,40 +2,42 @@
 
 ``comp_industry`` merges the daily SIC/NAICS panel (``comp_other``) and the
 daily GICS panel (``comp_hgics``) into a single daily Compustat industry file.
-Its DuckDB SQL does the following, per ``gvkey``:
+It is implemented as a lazy Polars plan (Issue #195) that reproduces the
+semantics of the historical DuckDB SQL, per ``gvkey``:
 
-1. ``FULL OUTER JOIN`` ``comp_gics`` and ``comp_other`` on ``(gvkey, date)``.
-2. ``aux_date = LEAD(date) OVER (PARTITION BY gvkey ORDER BY date) - 1 day``,
-   with ``COALESCE(..., date)`` so the *last* row of each gvkey gets
-   ``aux_date = date``.
-3. Rows with ``date <> aux_date`` are "gap" anchors; ``generate_series(date,
-   aux_date)`` expands them into a contiguous daily axis. The expanded rows are
-   ``LEFT JOIN``-ed back to the anchors on ``(gvkey, date)``, so **only the
-   anchor date keeps its codes — the in-between days carry NULL codes** (the
-   axis is made continuous, but codes are intentionally not forward-filled).
+1. Full outer join of ``comp_gics`` and ``comp_other`` on ``(gvkey, date)``.
+2. ``aux_date`` = next date within the gvkey minus 1 day, falling back to
+   ``date`` itself so the *last* row of each gvkey gets ``aux_date = date``.
+3. Rows with ``date <> aux_date`` are "gap" anchors; the days in
+   ``[date + 1, aux_date]`` are emitted to make the daily axis contiguous, but
+   **only the anchor date keeps its codes — the in-between days carry NULL
+   codes** (codes are intentionally not forward-filled).
 4. Rows with ``date = aux_date`` (the terminal row of every gvkey, plus any
-   single-date gvkey) pass through unchanged via the ``continuous`` branch.
-5. ``continuous`` UNION ``gaps`` → ``SELECT DISTINCT ON (gvkey, date)`` ordered
-   by ``(gvkey, date)``.
+   single-date gvkey) pass through unchanged.
+5. Joined rows and gap rows are concatenated and sorted by ``(gvkey, date)``.
+
+Row-for-row equivalence with the pre-rewrite DuckDB SQL is guarded separately
+by ``tests/unit/test_comp_industry_legacy_equivalence.py``, which runs the
+legacy SQL verbatim against the same inputs.
 
 Coverage here, keyed to the behaviors Issue #155 calls out:
 
 - Gap-fill continuity, including multi-span chaining within one gvkey.
-- Per-gvkey isolation of the ``PARTITION BY`` window (one gvkey's gap range
-  must not bleed into another's rows on the same calendar date).
+- Per-gvkey isolation of the next-date window (one gvkey's gap range must not
+  bleed into another's rows on the same calendar date).
 - Full-outer-join shape when a date is present in only one source.
 - Same-(gvkey, date) coalesce: a date present in *both* sources collapses to a
   single row carrying GICS *and* SIC/NAICS.
-- ``COALESCE(LEAD..., date)`` terminal-row handling for single-date gvkeys
+- Terminal-row (``aux_date`` fallback) handling for single-date gvkeys
   (present in both sources, and present in only one source).
 - Terminal-row preservation for multi-date gvkeys.
 - Dedup to unique ``(gvkey, date)``.
 - Sort by ``(gvkey, date)``.
 - Output schema (column names + dtypes), to catch silent dtype drift.
-- Robust cleanup of the transient ``aux_comp_ind.ddb`` file.
+- A stale ``aux_comp_ind.ddb`` left behind by pre-rewrite runs is ignored.
 - A regression golden fixture locking the output bit-for-bit.
 
-To exercise only ``comp_industry``'s SQL we stub its two upstream sub-calls
+To exercise only ``comp_industry``'s merge logic we stub its two upstream sub-calls
 (``comp_sic_naics``, ``hgics_join``) to no-ops — see
 ``tests.golden.comp_industry_stubs`` — and write ``comp_other.parquet`` /
 ``comp_hgics.parquet`` directly.
@@ -452,17 +454,17 @@ class TestCompIndustry:
         assert_sorted_by_keys(result, "gvkey", "date")
 
     # ------------------------------------------------------------------
-    # Operational: transient DuckDB file
+    # Operational: stale legacy DuckDB file
     # ------------------------------------------------------------------
 
     def test_runs_despite_stale_aux_ddb(self) -> None:
-        """A stale ``aux_comp_ind.ddb`` from a prior run must not break the call.
+        """A stale ``aux_comp_ind.ddb`` from a pre-rewrite run must not break the call.
 
-        The guarantee in the code is the ``unlink(missing_ok=True)`` *before*
-        connecting: a leftover file is removed so a fresh DuckDB database is
-        created cleanly. We plant non-DuckDB bytes at that path and assert the
-        run still succeeds and produces correct output (which it cannot do if
-        the stale file poisoned the new connection).
+        The historical DuckDB implementation persisted its scratch database at
+        this path, so interim directories from older runs may still contain
+        one. The Polars rewrite never opens it: we plant non-DuckDB bytes at
+        that path and assert the run still succeeds, produces correct output,
+        and leaves the file untouched.
         """
         comp_other = _other_frame(["100000"], [date(2020, 1, 1)], [7372], [511210])
         comp_hgics = _gics_frame(["100000"], [date(2020, 1, 1)], [10101010])
@@ -475,17 +477,16 @@ class TestCompIndustry:
 
         result = pl.read_parquet(self.output_path)
         assert result.height == 1, (
-            f"Expected 1 output row after stale-ddb recovery, got {result.height}"
+            f"Expected 1 output row despite a stale ddb file, got {result.height}"
         )
         row = result.row(0, named=True)
         assert (row["sic"], row["naics"], row["gics"]) == (7372, 511210, 10101010), (
             f"Expected codes (7372, 511210, 10101010), "
             f"got {(row['sic'], row['naics'], row['gics'])}"
         )
-        # The stale bytes were replaced by a real DuckDB database.
-        assert self.ddb_path.exists(), "Expected aux_comp_ind.ddb to exist after a successful run"
-        assert self.ddb_path.read_bytes()[:23] != b"not a valid duckdb file", (
-            "Stale DuckDB file was not replaced by a valid database"
+        # The rewrite neither reads nor rewrites the legacy scratch database.
+        assert self.ddb_path.read_bytes() == b"not a valid duckdb file", (
+            "aux_comp_ind.ddb should be ignored by the Polars implementation"
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_comp_industry_legacy_equivalence.py
+++ b/tests/unit/test_comp_industry_legacy_equivalence.py
@@ -1,0 +1,164 @@
+"""Equivalence tests: pure-Polars comp_industry must reproduce the legacy DuckDB output.
+
+comp_industry was rewritten from a disk-backed DuckDB SQL pipeline to lazy Polars
+for speed. These tests run the legacy SQL (verbatim) against the same intermediate
+inputs and assert the new implementation produces identical rows, including the
+null-coded interior gap days the legacy gap-fill emitted.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import duckdb
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from jkp.data.aux_functions import comp_industry
+from jkp.data.paths import DataPaths
+
+# Verbatim SQL from the pre-rewrite comp_industry (only table creation moved to
+# plain duckdb from ibis).
+LEGACY_SQL = """
+            DROP TABLE IF EXISTS join_table;
+            CREATE TABLE join_table AS
+            SELECT          *,
+                            COALESCE( LEAD(date) OVER (PARTITION BY gvkey ORDER BY date) - INTERVAL '1 day', date )::DATE AS aux_date
+            FROM            comp_gics
+            FULL OUTER JOIN comp_other
+            USING           (gvkey, date);
+
+            DROP TABLE IF EXISTS gap_dates;
+            CREATE TABLE gap_dates AS
+            SELECT *
+            FROM join_table
+            WHERE date <> aux_date;
+
+            DROP TABLE IF EXISTS gaps;
+            CREATE TABLE gaps AS
+            WITH full_span AS (
+            SELECT
+                j.gvkey, gs.gap_date::DATE AS date,
+                FROM gap_dates as j
+                CROSS JOIN LATERAL
+                generate_series(j.date, j.aux_date, INTERVAL '1 day') AS gs(gap_date)
+                ORDER BY gvkey, date
+            )
+            SELECT
+            fs.gvkey, fs.date, gd.gics, gd.sic, gd.naics
+            FROM full_span fs
+            LEFT JOIN gap_dates gd
+            ON gd.gvkey = fs.gvkey
+            AND gd.date  = fs.date
+            ORDER BY fs.gvkey, fs.date;
+
+            DROP TABLE IF EXISTS continuous;
+            CREATE TABLE continuous AS
+            SELECT *
+            FROM join_table
+            WHERE date = aux_date;
+
+            DROP TABLE IF EXISTS merged_data;
+            CREATE TABLE merged_data AS
+            SELECT gvkey, date, gics, sic, naics FROM continuous
+            UNION
+            SELECT gvkey, date, gics, sic, naics FROM gaps;
+
+            DROP TABLE IF EXISTS comp_industry;
+            CREATE TABLE comp_industry AS
+            SELECT DISTINCT ON (gvkey, date)
+                *
+            FROM merged_data
+            ORDER BY (gvkey, date);
+"""
+
+
+def _legacy_comp_industry(interim_dir: Path) -> pl.DataFrame:
+    """Run the pre-rewrite DuckDB pipeline on the intermediate parquets."""
+    con = duckdb.connect()
+    try:
+        gics_path = (interim_dir / "comp_hgics.parquet").as_posix()
+        other_path = (interim_dir / "comp_other.parquet").as_posix()
+        con.execute(f"CREATE TABLE comp_gics AS SELECT * FROM read_parquet('{gics_path}')")
+        con.execute(f"CREATE TABLE comp_other AS SELECT * FROM read_parquet('{other_path}')")
+        con.execute(LEGACY_SQL)
+        return con.execute("SELECT * FROM comp_industry").pl()
+    finally:
+        con.close()
+
+
+def _write_raw_fixtures(raw_data_dfs: Path) -> None:
+    """Synthetic GICS histories and SIC/NAICS records exercising the gap-fill paths.
+
+    Covers: multi-interval gvkeys with gaps, open-ended (null indthru) terminal
+    records, gvkeys present in only one source, misaligned gics vs sic dates, and
+    single-record gvkeys. Intervals within each library do not overlap, since
+    overlapping (gvkey, date) keys are resolved nondeterministically (unique
+    keep="any") by both old and new code.
+    """
+    pl.DataFrame(
+        {
+            "gvkey": ["000001", "000001", "000003", "000006"],
+            "indfrom": [date(2020, 1, 1), date(2020, 1, 20), date(2020, 3, 1), None],
+            "indthru": [date(2020, 1, 10), date(2020, 2, 5), None, date(2020, 5, 1)],
+            "gics": [10101010, 20202020, None, 50505050],
+        }
+    ).write_parquet(raw_data_dfs / "comp_hgics_na.parquet")
+    pl.DataFrame(
+        {
+            "gvkey": ["000001", "000004"],
+            "indfrom": [date(2020, 1, 5), date(2020, 2, 10)],
+            "indthru": [date(2020, 1, 8), date(2020, 2, 12)],
+            "gics": [30303030, 40404040],
+        }
+    ).write_parquet(raw_data_dfs / "comp_hgics_gl.parquet")
+    pl.DataFrame(
+        {
+            "gvkey": ["000001", "000001", "000002"],
+            "datadate": [date(2020, 1, 5), date(2020, 1, 25), date(2020, 2, 1)],
+            "sic": [3711, None, 6020],
+            "naics": [336111, 336112, 522110],
+        }
+    ).write_parquet(raw_data_dfs / "sic_naics_na.parquet")
+    pl.DataFrame(
+        {
+            "gvkey": ["000002", "000005"],
+            "datadate": [date(2020, 2, 3), date(2020, 4, 15)],
+            "sic": [6021, 2834],
+            "naics": [522120, 325412],
+        }
+    ).write_parquet(raw_data_dfs / "sic_naics_gl.parquet")
+
+
+@pytest.fixture(scope="module")
+def comp_ind_paths(tmp_path_factory: pytest.TempPathFactory) -> DataPaths:
+    """Write the synthetic raw fixtures and run comp_industry once for the module."""
+    paths = DataPaths(tmp_path_factory.mktemp("comp_ind"))
+    raw_data_dfs = paths.interim_dir / "raw_data_dfs"
+    raw_data_dfs.mkdir(parents=True)
+    _write_raw_fixtures(raw_data_dfs)
+    comp_industry(paths)
+    return paths
+
+
+@pytest.mark.unit
+class TestCompIndustryEquivalence:
+    """comp_industry rewrite must match the legacy DuckDB SQL row-for-row."""
+
+    def test_matches_legacy_duckdb_output(self, comp_ind_paths: DataPaths) -> None:
+        new = pl.read_parquet(comp_ind_paths.interim_dir / "comp_ind.parquet")
+        legacy = _legacy_comp_industry(comp_ind_paths.interim_dir)
+
+        sort_cols = ["gvkey", "date"]
+        assert_frame_equal(
+            new.sort(sort_cols).select(legacy.columns),
+            legacy.sort(sort_cols),
+            check_dtypes=False,
+        )
+
+    def test_no_duplicate_keys(self, comp_ind_paths: DataPaths) -> None:
+        """DISTINCT ON in the legacy SQL was a no-op; the rewrite must not introduce dups."""
+        new = pl.read_parquet(comp_ind_paths.interim_dir / "comp_ind.parquet")
+        assert new.height == new.unique(["gvkey", "date"]).height

--- a/tests/unit/test_comp_industry_legacy_equivalence.py
+++ b/tests/unit/test_comp_industry_legacy_equivalence.py
@@ -93,17 +93,38 @@ def _write_raw_fixtures(raw_data_dfs: Path) -> None:
     """Synthetic GICS histories and SIC/NAICS records exercising the gap-fill paths.
 
     Covers: multi-interval gvkeys with gaps, open-ended (null indthru) terminal
-    records, gvkeys present in only one source, misaligned gics vs sic dates, and
-    single-record gvkeys. Intervals within each library do not overlap, since
-    overlapping (gvkey, date) keys are resolved nondeterministically (unique
-    keep="any") by both old and new code.
+    records, gvkeys present in only one source, misaligned gics vs sic dates,
+    single-record gvkeys, and a gvkey mixing a null-indfrom record with
+    real-dated records (000007). The mixed gvkey pins the null-date handling:
+    the rewrite filters null dates *before* computing aux_date, while the
+    legacy SQL ran LEAD() over the unfiltered partition (nulls last) and only
+    dropped the rows afterwards — equivalent, but easy to break in a refactor.
+    Intervals within each library do not overlap, since overlapping
+    (gvkey, date) keys are resolved nondeterministically (unique keep="any")
+    by both old and new code.
     """
     pl.DataFrame(
         {
-            "gvkey": ["000001", "000001", "000003", "000006"],
-            "indfrom": [date(2020, 1, 1), date(2020, 1, 20), date(2020, 3, 1), None],
-            "indthru": [date(2020, 1, 10), date(2020, 2, 5), None, date(2020, 5, 1)],
-            "gics": [10101010, 20202020, None, 50505050],
+            "gvkey": ["000001", "000001", "000003", "000006", "000007", "000007", "000007"],
+            "indfrom": [
+                date(2020, 1, 1),
+                date(2020, 1, 20),
+                date(2020, 3, 1),
+                None,
+                date(2020, 6, 1),
+                None,
+                date(2020, 6, 20),
+            ],
+            "indthru": [
+                date(2020, 1, 10),
+                date(2020, 2, 5),
+                None,
+                date(2020, 5, 1),
+                date(2020, 6, 5),
+                date(2020, 7, 1),
+                date(2020, 6, 22),
+            ],
+            "gics": [10101010, 20202020, None, 50505050, 60606060, 61616161, 62626262],
         }
     ).write_parquet(raw_data_dfs / "comp_hgics_na.parquet")
     pl.DataFrame(
@@ -116,10 +137,10 @@ def _write_raw_fixtures(raw_data_dfs: Path) -> None:
     ).write_parquet(raw_data_dfs / "comp_hgics_gl.parquet")
     pl.DataFrame(
         {
-            "gvkey": ["000001", "000001", "000002"],
-            "datadate": [date(2020, 1, 5), date(2020, 1, 25), date(2020, 2, 1)],
-            "sic": [3711, None, 6020],
-            "naics": [336111, 336112, 522110],
+            "gvkey": ["000001", "000001", "000002", "000007"],
+            "datadate": [date(2020, 1, 5), date(2020, 1, 25), date(2020, 2, 1), date(2020, 6, 3)],
+            "sic": [3711, None, 6020, 1311],
+            "naics": [336111, 336112, 522110, 211120],
         }
     ).write_parquet(raw_data_dfs / "sic_naics_na.parquet")
     pl.DataFrame(


### PR DESCRIPTION
Closes #195

## Simple explanation

`comp_industry` built the daily Compustat industry panel through a disk-backed DuckDB pipeline that materialized six intermediate tables (a ~16 GB scratch `.ddb` on disk) and ran redundant dedup/gap-fill steps. This PR rewrites the chain as a single lazy Polars plan with streaming writes. Same output, 2.5x faster, no scratch file.

## Technical details

- `comp_industry`: DuckDB SQL → lazy Polars. Two provable no-ops removed: the `UNION` dedup + `DISTINCT ON` (key sets of continuous and gap rows are disjoint) and the gap-fill value join (only the gap-start day — already present in the joined panel — ever carried values; interior days are null). The rewrite emits joined rows plus null-coded interior gap days directly.
- Legacy SQL silently dropped null-date rows (from GICS records with null `indfrom`): both `WHERE date <> aux_date` and `WHERE date = aux_date` evaluate to NULL for them. Replicated with an explicit `.filter(pl.col("date").is_not_null())` and a comment.
- `comp_hgics`, `hgics_join`, `comp_sic_naics`: eager `collect().write_parquet()` → streaming `sink_parquet`; `comp_hgics` also goes fully lazy (`scan_parquet`, `pl.max_horizontal` for the terminal-date cap, same semantics).
- Polars CSE caches the shared join subplan (verified via `explain()`), so the panel join executes once despite two consumers.

Validated on full production data (Yale, 128-core node, job 1016196):

| | before (run 817992) | after |
|---|---|---|
| `COMP_INDUSTRY` chain | 8m 47s | 3m 31s |
| `comp_ind.parquet` | 634,366,645 rows | row-identical |
| scratch `aux_comp_ind.ddb` | 16 GB | none |

All five stage outputs (`g_hgics`, `na_hgics`, `comp_hgics`, `comp_other`, `comp_ind`) compared row-identical against the production run.

## Test plan

- New `tests/unit/test_comp_industry.py`: runs the **legacy SQL verbatim** (DuckDB) against the rewrite on synthetic fixtures covering gaps, open-ended intervals, null `indfrom`, single-source gvkeys, and misaligned GICS/SIC dates; asserts row-identical output plus a no-duplicate-keys guard.
- Full unit suite passes (605 tests); ruff check + format clean.