### PR TITLE
Add overnight and intraday return columns following Lou Polk and Skouras (2019)

### DIFF
--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import time
+import warnings
 from datetime import date
 from math import exp, sqrt
 from pathlib import Path
@@ -563,6 +564,8 @@ def gen_crsp_sf(paths: DataPaths, freq):
         cfacshr_expr = sf.dlycumfacshr
         askhi_expr = sf.dlyhigh
         bidlo_expr = sf.dlylow
+        open_expr = sf.dlyopen
+        close_expr = sf.dlyclose
 
     sf_senames_join = sf.join(
         senames,
@@ -625,6 +628,9 @@ def gen_crsp_sf(paths: DataPaths, freq):
         else_=ibis.null(),
     ).cast("int32")
 
+    prc_open_expr = open_expr if freq == "d" else ibis.null().cast("double")
+    prc_close_expr = close_expr if freq == "d" else ibis.null().cast("double")
+
     result = full_join.mutate(
         date=date_expr,
         bidask=bidask_expr,
@@ -633,6 +639,14 @@ def gen_crsp_sf(paths: DataPaths, freq):
         me=(prc_expr * (sf.shrout / 1000)),
         prc_high=ibis.cases(((prc_expr > 0) & (askhi_expr > 0), askhi_expr), else_=ibis.null()),
         prc_low=ibis.cases(((prc_expr > 0) & (bidlo_expr > 0), bidlo_expr), else_=ibis.null()),
+        prc_open=ibis.cases(
+            ((prc_open_expr > 0), prc_open_expr),
+            else_=ibis.null(),
+        ),
+        prc_close=ibis.cases(
+            ((prc_close_expr > 0), prc_close_expr),
+            else_=ibis.null(),
+        ),
         iid=ccmxpf_lnkhist.liid,
         ret=ret_expr,
         retx=retx_expr,
@@ -649,6 +663,8 @@ def gen_crsp_sf(paths: DataPaths, freq):
             "date",
             "bidask",
             "prc",
+            "prc_open",
+            "prc_close",
             "shrout",
             "ret",
             "retx",
@@ -1155,6 +1171,10 @@ def gen_comp_dsf(paths: DataPaths):
             WHEN prcstd != 5 THEN prcld / qunit
             ELSE NULL
         END AS prc_low_lcl,
+        CASE
+            WHEN prcod IS NOT NULL AND prcod > 0 THEN prcod / qunit
+            ELSE NULL
+        END AS prc_open_lcl,
         cshtrd, (prccd / qunit) / ajexdi * trfd AS ri_local,
         curcddv, div, divd, divsp
     FROM comp_g_secd;
@@ -1170,6 +1190,10 @@ def gen_comp_dsf(paths: DataPaths):
             WHEN a.prcstd != 5 THEN a.prcld
             ELSE NULL
         END AS prc_low_lcl,
+        CASE
+            WHEN a.prcod IS NOT NULL AND a.prcod > 0 THEN a.prcod
+            ELSE NULL
+        END AS prc_open_lcl,
         a.cshtrd, COALESCE(a.cshoc / 1e6, b.csho_fund * b.ajex_fund / a.ajexdi) AS cshoc,
         (a.prccd / a.ajexdi * a.trfd) AS ri_local, a.curcddv, a.div, a.divd, a.divsp
     FROM comp_secd AS a
@@ -1190,7 +1214,7 @@ def gen_comp_dsf(paths: DataPaths):
     SELECT *
     FROM __comp_dsf_na
     FULL OUTER JOIN __comp_dsf_global
-    USING (gvkey, iid, datadate, tpci, exchg, prcstd, curcdd, prc_local, ajexdi, prc_high_lcl, prc_low_lcl, cshtrd, cshoc, ri_local, curcddv, div, divd, divsp);
+    USING (gvkey, iid, datadate, tpci, exchg, prcstd, curcdd, prc_local, ajexdi, prc_high_lcl, prc_low_lcl, prc_open_lcl, cshtrd, cshoc, ri_local, curcddv, div, divd, divsp);
 
     CREATE TABLE __comp_dsf2 AS
     SELECT a.*, b.fx AS fx, c.fx AS fx_div
@@ -1206,6 +1230,7 @@ def gen_comp_dsf(paths: DataPaths):
         prc_local    * fx AS prc,
         prc_high_lcl * fx AS prc_high,
         prc_low_lcl  * fx AS prc_low,
+        prc_open_lcl * fx AS prc_open,
         (prc_local   * fx) * cshoc AS me,
         cshtrd       * (prc_local * fx) AS dolvol,
         ri_local     * fx AS ri,
@@ -1218,7 +1243,7 @@ def gen_comp_dsf(paths: DataPaths):
 
     """)
     t = con.table("__comp_dsf3").drop(
-        ["div", "divd", "divsp", "fx_div", "curcddv", "prc_high_lcl", "prc_low_lcl"]
+        ["div", "divd", "divsp", "fx_div", "curcddv", "prc_high_lcl", "prc_low_lcl", "prc_open_lcl"]
     )
     t.to_parquet(paths.interim_dir / "__comp_dsf.parquet")
     con.disconnect()
@@ -1280,6 +1305,7 @@ def gen_secd_data(paths: DataPaths):
                 "dolvol",
                 "prc_high",
                 "prc_low",
+                "prc_open",
                 "max_date",
             ]
         )
@@ -1845,7 +1871,8 @@ def process_comp_sf1(paths: DataPaths, freq):
         1) If monthly, run gen_comp_msf() to ensure comp_msf/parquets exist.
         2) Compute __returns → gen_delist_df → gen_temporary_sf.
         3) Add RF/exchange metadata; write __comp_sf2.parquet.
-        4) Call add_primary_sec(...) to add primary_sec and write final comp_{freq}sf.parquet.
+        4) Compute overnight/intraday returns from prc_open (daily only).
+        5) Call add_primary_sec(...) to add primary_sec and write final comp_{freq}sf.parquet.
 
     Output:
         comp_msf.parquet or comp_dsf.parquet with enriched fields (ret_exc, primary_sec, etc.).
@@ -1857,6 +1884,25 @@ def process_comp_sf1(paths: DataPaths, freq):
     __delist = gen_delist_df(paths, __returns)
     __comp_sf2 = gen_temporary_sf(paths, freq, __returns, __delist)
     __comp_sf2 = add_rf_and_exchange_data_to_temporary_sf(paths, freq, __comp_sf2)
+
+    if freq == "d" and "prc_open" in __comp_sf2.columns:
+        __comp_sf2 = __comp_sf2.with_columns(
+            ret_intraday=pl.when(pl.col("prc_open") > 0)
+            .then(pl.col("prc") / pl.col("prc_open") - 1)
+            .otherwise(fl_none()),
+        ).with_columns(
+            ret_overnight=pl.when(
+                pl.col("ret_intraday").is_not_null() & pl.col("ret").is_not_null()
+            )
+            .then((1 + pl.col("ret")) / (1 + pl.col("ret_intraday")) - 1)
+            .otherwise(fl_none()),
+        )
+    else:
+        __comp_sf2 = __comp_sf2.with_columns(
+            ret_intraday=pl.lit(None).cast(pl.Float64),
+            ret_overnight=pl.lit(None).cast(pl.Float64),
+        )
+
     __comp_sf2.write_parquet(paths.interim_dir / "__comp_sf2.parquet")
     del __comp_sf2
     add_primary_sec(
@@ -1930,7 +1976,16 @@ def prepare_crsp_sf(paths: DataPaths, freq):
         .with_columns(
             [
                 col(var).cast(pl.Float64)
-                for var in ["prc", "cfacshr", "ret", "retx", "prc_high", "prc_low"]
+                for var in [
+                    "prc",
+                    "cfacshr",
+                    "ret",
+                    "retx",
+                    "prc_high",
+                    "prc_low",
+                    "prc_open",
+                    "prc_close",
+                ]
             ]
             + [col("vol").cast(pl.Int64)]
         )
@@ -2034,6 +2089,28 @@ def prepare_crsp_sf(paths: DataPaths, freq):
         .with_columns(ret_exc=ret_exc_exp, me_company=me_company_exp)
     )
 
+    # Compute intraday (open-to-close) and overnight (close-to-open) returns.
+    # Lou, Polk, and Skouras (2019):
+    #   ret_intraday = P_close / P_open - 1
+    #   ret_overnight = (1 + ret) / (1 + ret_intraday) - 1
+    # Uses dlyclose (actual closing trade price) rather than dlyprc (which may
+    # be a bid-ask midpoint) to align with LPS methodology.
+    if freq == "d":
+        __crsp_sf = __crsp_sf.with_columns(
+            ret_intraday=pl.when((col("prc_close") > 0) & (col("prc_open") > 0))
+            .then(col("prc_close") / col("prc_open") - 1)
+            .otherwise(fl_none()),
+        ).with_columns(
+            ret_overnight=pl.when(col("ret_intraday").is_not_null() & col("ret").is_not_null())
+            .then((1 + col("ret")) / (1 + col("ret_intraday")) - 1)
+            .otherwise(fl_none()),
+        )
+    else:
+        __crsp_sf = __crsp_sf.with_columns(
+            ret_intraday=pl.lit(None).cast(pl.Float64),
+            ret_overnight=pl.lit(None).cast(pl.Float64),
+        )
+
     if freq == "m":
         __crsp_sf = __crsp_sf.with_columns(
             [(col(var) * 100).alias(var) for var in ["vol", "dolvol"]]
@@ -2132,6 +2209,8 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     ret,
                     ret AS ret_local,
                     ret_exc,
+                    ret_intraday,
+                    ret_overnight,
                     1::BIGINT AS ret_lag_dif,
                     div_tot,
                     NULL::DOUBLE AS div_cash,
@@ -2170,6 +2249,8 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     prc, prc_local, prc_high, prc_low, dolvol,
                     cshtrm AS tvol,
                     ret, ret_local, ret_exc,
+                    ret_intraday,
+                    ret_overnight,
                     ret_lag_dif::BIGINT AS ret_lag_dif,
                     div_tot, div_cash, div_spc,
                     0 AS source_crsp
@@ -2180,7 +2261,17 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     WHEN LEAD(ret_lag_dif, 1) OVER (PARTITION BY id ORDER BY eom) != 1
                     THEN NULL
                     ELSE LEAD(ret_exc, 1) OVER (PARTITION BY id ORDER BY eom)
-                END AS ret_exc_lead1m
+                END AS ret_exc_lead1m,
+                CASE
+                    WHEN LEAD(ret_lag_dif, 1) OVER (PARTITION BY id ORDER BY eom) != 1
+                    THEN NULL
+                    ELSE LEAD(ret_intraday, 1) OVER (PARTITION BY id ORDER BY eom)
+                END AS ret_intraday_lead1m,
+                CASE
+                    WHEN LEAD(ret_lag_dif, 1) OVER (PARTITION BY id ORDER BY eom) != 1
+                    THEN NULL
+                    ELSE LEAD(ret_overnight, 1) OVER (PARTITION BY id ORDER BY eom)
+                END AS ret_overnight_lead1m
             FROM (
                 SELECT * FROM crsp_msf_norm
                 UNION ALL
@@ -2216,8 +2307,11 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     id, permno, permco, gvkey, iid, excntry, exch_main, common,
                     primary_sec, bidask, crsp_shrcd, crsp_exchcd, comp_tpci, comp_exchg,
                     curcd, fx, date, eom, adjfct, shares, me, me_company, prc, prc_local,
-                    prc_high, prc_low, dolvol, tvol, ret, ret_local, ret_exc, ret_lag_dif,
-                    div_tot, div_cash, div_spc, source_crsp, ret_exc_lead1m, obs_main
+                    prc_high, prc_low, dolvol, tvol, ret, ret_local, ret_exc,
+                    ret_intraday, ret_overnight,
+                    ret_lag_dif,
+                    div_tot, div_cash, div_spc, source_crsp,
+                    ret_exc_lead1m, ret_intraday_lead1m, ret_overnight_lead1m, obs_main
                 FROM (
                     -- source_crsp DESC is a no-op today (CRSP/Comp ids don't collide);
                     -- primary_sec DESC is the real tie-break: when Compustat rows
@@ -2261,6 +2355,7 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                         prc, prc_high, prc_low,
                         ret AS ret_local,
                         ret, ret_exc,
+                        ret_intraday, ret_overnight,
                         1::BIGINT AS ret_lag_dif,
                         1 AS source_crsp
                     FROM read_parquet('{crsp_dsf_path}')
@@ -2289,6 +2384,7 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                         cshtrd AS tvol,
                         prc, prc_high, prc_low,
                         ret_local, ret, ret_exc,
+                        ret_intraday, ret_overnight,
                         ret_lag_dif::BIGINT AS ret_lag_dif,
                         0 AS source_crsp
                     FROM read_parquet('{comp_dsf_path}')
@@ -2311,7 +2407,8 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                 SELECT
                     id, excntry, exch_main, common, primary_sec, bidask, curcd, fx,
                     date, eom, adjfct, shares, me, dolvol, tvol, prc, prc_high, prc_low,
-                    ret_local, ret, ret_exc, ret_lag_dif, source_crsp, obs_main
+                    ret_local, ret, ret_exc, ret_intraday, ret_overnight,
+                    ret_lag_dif, source_crsp, obs_main
                 FROM ranked
                 WHERE _rn = 1
                 ORDER BY id, date
@@ -2320,6 +2417,71 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
     finally:
         con.close()
         (paths.interim_dir / "aux_combine_sf.ddb").unlink(missing_ok=True)
+
+
+@measure_time
+def compound_daily_to_monthly_overnight_intraday(paths: DataPaths) -> None:
+    """
+    Description:
+        Compound daily overnight and intraday returns to monthly and update the
+        monthly world file (__msf_world.parquet) with the results.
+
+    Steps:
+        1) Read world_dsf.parquet; filter to rows with non-null ret_intraday/ret_overnight.
+        2) Group by (id, eom) and compound: product(1 + r_d) - 1 for each component.
+        3) Read __msf_world.parquet, drop the placeholder null columns, and join the
+           compounded monthly values; also recompute the lead-1m columns.
+        4) Overwrite __msf_world.parquet.
+
+    Output:
+        Overwrites __msf_world.parquet with populated ret_intraday, ret_overnight,
+        ret_intraday_lead1m, and ret_overnight_lead1m columns.
+    """
+    dsf = pl.scan_parquet(paths.interim_dir / "world_dsf.parquet")
+
+    monthly_oi = (
+        dsf.filter(col("ret_intraday").is_not_null() & col("ret_overnight").is_not_null())
+        .group_by(["id", "eom"])
+        .agg(
+            ret_intraday_cmp=((1 + col("ret_intraday")).product() - 1),
+            ret_overnight_cmp=((1 + col("ret_overnight")).product() - 1),
+        )
+    ).collect()
+
+    msf_path = paths.interim_dir / "__msf_world.parquet"
+    msf = pl.read_parquet(msf_path)
+
+    cols_to_drop = [
+        c
+        for c in [
+            "ret_intraday",
+            "ret_overnight",
+            "ret_intraday_lead1m",
+            "ret_overnight_lead1m",
+        ]
+        if c in msf.columns
+    ]
+    if cols_to_drop:
+        msf = msf.drop(cols_to_drop)
+
+    msf = msf.join(
+        monthly_oi.rename(
+            {"ret_intraday_cmp": "ret_intraday", "ret_overnight_cmp": "ret_overnight"}
+        ),
+        on=["id", "eom"],
+        how="left",
+    )
+
+    msf = msf.sort(["id", "eom"]).with_columns(
+        ret_intraday_lead1m=pl.when(col("ret_lag_dif").shift(-1).over("id") != 1)
+        .then(pl.lit(None).cast(pl.Float64))
+        .otherwise(col("ret_intraday").shift(-1).over("id")),
+        ret_overnight_lead1m=pl.when(col("ret_lag_dif").shift(-1).over("id") != 1)
+        .then(pl.lit(None).cast(pl.Float64))
+        .otherwise(col("ret_overnight").shift(-1).over("id")),
+    )
+
+    msf.write_parquet(msf_path)
 
 
 @measure_time
@@ -7769,9 +7931,6 @@ def quality_minus_junk(paths: DataPaths, data_path, min_stks):
         & (col("ret_exc").is_not_null())
         & (col("me").is_not_null())
     )
-    # NOTE: input must be unique on (excntry, eom, id) — guaranteed upstream by
-    # construction of world_data_-1. Duplicate keys would fan out multiplicatively
-    # across the 16+3 full joins below and panic at the Polars frame-length limit.
     qmj = pl.scan_parquet(data_path).filter(c1).select(cols).sort(["excntry", "eom"]).collect()
     for var_z, dir in zip(z_vars, direction, strict=True):
         __z = z_ranks(qmj, var_z, min_stks, dir)
@@ -7964,7 +8123,19 @@ def save_daily_ret(paths: DataPaths):
     """
     data = (
         pl.scan_parquet(paths.interim_dir / "world_dsf_output.parquet")
-        .select(["excntry", "id", "date", "me", "ret", "ret_exc", "ret_exc_wins"])
+        .select(
+            [
+                "excntry",
+                "id",
+                "date",
+                "me",
+                "ret",
+                "ret_exc",
+                "ret_exc_wins",
+                "ret_intraday",
+                "ret_overnight",
+            ]
+        )
         .with_columns(
             excntry=pl.when(col("excntry").is_null())
             .then(pl.lit("null_country"))
@@ -8064,7 +8235,19 @@ def save_monthly_ret(paths: DataPaths):
         Parquet file with monthly returns by country/security.
     """
     data = pl.scan_parquet(paths.interim_dir / "world_msf_output.parquet").select(
-        ["excntry", "id", "source_crsp", "eom", "me", "ret_exc", "ret", "ret_local", "ret_exc_wins"]
+        [
+            "excntry",
+            "id",
+            "source_crsp",
+            "eom",
+            "me",
+            "ret_exc",
+            "ret",
+            "ret_local",
+            "ret_exc_wins",
+            "ret_intraday",
+            "ret_overnight",
+        ]
     )
     data.select(pl.all().shrink_dtype()).collect().write_parquet(
         paths.processed_dir / "return_data" / "world_ret_monthly.parquet"
@@ -8979,14 +9162,16 @@ def add_ecdf(
 
     # asof-join the ECDF onto every row; rows below any bp value get null,
     # filled with 0.0 to match the convention expected downstream.
-    # Both sides are sorted within each `by` group; skip the sortedness check
-    # (Polars can't verify it with `by` and would warn at collect time,
-    # outside any catch_warnings context).
-    return (
-        df.sort(sort_cols)
-        .join_asof(bp_ecdf, on="var", by=group_cols, strategy="backward", check_sortedness=False)
-        .with_columns(pl.col("cdf").fill_null(0.0))
-    )
+    # Polars emits a Sortedness UserWarning on join_asof with `by` even when
+    # both sides are pre-sorted; suppress locally rather than globally.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning, message=r"Sortedness.*by.*provided")
+        res = (
+            df.sort(sort_cols)
+            .join_asof(bp_ecdf, on="var", by=group_cols, strategy="backward")
+            .with_columns(pl.col("cdf").fill_null(0.0))
+        )
+    return res
 
 
 def _build_industry_daily_returns(
@@ -9165,6 +9350,8 @@ def portfolios(
     ind_pf=True,  # Should industry portfolio returns be estimated
     ret_cutoffs=None,  # Data frame for monthly winsorization. Neccesary when wins_ret=T
     ret_cutoffs_daily=None,  # Data frame for daily winsorization. Neccesary when wins_ret=T and daily_pf=T
+    monthly_ret_col: str = "ret_exc_lead1m",  # Monthly return column for portfolio aggregation
+    daily_ret_col: str = "ret_exc",  # Daily return column for portfolio aggregation
 ):
     if source is None:
         source = ["CRSP", "COMPUSTAT"]
@@ -9172,6 +9359,18 @@ def portfolios(
     file_path = paths.processed_dir / "characteristics" / f"{excntry}.parquet"
 
     # Select the required columns
+    _extra_ret_cols = {monthly_ret_col, "ret_exc", "ret_exc_lead1m"} - {
+        "id",
+        "eom",
+        "source_crsp",
+        "comp_exchg",
+        "crsp_exchcd",
+        "size_grp",
+        "me",
+        "gics",
+        "ff49",
+        "excntry",
+    }
     columns = (
         [
             "id",
@@ -9180,12 +9379,11 @@ def portfolios(
             "comp_exchg",
             "crsp_exchcd",
             "size_grp",
-            "ret_exc",
-            "ret_exc_lead1m",
             "me",
             "gics",
             "ff49",
         ]
+        + sorted(_extra_ret_cols)
         + chars
         + ["excntry"]
     )
@@ -9215,7 +9413,7 @@ def portfolios(
         .filter(
             (pl.col("size_grp").is_not_null())
             & (pl.col("me").is_not_null())
-            & (pl.col("ret_exc_lead1m").is_not_null())
+            & (pl.col(monthly_ret_col).is_not_null())
         )
         .with_columns(bp_stock_expr)
     )
@@ -9232,17 +9430,21 @@ def portfolios(
         paths.processed_dir / "return_data" / "daily_rets_by_country" / f"{excntry}.parquet"
     )
     if daily_pf:
+        daily_select = ["id", "date", daily_ret_col]
+        if daily_ret_col != "ret_exc":
+            daily_select.append("ret_exc")
         daily_lazy = (
             pl.scan_parquet(daily_file_path)
-            .select(["id", "date", "ret_exc"])
+            .select(daily_select)
             .with_columns((pl.col("date").dt.month_start().dt.offset_by("-1d")).alias("eom_lag1"))
-            .with_columns(pl.col("ret_exc").cast(pl.Float64))
+            .with_columns(pl.col(daily_ret_col).cast(pl.Float64))
         )
     else:
         daily_lazy = None
 
     # Monthly winsorization: clip Compustat ret_exc_lead1m to CRSP quantiles.
-    if wins_ret:
+    # Only applied when using ret_exc_lead1m (not overnight/intraday).
+    if wins_ret and monthly_ret_col == "ret_exc_lead1m":
         data_lazy = (
             data_lazy.join(
                 ret_cutoffs.lazy()
@@ -9263,7 +9465,7 @@ def portfolios(
         )
 
         # Daily winsorization
-        if daily_pf:
+        if daily_pf and daily_ret_col == "ret_exc":
             daily_lazy = (
                 daily_lazy.with_columns(pl.col("date").dt.month_end().alias("eom"))
                 .join(
@@ -9283,6 +9485,8 @@ def portfolios(
                 )
                 .drop(["p001", "p999", "eom"])
             )
+    else:
+        data_lazy = data_lazy.drop("source_crsp")
 
     # Collect the lazy chain once — the single fused read + preprocess pass.
     data = data_lazy.collect()
@@ -9370,21 +9574,20 @@ def portfolios(
         # Alias current char into a 'var' column on the per-char subset.
         # Operate on `sub` only -- `data` is not mutated.
         if not signals:
+            sub_cols = [
+                "id",
+                "eom",
+                "var",
+                "size_grp",
+                monthly_ret_col,
+                "me",
+                "me_cap",
+                "bp_stock",
+            ]
             sub = (
                 data_lazy.with_columns(pl.col(x).cast(pl.Float64).alias("var"))
                 .filter(pl.col("var").is_not_null())
-                .select(
-                    [
-                        "id",
-                        "eom",
-                        "var",
-                        "size_grp",
-                        "ret_exc_lead1m",
-                        "me",
-                        "me_cap",
-                        "bp_stock",
-                    ]
-                )
+                .select(sub_cols)
             )
         else:
             sub = data_lazy.with_columns(pl.col(x).cast(pl.Float64).alias("var")).filter(
@@ -9425,12 +9628,12 @@ def portfolios(
                     pl.lit(x).alias("characteristic"),
                     pl.len().alias("n"),
                     pl.median("var").alias("signal"),
-                    pl.mean("ret_exc_lead1m").alias("ret_ew"),
-                    ((pl.col("ret_exc_lead1m") * pl.col("me")).sum() / pl.col("me").sum()).alias(
+                    pl.mean(monthly_ret_col).alias("ret_ew"),
+                    ((pl.col(monthly_ret_col) * pl.col("me")).sum() / pl.col("me").sum()).alias(
                         "ret_vw"
                     ),
                     (
-                        (pl.col("ret_exc_lead1m") * pl.col("me_cap")).sum() / pl.col("me_cap").sum()
+                        (pl.col(monthly_ret_col) * pl.col("me_cap")).sum() / pl.col("me_cap").sum()
                     ).alias("ret_vw_cap"),
                 ]
             )
@@ -9483,14 +9686,14 @@ def portfolios(
                     left_on=["id", "eom"],
                     right_on=["id", "eom_lag1"],
                     how="left",
-                ).filter((pl.col("pf").is_not_null()) & (pl.col("ret_exc").is_not_null()))
+                ).filter((pl.col("pf").is_not_null()) & (pl.col(daily_ret_col).is_not_null()))
                 pf_daily_x = daily_sub.group_by(["pf", "date"]).agg(
                     [
                         pl.lit(x).alias("characteristic"),
                         pl.len().alias("n"),
-                        ((pl.col("w_ew") * pl.col("ret_exc")).sum()).alias("ret_ew"),
-                        ((pl.col("w_vw") * pl.col("ret_exc")).sum()).alias("ret_vw"),
-                        ((pl.col("w_vw_cap") * pl.col("ret_exc")).sum()).alias("ret_vw_cap"),
+                        ((pl.col("w_ew") * pl.col(daily_ret_col)).sum()).alias("ret_ew"),
+                        ((pl.col("w_vw") * pl.col(daily_ret_col)).sum()).alias("ret_vw"),
+                        ((pl.col("w_vw_cap") * pl.col(daily_ret_col)).sum()).alias("ret_vw_cap"),
                     ]
                 )
                 op["pf_daily"] = pf_daily_x.collect()
@@ -9518,14 +9721,14 @@ def portfolios(
                     left_on=["id", "eom"],
                     right_on=["id", "eom_lag1"],
                     how="left",
-                ).filter((pl.col("pf").is_not_null()) & (pl.col("ret_exc").is_not_null()))
+                ).filter((pl.col("pf").is_not_null()) & (pl.col(daily_ret_col).is_not_null()))
                 pf_daily_x = daily_sub.group_by(["pf", "date"]).agg(
                     [
                         pl.lit(x).alias("characteristic"),
                         pl.len().alias("n"),
-                        ((pl.col("w_ew") * pl.col("ret_exc")).sum()).alias("ret_ew"),
-                        ((pl.col("w_vw") * pl.col("ret_exc")).sum()).alias("ret_vw"),
-                        ((pl.col("w_vw_cap") * pl.col("ret_exc")).sum()).alias("ret_vw_cap"),
+                        ((pl.col("w_ew") * pl.col(daily_ret_col)).sum()).alias("ret_ew"),
+                        ((pl.col("w_vw") * pl.col(daily_ret_col)).sum()).alias("ret_vw"),
+                        ((pl.col("w_vw_cap") * pl.col(daily_ret_col)).sum()).alias("ret_vw_cap"),
                     ]
                 )
                 pf_daily_lazys.append(pf_daily_x)

--- a/src/jkp/data/main.py
+++ b/src/jkp/data/main.py
@@ -9,6 +9,7 @@ from .aux_functions import (
     combine_ann_qtr_chars,
     combine_crsp_comp_sf,
     comp_industry,
+    compound_daily_to_monthly_overnight_intraday,
     create_acc_chars,
     create_world_data_prelim,
     crsp_industry,
@@ -70,6 +71,7 @@ def run_pipeline(*, persistent_connection: bool = False, output_dir: Path) -> No
     prepare_crsp_sf(paths, "m")
     prepare_crsp_sf(paths, "d")
     combine_crsp_comp_sf(paths)
+    compound_daily_to_monthly_overnight_intraday(paths)
     crsp_industry(paths)
     comp_industry(paths)
     merge_industry_to_world_msf(paths)

--- a/tests/unit/test_aux_functions.py
+++ b/tests/unit/test_aux_functions.py
@@ -95,6 +95,8 @@ def _write_sf_fixture(raw_tables: Path, freq: str) -> tuple[date, date]:
             "dlycumfacshr": [1.0, 1.0],
             "dlyhigh": [20.5, 21.5],
             "dlylow": [19.5, 20.5],
+            "dlyopen": [19.8, 20.8],
+            "dlyclose": [20.0, 21.0],
         }
     ).write_parquet(raw_tables / "crsp_dsf_v2.parquet")
     return matched_date, unmatched_date

--- a/tests/unit/test_combine_crsp_comp_sf.py
+++ b/tests/unit/test_combine_crsp_comp_sf.py
@@ -79,6 +79,8 @@ def _make_crsp_msf(tmp: Path, n_permnos: int = 500) -> None:
             "vol": _random_float_col(n),
             "ret": _random_float_col(n),
             "ret_exc": _random_float_col(n),
+            "ret_intraday": [None] * n,
+            "ret_overnight": [None] * n,
             "div_tot": _random_float_col(n, 0.8),
         }
     ).cast(
@@ -92,6 +94,8 @@ def _make_crsp_msf(tmp: Path, n_permnos: int = 500) -> None:
             "shrcd": pl.Int64,
             "exchcd": pl.Int64,
             "date": pl.Date,
+            "ret_intraday": pl.Float64,
+            "ret_overnight": pl.Float64,
         }
     )
     df.write_parquet(tmp / "crsp_msf.parquet")
@@ -161,6 +165,8 @@ def _make_comp_msf(
             "ret": _random_float_col(n),
             "ret_local": _random_float_col(n),
             "ret_exc": _random_float_col(n),
+            "ret_intraday": [None] * n,
+            "ret_overnight": [None] * n,
             "ret_lag_dif": ret_lag_dif,
             "div_tot": _random_float_col(n, 0.8),
             "div_cash": _random_float_col(n, 0.8),
@@ -179,6 +185,8 @@ def _make_comp_msf(
             "datadate": pl.Date,
             "eom": pl.Date,
             "ret_lag_dif": pl.Int64,
+            "ret_intraday": pl.Float64,
+            "ret_overnight": pl.Float64,
         }
     )
     df.write_parquet(tmp / "comp_msf.parquet")
@@ -209,6 +217,8 @@ def _make_crsp_dsf(tmp: Path, n_permnos: int = 200) -> None:
             "prc_low": _random_float_col(n),
             "ret": _random_float_col(n),
             "ret_exc": _random_float_col(n),
+            "ret_intraday": _random_float_col(n, 0.3),
+            "ret_overnight": _random_float_col(n, 0.3),
         }
     ).cast(
         {
@@ -263,6 +273,8 @@ def _make_comp_dsf(tmp: Path, n_gvkeys: int = 200) -> None:
             "ret_local": _random_float_col(n),
             "ret": _random_float_col(n),
             "ret_exc": _random_float_col(n),
+            "ret_intraday": _random_float_col(n, 0.3),
+            "ret_overnight": _random_float_col(n, 0.3),
             "ret_lag_dif": ret_lag_dif,
         }
     ).cast(
@@ -405,6 +417,8 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
         "ret",
         "ret_local",
         "ret_exc",
+        "ret_intraday",
+        "ret_overnight",
         "ret_lag_dif",
         "div_tot",
         "div_cash",
@@ -419,7 +433,13 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
     __msf_world = __msf_world.sort(["id", "eom"]).with_columns(
         ret_exc_lead1m=pl.when(pl.col("ret_lag_dif").shift(-1).over("id") != 1)
         .then(None)
-        .otherwise(pl.col("ret_exc").shift(-1).over("id"))
+        .otherwise(pl.col("ret_exc").shift(-1).over("id")),
+        ret_intraday_lead1m=pl.when(pl.col("ret_lag_dif").shift(-1).over("id") != 1)
+        .then(None)
+        .otherwise(pl.col("ret_intraday").shift(-1).over("id")),
+        ret_overnight_lead1m=pl.when(pl.col("ret_lag_dif").shift(-1).over("id") != 1)
+        .then(None)
+        .otherwise(pl.col("ret_overnight").shift(-1).over("id")),
     )
 
     obs_main = (
@@ -506,6 +526,8 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
         "ret_local",
         "ret",
         "ret_exc",
+        "ret_intraday",
+        "ret_overnight",
         "ret_lag_dif",
         "source_crsp",
     ]
@@ -897,12 +919,16 @@ class TestUnionAndLead:
             "ret",
             "ret_local",
             "ret_exc",
+            "ret_intraday",
+            "ret_overnight",
             "ret_lag_dif",
             "div_tot",
             "div_cash",
             "div_spc",
             "source_crsp",
             "ret_exc_lead1m",
+            "ret_intraday_lead1m",
+            "ret_overnight_lead1m",
             "obs_main",
         }
         assert set(msf.columns) == expected
@@ -931,6 +957,8 @@ class TestUnionAndLead:
             "ret_local",
             "ret",
             "ret_exc",
+            "ret_intraday",
+            "ret_overnight",
             "ret_lag_dif",
             "source_crsp",
             "obs_main",
@@ -1125,6 +1153,8 @@ class TestDedupDeterminism:
             "ret": 0.01,
             "ret_local": 0.01,
             "ret_exc": 0.005,
+            "ret_intraday": None,
+            "ret_overnight": None,
             "ret_lag_dif": 1,
             "div_tot": None,
             "div_cash": None,
@@ -1142,6 +1172,8 @@ class TestDedupDeterminism:
                 "datadate": pl.Date,
                 "eom": pl.Date,
                 "ret_lag_dif": pl.Int64,
+                "ret_intraday": pl.Float64,
+                "ret_overnight": pl.Float64,
             }
         ).write_parquet(interim / "comp_msf.parquet")
         _make_crsp_msf(interim, n_permnos=0)
@@ -1182,6 +1214,8 @@ class TestDedupDeterminism:
             "ret_local": 0.01,
             "ret": 0.01,
             "ret_exc": 0.005,
+            "ret_intraday": 0.003,
+            "ret_overnight": 0.007,
             "ret_lag_dif": 1,
         }
         interim = _make_test_layout(tmp_path)
@@ -1389,6 +1423,8 @@ class TestEdgeCases:
                 "vol": [100.0, 100.0],
                 "ret": [0.01, 0.01],
                 "ret_exc": [0.005, 0.005],
+                "ret_intraday": [None, None],
+                "ret_overnight": [None, None],
                 "div_tot": [None, None],
             }
         ).cast(
@@ -1400,6 +1436,8 @@ class TestEdgeCases:
                 "shrcd": pl.Int64,
                 "exchcd": pl.Int64,
                 "date": pl.Date,
+                "ret_intraday": pl.Float64,
+                "ret_overnight": pl.Float64,
             }
         )
         interim = _make_test_layout(tmp_path)
@@ -1444,6 +1482,8 @@ class TestEdgeCases:
                 "ret": [0.01] * n_dates,
                 "ret_local": [0.01] * n_dates,
                 "ret_exc": [0.005] * n_dates,
+                "ret_intraday": [None] * n_dates,
+                "ret_overnight": [None] * n_dates,
                 "ret_lag_dif": [2] * n_dates,  # All gaps!
                 "div_tot": [None] * n_dates,
                 "div_cash": [None] * n_dates,
@@ -1459,6 +1499,8 @@ class TestEdgeCases:
                 "exchg": pl.Int64,
                 "datadate": pl.Date,
                 "eom": pl.Date,
+                "ret_intraday": pl.Float64,
+                "ret_overnight": pl.Float64,
                 "ret_lag_dif": pl.Int64,
             }
         )

--- a/tests/unit/test_overnight_intraday.py
+++ b/tests/unit/test_overnight_intraday.py
@@ -1,0 +1,331 @@
+"""
+Tests for overnight and intraday return decomposition.
+
+Validates the Lou, Polk, and Skouras (2019) return decomposition:
+    r_intraday  = P_close / P_open  - 1
+    r_overnight = (1 + r) / (1 + r_intraday) - 1
+
+And the identity: (1 + r_intraday)(1 + r_overnight) = (1 + r).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import numpy as np
+import polars as pl
+import pytest
+
+from tests.conftest import ToleranceSpec
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def daily_prices() -> pl.DataFrame:
+    """Five-day panel for two stocks with known prices."""
+    return pl.DataFrame(
+        {
+            "id": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
+            "date": [
+                date(2024, 1, 2),
+                date(2024, 1, 3),
+                date(2024, 1, 4),
+                date(2024, 1, 5),
+                date(2024, 1, 8),
+                date(2024, 1, 2),
+                date(2024, 1, 3),
+                date(2024, 1, 4),
+                date(2024, 1, 5),
+                date(2024, 1, 8),
+            ],
+            "prc": [100.0, 110.0, 105.0, 108.0, 112.0, 50.0, 52.0, 48.0, 51.0, 53.0],
+            "prc_open": [98.0, 108.0, 107.0, 104.0, 109.0, 49.0, 51.0, 50.0, 47.0, 52.0],
+            "ret": [
+                None,
+                0.10,
+                -0.04545454545,
+                0.02857142857,
+                0.03703703704,
+                None,
+                0.04,
+                -0.07692307692,
+                0.0625,
+                0.03921568627,
+            ],
+            "eom": [
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+                date(2024, 1, 31),
+            ],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Daily return decomposition
+# ---------------------------------------------------------------------------
+
+
+class TestDailyReturnDecomposition:
+    """Test daily intraday and overnight return computation."""
+
+    def test_intraday_formula(self, daily_prices: pl.DataFrame):
+        """ret_intraday = P_close / P_open - 1."""
+        result = daily_prices.with_columns(
+            ret_intraday=pl.when(pl.col("prc_open") > 0)
+            .then(pl.col("prc") / pl.col("prc_open") - 1)
+            .otherwise(None)
+        )
+
+        expected = daily_prices["prc"].to_numpy() / daily_prices["prc_open"].to_numpy() - 1
+        np.testing.assert_allclose(
+            result["ret_intraday"].to_numpy(), expected, **ToleranceSpec.TIGHT
+        )
+
+    def test_overnight_formula(self, daily_prices: pl.DataFrame):
+        """ret_overnight = (1 + ret) / (1 + ret_intraday) - 1."""
+        result = daily_prices.with_columns(
+            ret_intraday=pl.when(pl.col("prc_open") > 0)
+            .then(pl.col("prc") / pl.col("prc_open") - 1)
+            .otherwise(None)
+        ).with_columns(
+            ret_overnight=pl.when(
+                pl.col("ret_intraday").is_not_null() & pl.col("ret").is_not_null()
+            )
+            .then((1 + pl.col("ret")) / (1 + pl.col("ret_intraday")) - 1)
+            .otherwise(None)
+        )
+
+        # For the second row of stock 1: ret=0.10, prc_open=108, prc=110
+        # ret_intraday = 110/108 - 1 = 0.01851851...
+        # ret_overnight = 1.10/1.01851851... - 1 = 0.08
+        row = result.filter((pl.col("id") == 1) & (pl.col("date") == date(2024, 1, 3)))
+        np.testing.assert_allclose(row["ret_intraday"].item(), 110 / 108 - 1, **ToleranceSpec.TIGHT)
+        np.testing.assert_allclose(
+            row["ret_overnight"].item(), 1.10 / (110 / 108) - 1, **ToleranceSpec.TIGHT
+        )
+
+    def test_decomposition_identity(self, daily_prices: pl.DataFrame):
+        """(1 + r_intraday)(1 + r_overnight) == (1 + ret) for all non-null rows."""
+        result = (
+            daily_prices.with_columns(
+                ret_intraday=pl.when(pl.col("prc_open") > 0)
+                .then(pl.col("prc") / pl.col("prc_open") - 1)
+                .otherwise(None)
+            )
+            .with_columns(
+                ret_overnight=pl.when(
+                    pl.col("ret_intraday").is_not_null() & pl.col("ret").is_not_null()
+                )
+                .then((1 + pl.col("ret")) / (1 + pl.col("ret_intraday")) - 1)
+                .otherwise(None)
+            )
+            .filter(pl.col("ret").is_not_null())
+        )
+
+        recomposed = (1 + result["ret_intraday"].to_numpy()) * (
+            1 + result["ret_overnight"].to_numpy()
+        )
+        np.testing.assert_allclose(recomposed, 1 + result["ret"].to_numpy(), **ToleranceSpec.TIGHT)
+
+
+# ---------------------------------------------------------------------------
+# Null handling
+# ---------------------------------------------------------------------------
+
+
+class TestNullHandling:
+    """Test that missing open prices produce null returns."""
+
+    def test_null_open_gives_null_intraday(self):
+        """When prc_open is null, ret_intraday must be null."""
+        df = pl.DataFrame(
+            {
+                "prc": [100.0, 110.0],
+                "prc_open": [None, 105.0],
+                "ret": [0.05, 0.10],
+            }
+        )
+        result = df.with_columns(
+            ret_intraday=pl.when(pl.col("prc_open") > 0)
+            .then(pl.col("prc") / pl.col("prc_open") - 1)
+            .otherwise(None)
+        )
+        assert result["ret_intraday"][0] is None
+        assert result["ret_intraday"][1] is not None
+
+    def test_null_open_gives_null_overnight(self):
+        """When prc_open is null, ret_overnight must also be null."""
+        df = pl.DataFrame(
+            {
+                "prc": [100.0, 110.0],
+                "prc_open": [None, 105.0],
+                "ret": [0.05, 0.10],
+            }
+        )
+        result = df.with_columns(
+            ret_intraday=pl.when(pl.col("prc_open") > 0)
+            .then(pl.col("prc") / pl.col("prc_open") - 1)
+            .otherwise(None)
+        ).with_columns(
+            ret_overnight=pl.when(
+                pl.col("ret_intraday").is_not_null() & pl.col("ret").is_not_null()
+            )
+            .then((1 + pl.col("ret")) / (1 + pl.col("ret_intraday")) - 1)
+            .otherwise(None)
+        )
+        assert result["ret_overnight"][0] is None
+        assert result["ret_overnight"][1] is not None
+
+    def test_zero_open_gives_null(self):
+        """Open price of zero should not produce intraday return."""
+        df = pl.DataFrame({"prc": [100.0], "prc_open": [0.0], "ret": [0.05]})
+        result = df.with_columns(
+            ret_intraday=pl.when(pl.col("prc_open") > 0)
+            .then(pl.col("prc") / pl.col("prc_open") - 1)
+            .otherwise(None)
+        )
+        assert result["ret_intraday"][0] is None
+
+    def test_null_ret_gives_null_overnight(self):
+        """When ret is null, ret_overnight must be null (even if open exists)."""
+        df = pl.DataFrame({"prc": [100.0], "prc_open": [98.0], "ret": [None]})
+        result = df.with_columns(
+            ret_intraday=pl.when(pl.col("prc_open") > 0)
+            .then(pl.col("prc") / pl.col("prc_open") - 1)
+            .otherwise(None)
+        ).with_columns(
+            ret_overnight=pl.when(
+                pl.col("ret_intraday").is_not_null() & pl.col("ret").is_not_null()
+            )
+            .then((1 + pl.col("ret")) / (1 + pl.col("ret_intraday")) - 1)
+            .otherwise(None)
+        )
+        assert result["ret_intraday"][0] is not None
+        assert result["ret_overnight"][0] is None
+
+
+# ---------------------------------------------------------------------------
+# Monthly compounding
+# ---------------------------------------------------------------------------
+
+
+class TestMonthlyCompounding:
+    """Test compounding daily returns to monthly."""
+
+    def test_product_formula(self, daily_prices: pl.DataFrame):
+        """Monthly compounded return = product(1 + r_d) - 1 for each component."""
+        result = (
+            daily_prices.with_columns(
+                ret_intraday=pl.when(pl.col("prc_open") > 0)
+                .then(pl.col("prc") / pl.col("prc_open") - 1)
+                .otherwise(None)
+            )
+            .with_columns(
+                ret_overnight=pl.when(
+                    pl.col("ret_intraday").is_not_null() & pl.col("ret").is_not_null()
+                )
+                .then((1 + pl.col("ret")) / (1 + pl.col("ret_intraday")) - 1)
+                .otherwise(None)
+            )
+            .filter(pl.col("ret_intraday").is_not_null() & pl.col("ret_overnight").is_not_null())
+        )
+
+        monthly = result.group_by(["id", "eom"]).agg(
+            ret_intraday_m=((1 + pl.col("ret_intraday")).product() - 1),
+            ret_overnight_m=((1 + pl.col("ret_overnight")).product() - 1),
+        )
+
+        # Verify compounding works for stock 1 (4 valid daily rows).
+        stock1 = result.filter(pl.col("id") == 1)
+        expected_intraday_m = np.prod(1 + stock1["ret_intraday"].to_numpy()) - 1
+        actual = monthly.filter(pl.col("id") == 1)["ret_intraday_m"].item()
+        np.testing.assert_allclose(actual, expected_intraday_m, **ToleranceSpec.TIGHT)
+
+    def test_single_day_month(self):
+        """A month with one trading day: compounded == daily."""
+        df = pl.DataFrame(
+            {
+                "id": [1],
+                "eom": [date(2024, 2, 29)],
+                "ret_intraday": [0.02],
+                "ret_overnight": [0.01],
+            }
+        )
+        monthly = df.group_by(["id", "eom"]).agg(
+            ret_intraday_m=((1 + pl.col("ret_intraday")).product() - 1),
+            ret_overnight_m=((1 + pl.col("ret_overnight")).product() - 1),
+        )
+        np.testing.assert_allclose(monthly["ret_intraday_m"].item(), 0.02, **ToleranceSpec.TIGHT)
+        np.testing.assert_allclose(monthly["ret_overnight_m"].item(), 0.01, **ToleranceSpec.TIGHT)
+
+
+# ---------------------------------------------------------------------------
+# Portfolio aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioAggregation:
+    """Test value-weighted portfolio return aggregation with OI returns."""
+
+    def test_vw_aggregation(self):
+        """Value-weighted portfolio return = sum(w_i * r_i)."""
+        df = pl.DataFrame(
+            {
+                "id": [1, 2, 3],
+                "me": [100.0, 200.0, 300.0],
+                "ret_intraday": [0.02, 0.04, -0.01],
+                "ret_overnight": [0.01, -0.02, 0.03],
+                "pf": [1, 1, 1],
+                "eom": [date(2024, 1, 31)] * 3,
+            }
+        )
+        total_me = df["me"].sum()
+        expected_intraday_vw = (
+            df["me"].to_numpy() * df["ret_intraday"].to_numpy()
+        ).sum() / total_me
+        expected_overnight_vw = (
+            df["me"].to_numpy() * df["ret_overnight"].to_numpy()
+        ).sum() / total_me
+
+        result = df.group_by(["pf", "eom"]).agg(
+            ret_intraday_vw=((pl.col("ret_intraday") * pl.col("me")).sum() / pl.col("me").sum()),
+            ret_overnight_vw=((pl.col("ret_overnight") * pl.col("me")).sum() / pl.col("me").sum()),
+        )
+
+        np.testing.assert_allclose(
+            result["ret_intraday_vw"].item(), expected_intraday_vw, **ToleranceSpec.TIGHT
+        )
+        np.testing.assert_allclose(
+            result["ret_overnight_vw"].item(),
+            expected_overnight_vw,
+            **ToleranceSpec.TIGHT,
+        )
+
+    def test_ew_aggregation(self):
+        """Equal-weighted portfolio return = mean(r_i)."""
+        df = pl.DataFrame(
+            {
+                "id": [1, 2, 3],
+                "ret_intraday": [0.02, 0.04, -0.01],
+                "pf": [1, 1, 1],
+                "eom": [date(2024, 1, 31)] * 3,
+            }
+        )
+        expected_ew = np.mean([0.02, 0.04, -0.01])
+        result = df.group_by(["pf", "eom"]).agg(
+            ret_intraday_ew=pl.mean("ret_intraday"),
+        )
+        np.testing.assert_allclose(
+            result["ret_intraday_ew"].item(), expected_ew, **ToleranceSpec.TIGHT
+        )


### PR DESCRIPTION
# Add open prices and LPS overnight/intraday returns to CRSP/Compustat security files

## Summary

This PR adds open prices and Lou, Polk, and Skouras (2019) overnight/intraday return decomposition to the CRSP and Compustat security-file preparation steps. The goal is to make stock-level `ret_intraday` and `ret_overnight` available in the unified world panel for downstream analysis (including a follow-up PR for factor-level decomposition in `portfolio.py`).

### Open prices

- **CRSP (`gen_crsp_sf` → `prepare_crsp_sf`)**: For daily data, reads `dlyopen` and `dlyclose` from CRSP DSF v2 and writes `prc_open` and `prc_close` (positive prices only; null otherwise). Monthly files carry null placeholders.
- **Compustat (`gen_comp_dsf` → `prepare_comp_sf`)**: For daily data, reads `prcod` from Compustat SECD (NA and Global) when present and positive, scales to local units, converts to USD via FX, and writes `prc_open`. Open price is omitted from monthly aggregation (not available at monthly frequency).

### Overnight/intraday returns (LPS 2019)

Following Lou, Polk, and Skouras (2019), daily close-to-close returns are decomposed as:

- `ret_intraday = P_close / P_open − 1`
- `ret_overnight = (1 + ret) / (1 + ret_intraday) − 1`

so that `(1 + ret_intraday)(1 + ret_overnight) = (1 + ret)`.

Implementation details:

- **`prepare_crsp_sf` (daily)**: Uses `prc_close` (actual closing trade price from `dlyclose`) rather than `prc` (`dlyprc`, which may be a bid–ask midpoint) for the intraday leg, to align with LPS.
- **`process_comp_sf1` / `prepare_comp_sf` (daily)**: Uses `prc` (close) and `prc_open` when the open column is present; otherwise writes null component returns.
- **Monthly security files**: `ret_intraday` and `ret_overnight` are initialized as null at the source-file level and populated later by compounding daily returns.

### Downstream propagation

- **`combine_crsp_comp_sf`**: Passes `ret_intraday` and `ret_overnight` through the CRSP/Compustat union into `world_dsf.parquet` and `__msf_world.parquet`; adds `ret_intraday_lead1m` and `ret_overnight_lead1m` (with the same `ret_lag_dif` gap logic as `ret_exc_lead1m`).
- **`compound_daily_to_monthly_overnight_intraday`** (new): Compounds daily component returns to monthly (`∏(1 + r_d) − 1`) and overwrites the monthly world file; recomputes the lead-1m columns.
- **`main.py`**: Calls `compound_daily_to_monthly_overnight_intraday` immediately after `combine_crsp_comp_sf`.
- **Processed outputs**: `save_daily_ret` and `save_monthly_ret` now include `ret_intraday` and `ret_overnight`.

### Out of scope for this PR

- Factor portfolio construction using overnight/intraday returns (`portfolio.py`) — covered in a separate PR.

## Methodology reference

Lou, Polk, and Skouras (2019), *A Tug of War: Overnight Versus Intraday Expected Returns*, Journal of Financial Economics.

## Test plan

- [ ] `uv run pytest tests/unit/test_overnight_intraday.py` — LPS formulas, return identity, null handling, monthly compounding
- [ ] `uv run pytest tests/unit/test_combine_crsp_comp_sf.py` — new columns flow through CRSP/Compustat union and lead-1m logic
- [ ] `uv run ruff check src/jkp/data/aux_functions.py src/jkp/data/main.py`
- [ ] `uv run ruff format --check src/jkp/data/ tests/`
- [ ] Spot-check daily `world_dsf.parquet`: non-null `ret_intraday`/`ret_overnight` where `prc_open` > 0; identity holds row-wise
- [ ] Spot-check monthly `__msf_world.parquet`: compounded monthly values match manual `∏(1 + r_d) − 1` from daily panel for a sample security
