### PR TITLE
Remove CRSP V1 residuals and express common-stock and NYSE screens na…

### DIFF
--- a/CHANGELOG_DATA.md
+++ b/CHANGELOG_DATA.md
@@ -3,6 +3,10 @@ This change log keeps track of changes to the underlying data set. In brackets, 
 
 This repository ports the original SAS pipeline ([ReplicationCrisis](https://github.com/bkelly-lab/ReplicationCrisis)) to Python using Polars. Entries up to and including 05-03-2025 are from the original change log.
 
+## 04-07-2026
+__Changes__:
+- Replaced `crsp_shrcd` and `crsp_exchcd` with `primaryexch` and `conditionaltype` in the characteristics output ([#205](https://github.com/bkelly-lab/jkp-data/pull/205))
+
 ## 27-04-2026
 __Changes__:
 - Added `mkt_vw_cap_exc` (cap-weighted excess market return) to market returns output ([#81](https://github.com/bkelly-lab/jkp-data/pull/81))

--- a/documentation/documentation.tex
+++ b/documentation/documentation.tex
@@ -455,7 +455,7 @@ Nano  & Below 1st percentile. \\
 \begin{itemize}
     \item \texttt{nyse\_cutoffs.csv} reports the monthly NYSE market equity (ME) breakpoints used for the micro-cap screen and capped value weights.
     \item For each month, we compute discrete percentiles of market equity across the NYSE universe: 1st, 20th, 50th, and 80th.
-    \item The monthly cutoffs are derived from a universe of NYSE common stocks (primary share/security, main class) with non-missing market equity on CRSP.
+    \item The monthly cutoffs are derived from a universe of NYSE common stocks (primary share/security, main class) with non-missing market equity on CRSP. On CRSP rows, NYSE membership is identified by \texttt{primaryexch}='N' and \texttt{conditionaltype}='RW'.
     
 \end{itemize}
 
@@ -619,7 +619,7 @@ Nano  & Below 1st percentile. \\
 \end{longtable}}
     
 \section{Identifier Variables}
-This section covers all of the variables that give firm/date level identifiers and information. If a variable starts with 'comp' or 'crsp', then the following variable name is drawn from the specified dataset. For example, 'crsp\_shrcd' is the 'shrcd' variable from CRSP.
+This section covers all of the variables that give firm/date level identifiers and information. Variables prefixed with \texttt{comp\_} are drawn from Compustat. For CRSP-sourced rows, \texttt{primaryexch} and \texttt{conditionaltype} are native CRSP CIZ security-descriptor fields (not legacy CRSP V1 share or exchange codes).
 
 {\scriptsize
 	\begin{longtable}{@{\extracolsep{\fill}}|l|m{14.2cm}|@{}}
@@ -653,7 +653,7 @@ This section covers all of the variables that give firm/date level identifiers a
 		obs\_main & For US stocks, we often have two observations for each security-month pair. One from Compustat, and one from CRSP. In cases with duplicates, the observation from CRSP has \texttt{obs\_main=1}, and the observation from Compustat has \texttt{obs\_main=0}.  
 		If there are more than one firm observations for one date, this identifies if the observation is considered as the 'main' observation. If available, CRSP observations are considered as the 'main' observation.\\[1ex]
 		
-		exch\_main & Indicator for ordinary exchanges. If CRSP is the source, main exchanges are those with \textit{crsp\_exchcd} 1, 2 and 3. If Compustat is the source, main exchanges are all \texttt{comp\_exchg} except 0, 1, 2, 3, 4, 13, 15, 16, 17, 18, 19, 20, 21, 127, 150, 157, 229, 263, 269, 281, 283, 290, 320, 326, 341, 342, 347, 348, 349, 352.  \\[1ex]
+		exch\_main & Indicator for ordinary exchanges. If CRSP is the source, main exchanges are NYSE, AMEX, and NASDAQ with regular-way trading (\texttt{primaryexch} in \{A, N, Q\} and \texttt{conditionaltype} = RW). If Compustat is the source, main exchanges are all \texttt{comp\_exchg} except 0, 1, 2, 3, 4, 13, 15, 16, 17, 18, 19, 20, 21, 127, 150, 157, 229, 263, 269, 281, 283, 290, 320, 326, 341, 342, 347, 348, 349, 352.  \\[1ex]
 		
 		gvkey & Permanent six-digit unique firm identifier from Compustat\\[1ex]
 		
@@ -671,15 +671,15 @@ This section covers all of the variables that give firm/date level identifiers a
 		
 		fx & Ratio of \textit{curcd} to USD at the date of observation\\[1ex]
 		
-		common & Indicator for common stocks. If CRSP is the source, common is one if the SHRCD variable is 10, 11 or 12. If Compustat is the source, common is one if TPCI is '0'  \\[1ex]
+		common & Indicator for common stocks. If CRSP is the source, common is one for ordinary common shares: equity securities with common subtype, no special share type, and issuer type ACOR or CORP (derived from CRSP CIZ fields at construction). If Compustat is the source, common is one if TPCI is '0'  \\[1ex]
 		
 		comp\_tpci & Compustat issue type identifier \\[1ex]
 		
-		crsp\_shrcd & CRSP share code\\[1ex]
+		primaryexch & CRSP primary exchange code (N=NYSE, A=AMEX, Q=NASDAQ). Null for Compustat rows. \\[1ex]
+		
+		conditionaltype & CRSP trading status (RW = regular way). Null for Compustat rows. \\[1ex]
 		
 		comp\_exchg & Compustat stock exchange code \\[1ex]
-		
-		crsp\_exchd & CRSP stock exchange code \\[1ex]
 		
 		date & Date of the last return observation during the month. \\[1ex]
 		

--- a/documentation/sas_to_python/release_notes.html
+++ b/documentation/sas_to_python/release_notes.html
@@ -2234,6 +2234,7 @@ vertical-align: -.125em;
 <li><strong>characteristics/</strong>
 <ul>
 <li><code>world_data.parquet</code> contains the monthly stock file with stock-level characteristics, filtered by the standard screens: <code>primary_sec == 1</code> (primary security flag), <code>common == 1</code> (common stock flag), <code>obs_main == 1</code> (main observation flag), <code>exch_main == 1</code> (main exchange flag).</li>
+<li>CRSP-sourced rows carry native CIZ exchange descriptors <code>primaryexch</code> and <code>conditionaltype</code> (replacing legacy <code>crsp_shrcd</code> / <code>crsp_exchcd</code> passthrough columns). NYSE breakpoint logic uses <code>primaryexch == &quot;N&quot;</code> and <code>conditionaltype == &quot;RW&quot;</code> on CRSP rows; Compustat NYSE rows still use <code>comp_exchg == 11</code>.</li>
 <li>Partitions of <code>world_data.parquet</code> by country (e.g., <code>GBR.parquet</code>, <code>USA.parquet</code>). Files are named using <a href="https://www.nationsonline.org/oneworld/country_code_list.htm">ISO Alpha-3 country codes</a>.</li>
 </ul></li>
 <li><strong>other_output/</strong>

--- a/documentation/sas_to_python/release_notes.qmd
+++ b/documentation/sas_to_python/release_notes.qmd
@@ -44,6 +44,7 @@ The output is organized as follows:
 
 2. **characteristics/**
    - `world_data.parquet` contains the monthly stock file with stock-level characteristics, filtered by the standard screens: `primary_sec == 1` (primary security flag), `common == 1` (common stock flag), `obs_main == 1` (main observation flag), `exch_main == 1` (main exchange flag).
+   - CRSP-sourced rows carry native CIZ exchange descriptors `primaryexch` and `conditionaltype` (replacing legacy `crsp_shrcd` / `crsp_exchcd` passthrough columns). NYSE breakpoint logic uses `primaryexch == "N"` and `conditionaltype == "RW"` on CRSP rows; Compustat NYSE rows still use `comp_exchg == 11`.
    - Partitions of `world_data.parquet` by country (e.g., `GBR.parquet`, `USA.parquet`). Files are named using [ISO Alpha-3 country codes](https://www.nationsonline.org/oneworld/country_code_list.htm).
 
 3. **other_output/**

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -612,6 +612,7 @@ def gen_crsp_sf(paths: DataPaths, freq):
     exch_main_expr = (primaryexch_expr.isin(["A", "N", "Q"]) & (conditionaltype_expr == "RW")).cast(
         "int32"
     )
+    crsp_nyse_expr = ((primaryexch_expr == "N") & (conditionaltype_expr == "RW")).cast("int32")
 
     result = full_join.mutate(
         date=date_expr,
@@ -630,6 +631,7 @@ def gen_crsp_sf(paths: DataPaths, freq):
         primaryexch=primaryexch_expr,
         conditionaltype=conditionaltype_expr,
         exch_main=exch_main_expr,
+        crsp_nyse=crsp_nyse_expr,
         gvkey=ccmxpf_lnkhist.gvkey,
     ).select(
         [
@@ -648,6 +650,7 @@ def gen_crsp_sf(paths: DataPaths, freq):
             "common",
             "primaryexch",
             "conditionaltype",
+            "crsp_nyse",
             "gvkey",
             "iid",
             "exch_main",
@@ -2113,6 +2116,7 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     bidask::INT AS bidask,
                     primaryexch,
                     conditionaltype,
+                    crsp_nyse::INT AS crsp_nyse,
                     NULL::VARCHAR AS comp_tpci,
                     NULL::BIGINT AS comp_exchg,
                     'USD' AS curcd,
@@ -2153,6 +2157,7 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     CASE WHEN prcstd = 4 THEN 1 ELSE 0 END AS bidask,
                     NULL::VARCHAR AS primaryexch,
                     NULL::VARCHAR AS conditionaltype,
+                    0 AS crsp_nyse,
                     tpci AS comp_tpci,
                     exchg::BIGINT AS comp_exchg,
                     curcdd AS curcd,
@@ -2210,7 +2215,7 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
             COPY (
                 SELECT
                     id, permno, permco, gvkey, iid, excntry, exch_main, common,
-                    primary_sec, bidask, primaryexch, conditionaltype, comp_tpci, comp_exchg,
+                    primary_sec, bidask, primaryexch, conditionaltype, crsp_nyse, comp_tpci, comp_exchg,
                     curcd, fx, date, eom, adjfct, shares, me, me_company, prc, prc_local,
                     prc_high, prc_low, dolvol, tvol, ret, ret_local, ret_exc, ret_lag_dif,
                     div_tot, div_cash, div_spc, source_crsp, ret_exc_lead1m, obs_main
@@ -2696,8 +2701,7 @@ def nyse_size_cutoffs(paths: DataPaths, data_path):
                 QUANTILE_DISC(me, 0.50)     AS nyse_p50,
                 QUANTILE_DISC(me, 0.80)     AS nyse_p80
             FROM self
-            WHERE  primaryexch = 'N'
-                AND conditionaltype = 'RW'
+            WHERE  crsp_nyse   = 1
                 AND obs_main   = 1
                 AND exch_main  = 1
                 AND primary_sec= 1
@@ -6457,13 +6461,7 @@ def sort_ff_style(char, min_stocks_bp, min_stocks_pf, date_col, data, sf):
     # print(f"Executing sort_ff_style for {char}", flush=True)
     c1 = (
         ((col("size_grp_l").is_in(["small", "large", "mega"])) & (col("excntry_l") != "USA"))
-        | (
-            (
-                ((col("primaryexch_l") == "N") & (col("conditionaltype_l") == "RW"))
-                | (col("comp_exchg_l") == 11)
-            )
-            & (col("excntry_l") == "USA")
-        )
+        | (((col("crsp_nyse_l") == 1) | (col("comp_exchg_l") == 11)) & (col("excntry_l") == "USA"))
     ) & col(f"{char}_l").is_not_null()
     char_pf_exp = (
         pl.when(col(f"{char}_l") >= col("bp_p70"))
@@ -6552,8 +6550,7 @@ def ap_factors(
     sf_cond = (col("ret_lag_dif") == 1) if freq == "m" else (col("ret_lag_dif") <= 5)
     lag_vars = [
         "comp_exchg",
-        "primaryexch",
-        "conditionaltype",
+        "crsp_nyse",
         "exch_main",
         "obs_main",
         "common",
@@ -9179,8 +9176,7 @@ def portfolios(
             "eom",
             "source_crsp",
             "comp_exchg",
-            "primaryexch",
-            "conditionaltype",
+            "crsp_nyse",
             "size_grp",
             "ret_exc",
             "ret_exc_lead1m",
@@ -9202,19 +9198,14 @@ def portfolios(
         "source_crsp",
         "size_grp",
         "excntry",
-        "primaryexch",
-        "conditionaltype",
+        "crsp_nyse",
     }
     cast_cols = [c for c in columns if c not in cast_exclude]
 
     if bps == "nyse":
         bp_stock_expr = (
-            (
-                (pl.col("primaryexch") == "N")
-                & (pl.col("conditionaltype") == "RW")
-                & pl.col("comp_exchg").is_null()
-            )
-            | ((pl.col("comp_exchg") == 11) & pl.col("primaryexch").is_null())
+            ((pl.col("crsp_nyse") == 1) & pl.col("comp_exchg").is_null())
+            | ((pl.col("comp_exchg") == 11) & (pl.col("crsp_nyse") != 1))
         ).alias("bp_stock")
     else:  # "non_mc"
         bp_stock_expr = pl.col("size_grp").is_in(["mega", "large", "small"]).alias("bp_stock")

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -606,24 +606,12 @@ def gen_crsp_sf(paths: DataPaths, freq):
         & (issuertype_expr.isin(["ACOR", "CORP"]))
     )
 
-    shrcd_expr = ibis.cases(
-        (is_common_expr, 10),
-        else_=ibis.null(),
-    ).cast("int32")
-
     primaryexch_expr = sf.primaryexch
     conditionaltype_expr = sf.conditionaltype
 
     exch_main_expr = (primaryexch_expr.isin(["A", "N", "Q"]) & (conditionaltype_expr == "RW")).cast(
         "int32"
     )
-
-    exchcd_expr = ibis.cases(
-        ((primaryexch_expr == "N") & (conditionaltype_expr == "RW"), 1),
-        ((primaryexch_expr == "A") & (conditionaltype_expr == "RW"), 2),
-        ((primaryexch_expr == "Q") & (conditionaltype_expr == "RW"), 3),
-        else_=ibis.null(),
-    ).cast("int32")
 
     result = full_join.mutate(
         date=date_expr,
@@ -638,9 +626,10 @@ def gen_crsp_sf(paths: DataPaths, freq):
         retx=retx_expr,
         cfacshr=cfacshr_expr,
         vol=vol_expr,
-        exchcd=exchcd_expr,
+        common=is_common_expr.cast("int32"),
+        primaryexch=primaryexch_expr,
+        conditionaltype=conditionaltype_expr,
         exch_main=exch_main_expr,
-        shrcd=shrcd_expr,
         gvkey=ccmxpf_lnkhist.gvkey,
     ).select(
         [
@@ -656,11 +645,12 @@ def gen_crsp_sf(paths: DataPaths, freq):
             "vol",
             "prc_high",
             "prc_low",
-            "exchcd",
+            "common",
+            "primaryexch",
+            "conditionaltype",
             "gvkey",
             "iid",
             "exch_main",
-            "shrcd",
             "me",
             "ticker",
         ]
@@ -1082,21 +1072,21 @@ def compustat_fx(paths: DataPaths):
     return __fx1.collect()
 
 
-def adj_trd_vol_NASDAQ(datevar, col_to_adjust, exchg_var, exchg_val):
+def adj_trd_vol_NASDAQ(datevar, col_to_adjust, is_nasdaq_expr):
     """
     Description:
         Apply historic NASDAQ trade-volume adjustments (pre-decimalization reporting) to a volume column.
 
     Steps:
         1) Build date cutoffs: <2001-02-01, ≤2001-12-31, <2003-12-31.
-        2) If exchg_var == exchg_val (NASDAQ) and within windows, scale col_to_adjust by
+        2) If is_nasdaq_expr is true and within windows, scale col_to_adjust by
         1/2, 1/1.8, or 1/1.6 respectively; otherwise keep original.
         3) Return the adjusted expression aliased as the original column name.
 
     Output:
         Polars expression that yields adjusted trade volume for NASDAQ histories.
     """
-    c1 = col(exchg_var) == exchg_val
+    c1 = is_nasdaq_expr
     c2 = col(datevar) < pl.datetime(2001, 2, 1)
     c3 = col(datevar) <= pl.datetime(2001, 12, 31)
     c4 = col(datevar) < pl.datetime(2003, 12, 31)
@@ -1934,7 +1924,13 @@ def prepare_crsp_sf(paths: DataPaths, freq):
             ]
             + [col("vol").cast(pl.Int64)]
         )
-        .with_columns(adj_trd_vol_NASDAQ("date", "vol", "exchcd", 3))
+        .with_columns(
+            adj_trd_vol_NASDAQ(
+                "date",
+                "vol",
+                (pl.col("primaryexch") == "Q") & (pl.col("conditionaltype") == "RW"),
+            )
+        )
         .sort(["permno", "date"])
         .with_columns(
             dolvol=col("prc").abs() * col("vol"),
@@ -2112,11 +2108,11 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     permno AS id, permno, permco, gvkey, iid,
                     'USA' AS excntry,
                     exch_main::INT AS exch_main,
-                    CASE WHEN shrcd IN (10, 11, 12) THEN 1 ELSE 0 END AS common,
+                    common::INT AS common,
                     1 AS primary_sec,
                     bidask::INT AS bidask,
-                    shrcd::DOUBLE AS crsp_shrcd,
-                    exchcd::DOUBLE AS crsp_exchcd,
+                    primaryexch,
+                    conditionaltype,
                     NULL::VARCHAR AS comp_tpci,
                     NULL::BIGINT AS comp_exchg,
                     'USD' AS curcd,
@@ -2155,8 +2151,8 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                     CASE WHEN tpci = '0' THEN 1 ELSE 0 END AS common,
                     primary_sec::INT AS primary_sec,
                     CASE WHEN prcstd = 4 THEN 1 ELSE 0 END AS bidask,
-                    NULL::DOUBLE AS crsp_shrcd,
-                    NULL::DOUBLE AS crsp_exchcd,
+                    NULL::VARCHAR AS primaryexch,
+                    NULL::VARCHAR AS conditionaltype,
                     tpci AS comp_tpci,
                     exchg::BIGINT AS comp_exchg,
                     curcdd AS curcd,
@@ -2214,7 +2210,7 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
             COPY (
                 SELECT
                     id, permno, permco, gvkey, iid, excntry, exch_main, common,
-                    primary_sec, bidask, crsp_shrcd, crsp_exchcd, comp_tpci, comp_exchg,
+                    primary_sec, bidask, primaryexch, conditionaltype, comp_tpci, comp_exchg,
                     curcd, fx, date, eom, adjfct, shares, me, me_company, prc, prc_local,
                     prc_high, prc_low, dolvol, tvol, ret, ret_local, ret_exc, ret_lag_dif,
                     div_tot, div_cash, div_spc, source_crsp, ret_exc_lead1m, obs_main
@@ -2247,7 +2243,7 @@ def combine_crsp_comp_sf(paths: DataPaths) -> None:
                         permno AS id,
                         'USA' AS excntry,
                         exch_main::INT AS exch_main,
-                        CASE WHEN shrcd IN (10, 11, 12) THEN 1 ELSE 0 END AS common,
+                        common::INT AS common,
                         1 AS primary_sec,
                         bidask::INT AS bidask,
                         'USD' AS curcd,
@@ -2700,7 +2696,8 @@ def nyse_size_cutoffs(paths: DataPaths, data_path):
                 QUANTILE_DISC(me, 0.50)     AS nyse_p50,
                 QUANTILE_DISC(me, 0.80)     AS nyse_p80
             FROM self
-            WHERE  crsp_exchcd = 1
+            WHERE  primaryexch = 'N'
+                AND conditionaltype = 'RW'
                 AND obs_main   = 1
                 AND exch_main  = 1
                 AND primary_sec= 1
@@ -6461,7 +6458,10 @@ def sort_ff_style(char, min_stocks_bp, min_stocks_pf, date_col, data, sf):
     c1 = (
         ((col("size_grp_l").is_in(["small", "large", "mega"])) & (col("excntry_l") != "USA"))
         | (
-            ((col("crsp_exchcd_l") == 1) | (col("comp_exchg_l") == 11))
+            (
+                ((col("primaryexch_l") == "N") & (col("conditionaltype_l") == "RW"))
+                | (col("comp_exchg_l") == 11)
+            )
             & (col("excntry_l") == "USA")
         )
     ) & col(f"{char}_l").is_not_null()
@@ -6552,7 +6552,8 @@ def ap_factors(
     sf_cond = (col("ret_lag_dif") == 1) if freq == "m" else (col("ret_lag_dif") <= 5)
     lag_vars = [
         "comp_exchg",
-        "crsp_exchcd",
+        "primaryexch",
+        "conditionaltype",
         "exch_main",
         "obs_main",
         "common",
@@ -9178,7 +9179,8 @@ def portfolios(
             "eom",
             "source_crsp",
             "comp_exchg",
-            "crsp_exchcd",
+            "primaryexch",
+            "conditionaltype",
             "size_grp",
             "ret_exc",
             "ret_exc_lead1m",
@@ -9194,13 +9196,25 @@ def portfolios(
     # polars push predicate/null filters into the parquet reader (skipping row
     # groups on real production files) and fuse the ~15 intermediate steps into
     # one pass instead of allocating ~15 intermediate DataFrames.
-    cast_exclude = {"id", "eom", "source_crsp", "size_grp", "excntry"}
+    cast_exclude = {
+        "id",
+        "eom",
+        "source_crsp",
+        "size_grp",
+        "excntry",
+        "primaryexch",
+        "conditionaltype",
+    }
     cast_cols = [c for c in columns if c not in cast_exclude]
 
     if bps == "nyse":
         bp_stock_expr = (
-            ((pl.col("crsp_exchcd") == 1) & pl.col("comp_exchg").is_null())
-            | ((pl.col("comp_exchg") == 11) & pl.col("crsp_exchcd").is_null())
+            (
+                (pl.col("primaryexch") == "N")
+                & (pl.col("conditionaltype") == "RW")
+                & pl.col("comp_exchg").is_null()
+            )
+            | ((pl.col("comp_exchg") == 11) & pl.col("primaryexch").is_null())
         ).alias("bp_stock")
     else:  # "non_mc"
         bp_stock_expr = pl.col("size_grp").is_in(["mega", "large", "small"]).alias("bp_stock")

--- a/tests/fixtures/portfolio_legacy.py
+++ b/tests/fixtures/portfolio_legacy.py
@@ -80,7 +80,8 @@ def portfolios(
             "eom",
             "source_crsp",
             "comp_exchg",
-            "crsp_exchcd",
+            "primaryexch",
+            "conditionaltype",
             "size_grp",
             "ret_exc",
             "ret_exc_lead1m",
@@ -371,7 +372,8 @@ def portfolios(
                         "ret_exc_lead1m",
                         "me",
                         "me_cap",
-                        "crsp_exchcd",
+                        "primaryexch",
+                        "conditionaltype",
                         "comp_exchg",
                     ]
                 )
@@ -384,8 +386,12 @@ def portfolios(
             # Create 'bp_stock' column for NYSE criteria
             sub = sub.with_columns(
                 (
-                    ((pl.col("crsp_exchcd") == 1) & pl.col("comp_exchg").is_null())
-                    | ((pl.col("comp_exchg") == 11) & pl.col("crsp_exchcd").is_null())
+                    (
+                        (pl.col("primaryexch") == "N")
+                        & (pl.col("conditionaltype") == "RW")
+                        & pl.col("comp_exchg").is_null()
+                    )
+                    | ((pl.col("comp_exchg") == 11) & pl.col("primaryexch").is_null())
                 ).alias("bp_stock")
             )
 

--- a/tests/unit/portfolio/conftest.py
+++ b/tests/unit/portfolio/conftest.py
@@ -189,10 +189,13 @@ def make_country_characteristics(
         p=[0.10, 0.25, 0.35, 0.20, 0.10],
     ).tolist()
     source_crsp_per_id: list[int] = rng.choice([0, 1], size=n_ids, p=[0.4, 0.6]).tolist()
-    crsp_exchcd_choices = rng.choice([1, 2, 3], size=n_ids).tolist()
+    primaryexch_choices = rng.choice(["N", "A", "Q"], size=n_ids).tolist()
     comp_exchg_choices = rng.choice([11, 12, 13], size=n_ids).tolist()
-    crsp_exchcd_per_id: list[int | None] = [
-        int(crsp_exchcd_choices[i]) if source_crsp_per_id[i] == 1 else None for i in range(n_ids)
+    primaryexch_per_id: list[str | None] = [
+        primaryexch_choices[i] if source_crsp_per_id[i] == 1 else None for i in range(n_ids)
+    ]
+    conditionaltype_per_id: list[str | None] = [
+        "RW" if primaryexch_per_id[i] is not None else None for i in range(n_ids)
     ]
     comp_exchg_per_id: list[int | None] = [
         int(comp_exchg_choices[i]) if source_crsp_per_id[i] == 0 else None for i in range(n_ids)
@@ -205,7 +208,8 @@ def make_country_characteristics(
     eom_col: list[date] = []
     sg_col: list[str] = []
     sc_col: list[int] = []
-    ce_col: list[int | None] = []
+    pe_col: list[str | None] = []
+    ct_col: list[str | None] = []
     cx_col: list[int | None] = []
     gics_col: list[str] = []
     ff49_col: list[int] = []
@@ -215,7 +219,8 @@ def make_country_characteristics(
             eom_col.append(eom)
             sg_col.append(size_grps_per_id[i])
             sc_col.append(int(source_crsp_per_id[i]))
-            ce_col.append(crsp_exchcd_per_id[i])
+            pe_col.append(primaryexch_per_id[i])
+            ct_col.append(conditionaltype_per_id[i])
             cx_col.append(comp_exchg_per_id[i])
             gics_col.append(gics_per_id[i])
             ff49_col.append(int(ff49_per_id[i]))
@@ -237,7 +242,8 @@ def make_country_characteristics(
             "eom": pl.Series("eom", eom_col, dtype=pl.Date),
             "source_crsp": pl.Series("source_crsp", sc_col, dtype=pl.Int64),
             "comp_exchg": pl.Series("comp_exchg", cx_col, dtype=pl.Int64),
-            "crsp_exchcd": pl.Series("crsp_exchcd", ce_col, dtype=pl.Int64),
+            "primaryexch": pl.Series("primaryexch", pe_col, dtype=pl.Utf8),
+            "conditionaltype": pl.Series("conditionaltype", ct_col, dtype=pl.Utf8),
             "size_grp": pl.Series("size_grp", sg_col, dtype=pl.Utf8),
             "ret_exc": pl.Series("ret_exc", ret_exc, dtype=pl.Float64),
             "ret_exc_lead1m": pl.Series("ret_exc_lead1m", ret_exc_lead1m, dtype=pl.Float64),
@@ -443,17 +449,17 @@ def make_known_monotone_dataset(
 
     size_grps = rng.choice(["mega", "large", "small", "nano"], size=n_ids).tolist()
     source_crsp = rng.choice([0, 1], size=n_ids, p=[0.4, 0.6]).tolist()
-    crsp_exchcd_raw = rng.choice([1, 2, 3], size=n_ids).tolist()
+    primaryexch_raw = rng.choice(["N", "A", "Q"], size=n_ids).tolist()
     comp_exchg_raw = rng.choice([11, 12, 13], size=n_ids).tolist()
     gics_sectors = rng.choice([10, 15, 20, 25], size=n_ids).tolist()
     ff49_per_id = rng.choice([1, 5, 10, 15, 20], size=n_ids).tolist()
 
     sg_col = [size_grps[(i - 1) % n_ids] for i in id_col]
     sc_col = [int(source_crsp[(i - 1) % n_ids]) for i in id_col]
-    ce_col = [
-        int(crsp_exchcd_raw[(i - 1) % n_ids]) if sc_col[k] == 1 else None
-        for k, i in enumerate(id_col)
+    pe_col = [
+        primaryexch_raw[(i - 1) % n_ids] if sc_col[k] == 1 else None for k, i in enumerate(id_col)
     ]
+    ct_col = ["RW" if pe is not None else None for pe in pe_col]
     cx_col = [
         int(comp_exchg_raw[(i - 1) % n_ids]) if sc_col[k] == 0 else None
         for k, i in enumerate(id_col)
@@ -478,7 +484,8 @@ def make_known_monotone_dataset(
             "me_cap": pl.Series("me_cap", me_cap, dtype=pl.Float64),
             "nyse_p80": pl.Series("nyse_p80", nyse_p80, dtype=pl.Float64),
             "comp_exchg": pl.Series("comp_exchg", cx_col, dtype=pl.Int64),
-            "crsp_exchcd": pl.Series("crsp_exchcd", ce_col, dtype=pl.Int64),
+            "primaryexch": pl.Series("primaryexch", pe_col, dtype=pl.Utf8),
+            "conditionaltype": pl.Series("conditionaltype", ct_col, dtype=pl.Utf8),
             "ret_exc": pl.Series("ret_exc", ret_exc, dtype=pl.Float64),
             "ret_exc_lead1m": pl.Series("ret_exc_lead1m", ret_exc_lead1m, dtype=pl.Float64),
             "ff49": pl.Series("ff49", ff49_col, dtype=pl.Int64),
@@ -499,7 +506,8 @@ def make_breakpoint_divergent_dataset(seed: int = 42) -> pl.DataFrame:
     # First half: NYSE-flagged but micro-cap. Second half: non-NYSE but large.
     size_grps = (["micro"] * half) + (["large"] * (n_ids - half))
     source_crsp = ([1] * half) + ([0] * (n_ids - half))
-    crsp_exchcd = ([1] * half) + ([None] * (n_ids - half))
+    primaryexch = (["N"] * half) + ([None] * (n_ids - half))
+    conditionaltype = (["RW"] * half) + ([None] * (n_ids - half))
     comp_exchg = ([None] * half) + ([12] * (n_ids - half))
 
     n_rows = n_ids * n_months
@@ -507,7 +515,8 @@ def make_breakpoint_divergent_dataset(seed: int = 42) -> pl.DataFrame:
     eom_col: list[date] = []
     sg_col: list[str] = []
     sc_col: list[int] = []
-    ce_col: list[int | None] = []
+    pe_col: list[str | None] = []
+    ct_col: list[str | None] = []
     cx_col: list[int | None] = []
     for eom in eoms:
         for i in range(n_ids):
@@ -515,7 +524,8 @@ def make_breakpoint_divergent_dataset(seed: int = 42) -> pl.DataFrame:
             eom_col.append(eom)
             sg_col.append(size_grps[i])
             sc_col.append(source_crsp[i])
-            ce_col.append(crsp_exchcd[i])
+            pe_col.append(primaryexch[i])
+            ct_col.append(conditionaltype[i])
             cx_col.append(comp_exchg[i])
 
     me = np.exp(rng.normal(7.0, 1.0, n_rows))
@@ -532,7 +542,8 @@ def make_breakpoint_divergent_dataset(seed: int = 42) -> pl.DataFrame:
             "excntry": pl.Series("excntry", ["USA"] * n_rows, dtype=pl.Utf8),
             "source_crsp": pl.Series("source_crsp", sc_col, dtype=pl.Int64),
             "comp_exchg": pl.Series("comp_exchg", cx_col, dtype=pl.Int64),
-            "crsp_exchcd": pl.Series("crsp_exchcd", ce_col, dtype=pl.Int64),
+            "primaryexch": pl.Series("primaryexch", pe_col, dtype=pl.Utf8),
+            "conditionaltype": pl.Series("conditionaltype", ct_col, dtype=pl.Utf8),
             "size_grp": pl.Series("size_grp", sg_col, dtype=pl.Utf8),
             "me": pl.Series("me", me, dtype=pl.Float64),
             "ret_exc": pl.Series("ret_exc", ret_exc, dtype=pl.Float64),

--- a/tests/unit/portfolio/conftest.py
+++ b/tests/unit/portfolio/conftest.py
@@ -244,6 +244,14 @@ def make_country_characteristics(
             "comp_exchg": pl.Series("comp_exchg", cx_col, dtype=pl.Int64),
             "primaryexch": pl.Series("primaryexch", pe_col, dtype=pl.Utf8),
             "conditionaltype": pl.Series("conditionaltype", ct_col, dtype=pl.Utf8),
+            "crsp_nyse": pl.Series(
+                "crsp_nyse",
+                [
+                    1 if pe == "N" and ct == "RW" else 0
+                    for pe, ct in zip(pe_col, ct_col, strict=True)
+                ],
+                dtype=pl.Int32,
+            ),
             "size_grp": pl.Series("size_grp", sg_col, dtype=pl.Utf8),
             "ret_exc": pl.Series("ret_exc", ret_exc, dtype=pl.Float64),
             "ret_exc_lead1m": pl.Series("ret_exc_lead1m", ret_exc_lead1m, dtype=pl.Float64),
@@ -486,6 +494,14 @@ def make_known_monotone_dataset(
             "comp_exchg": pl.Series("comp_exchg", cx_col, dtype=pl.Int64),
             "primaryexch": pl.Series("primaryexch", pe_col, dtype=pl.Utf8),
             "conditionaltype": pl.Series("conditionaltype", ct_col, dtype=pl.Utf8),
+            "crsp_nyse": pl.Series(
+                "crsp_nyse",
+                [
+                    1 if pe == "N" and ct == "RW" else 0
+                    for pe, ct in zip(pe_col, ct_col, strict=True)
+                ],
+                dtype=pl.Int32,
+            ),
             "ret_exc": pl.Series("ret_exc", ret_exc, dtype=pl.Float64),
             "ret_exc_lead1m": pl.Series("ret_exc_lead1m", ret_exc_lead1m, dtype=pl.Float64),
             "ff49": pl.Series("ff49", ff49_col, dtype=pl.Int64),
@@ -532,8 +548,8 @@ def make_breakpoint_divergent_dataset(seed: int = 42) -> pl.DataFrame:
     ret_exc = rng.normal(0.0, 0.05, n_rows)
     ret_exc_lead1m = rng.normal(0.0, 0.05, n_rows)
     char_a = rng.normal(0.0, 1.0, n_rows)
-    gics_col = ["20101010"] * n_rows
-    ff49_col = [1] * n_rows
+    gics_col_s = ["20101010"] * n_rows
+    ff49_col_s = [1] * n_rows
 
     return pl.DataFrame(
         {
@@ -544,12 +560,20 @@ def make_breakpoint_divergent_dataset(seed: int = 42) -> pl.DataFrame:
             "comp_exchg": pl.Series("comp_exchg", cx_col, dtype=pl.Int64),
             "primaryexch": pl.Series("primaryexch", pe_col, dtype=pl.Utf8),
             "conditionaltype": pl.Series("conditionaltype", ct_col, dtype=pl.Utf8),
+            "crsp_nyse": pl.Series(
+                "crsp_nyse",
+                [
+                    1 if pe == "N" and ct == "RW" else 0
+                    for pe, ct in zip(pe_col, ct_col, strict=True)
+                ],
+                dtype=pl.Int32,
+            ),
             "size_grp": pl.Series("size_grp", sg_col, dtype=pl.Utf8),
             "me": pl.Series("me", me, dtype=pl.Float64),
             "ret_exc": pl.Series("ret_exc", ret_exc, dtype=pl.Float64),
             "ret_exc_lead1m": pl.Series("ret_exc_lead1m", ret_exc_lead1m, dtype=pl.Float64),
-            "ff49": pl.Series("ff49", ff49_col, dtype=pl.Int64),
-            "gics": pl.Series("gics", gics_col, dtype=pl.Utf8),
+            "ff49": pl.Series("ff49", ff49_col_s, dtype=pl.Int64),
+            "gics": pl.Series("gics", gics_col_s, dtype=pl.Utf8),
             "char_a": pl.Series("char_a", char_a, dtype=pl.Float64),
         }
     )

--- a/tests/unit/portfolio/test_breakpoints_and_sources.py
+++ b/tests/unit/portfolio/test_breakpoints_and_sources.py
@@ -89,10 +89,10 @@ class TestBpsModes:
 
         ``bp_stock`` is internal, so we replicate the NYSE bp_stock
         expression and confirm it picks out the rows where either
-        ``crsp_exchcd == 1`` (and ``comp_exchg`` null) or
-        ``comp_exchg == 11`` (and ``crsp_exchcd`` null). In the divergent
-        dataset, only the micros (with ``crsp_exchcd=1``, ``comp_exchg``
-        null) match.
+        ``primaryexch == "N"`` and ``conditionaltype == "RW"`` (and ``comp_exchg`` null) or
+        ``comp_exchg == 11`` (and ``primaryexch`` null). In the divergent
+        dataset, only the micros (with ``primaryexch="N"``, ``conditionaltype="RW"``,
+        ``comp_exchg`` null) match.
         """
         excntry = "USA"
         df = make_breakpoint_divergent_dataset(seed=0)
@@ -103,12 +103,16 @@ class TestBpsModes:
         # Replicate the nyse bp_stock expression from portfolio.py:288-291.
         bp_stock = df.select(
             (
-                ((pl.col("crsp_exchcd") == 1) & pl.col("comp_exchg").is_null())
-                | ((pl.col("comp_exchg") == 11) & pl.col("crsp_exchcd").is_null())
+                (
+                    (pl.col("primaryexch") == "N")
+                    & (pl.col("conditionaltype") == "RW")
+                    & pl.col("comp_exchg").is_null()
+                )
+                | ((pl.col("comp_exchg") == 11) & pl.col("primaryexch").is_null())
             ).alias("bp_stock"),
             pl.col("size_grp"),
         )
-        # Only micros (with crsp_exchcd=1, comp_exchg null) are NYSE flagged.
+        # Only micros (with primaryexch=N, conditionaltype=RW, comp_exchg null) are NYSE flagged.
         n_micro = bp_stock.filter(pl.col("size_grp") == "micro").height
         assert bp_stock.filter(pl.col("size_grp") == "micro")["bp_stock"].sum() == n_micro
         # Large rows have comp_exchg=12 (not NYSE) → not flagged.

--- a/tests/unit/test_aux_functions.py
+++ b/tests/unit/test_aux_functions.py
@@ -113,9 +113,21 @@ def test_gen_crsp_sf_exposes_ticker_after_senames_join(freq: str, test_paths) ->
 
     df = result.to_polars().sort("date")
 
-    assert {"permno", "permco", "date", "me", "ticker"}.issubset(df.columns), (
-        f"Missing expected columns from output: {df.columns}"
-    )
+    assert {
+        "permno",
+        "permco",
+        "date",
+        "me",
+        "ticker",
+        "common",
+        "primaryexch",
+        "conditionaltype",
+    }.issubset(df.columns), f"Missing expected columns from output: {df.columns}"
+
+    matched = df.filter(pl.col("date") == matched_date)
+    assert matched["common"][0] == 1
+    assert matched["primaryexch"][0] == "N"
+    assert matched["conditionaltype"][0] == "RW"
 
     ticker_by_date = {
         row["date"]: row["ticker"] for row in df.select(["date", "ticker"]).to_dicts()

--- a/tests/unit/test_combine_crsp_comp_sf.py
+++ b/tests/unit/test_combine_crsp_comp_sf.py
@@ -57,44 +57,52 @@ def _make_crsp_msf(tmp: Path, n_permnos: int = 500) -> None:
     gvkeys = [f"{p % 100000:06d}" if _RNG.rand() > 0.3 else None for p in permno]
     iids = ["01" if _RNG.rand() > 0.1 else None for _ in range(n)]
 
-    df = pl.DataFrame(
-        {
-            "permno": permno,
-            "permco": [p + 10000 for p in permno],
-            "gvkey": gvkeys,
-            "iid": iids,
-            "exch_main": _RNG.choice([1, 2, 3], n).tolist(),
-            "bidask": _RNG.choice([0, 1], n).tolist(),
-            "common": _RNG.choice([0, 1], n).tolist(),
-            "primaryexch": _RNG.choice(["N", "A", "Q", None], n).tolist(),
-            "conditionaltype": _RNG.choice(["RW", "RW", "RW", None], n).tolist(),
-            "date": dates,
-            "cfacshr": _random_float_col(n, 0.02),
-            "shrout": _random_float_col(n, 0.02),
-            "me": _random_float_col(n),
-            "me_company": _random_float_col(n),
-            "prc": _random_float_col(n),
-            "prc_high": _random_float_col(n),
-            "prc_low": _random_float_col(n),
-            "dolvol": _random_float_col(n),
-            "vol": _random_float_col(n),
-            "ret": _random_float_col(n),
-            "ret_exc": _random_float_col(n),
-            "div_tot": _random_float_col(n, 0.8),
-        }
-    ).cast(
-        {
-            "permno": pl.Int64,
-            "permco": pl.Int64,
-            "gvkey": pl.Utf8,
-            "iid": pl.Utf8,
-            "exch_main": pl.Int64,
-            "bidask": pl.Int64,
-            "common": pl.Int64,
-            "primaryexch": pl.Utf8,
-            "conditionaltype": pl.Utf8,
-            "date": pl.Date,
-        }
+    df = (
+        pl.DataFrame(
+            {
+                "permno": permno,
+                "permco": [p + 10000 for p in permno],
+                "gvkey": gvkeys,
+                "iid": iids,
+                "exch_main": _RNG.choice([1, 2, 3], n).tolist(),
+                "bidask": _RNG.choice([0, 1], n).tolist(),
+                "common": _RNG.choice([0, 1], n).tolist(),
+                "primaryexch": _RNG.choice(["N", "A", "Q", None], n).tolist(),
+                "conditionaltype": _RNG.choice(["RW", "RW", "RW", None], n).tolist(),
+                "date": dates,
+                "cfacshr": _random_float_col(n, 0.02),
+                "shrout": _random_float_col(n, 0.02),
+                "me": _random_float_col(n),
+                "me_company": _random_float_col(n),
+                "prc": _random_float_col(n),
+                "prc_high": _random_float_col(n),
+                "prc_low": _random_float_col(n),
+                "dolvol": _random_float_col(n),
+                "vol": _random_float_col(n),
+                "ret": _random_float_col(n),
+                "ret_exc": _random_float_col(n),
+                "div_tot": _random_float_col(n, 0.8),
+            }
+        )
+        .cast(
+            {
+                "permno": pl.Int64,
+                "permco": pl.Int64,
+                "gvkey": pl.Utf8,
+                "iid": pl.Utf8,
+                "exch_main": pl.Int64,
+                "bidask": pl.Int64,
+                "common": pl.Int64,
+                "primaryexch": pl.Utf8,
+                "conditionaltype": pl.Utf8,
+                "date": pl.Date,
+            }
+        )
+        .with_columns(
+            crsp_nyse=((pl.col("primaryexch") == "N") & (pl.col("conditionaltype") == "RW")).cast(
+                pl.Int32
+            )
+        )
     )
     df.write_parquet(tmp / "crsp_msf.parquet")
 
@@ -328,6 +336,7 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
             div_cash=fl_none(),
             div_spc=fl_none(),
             source_crsp=pl.lit(1),
+            crsp_nyse=pl.col("crsp_nyse").cast(pl.Int32),
         )
         .rename(
             {
@@ -356,6 +365,7 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
             bidask=pl.when(pl.col("prcstd") == 4).then(pl.lit(1)).otherwise(pl.lit(0)),
             primaryexch=pl.lit(None).cast(pl.Utf8),
             conditionaltype=pl.lit(None).cast(pl.Utf8),
+            crsp_nyse=pl.lit(0).cast(pl.Int32),
             me_company=pl.col("me"),
             source_crsp=pl.lit(0),
             ret_lag_dif=pl.col("ret_lag_dif").cast(pl.Int64),
@@ -386,6 +396,7 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
         "bidask",
         "primaryexch",
         "conditionaltype",
+        "crsp_nyse",
         "comp_tpci",
         "comp_exchg",
         "curcd",
@@ -875,6 +886,7 @@ class TestUnionAndLead:
             "bidask",
             "primaryexch",
             "conditionaltype",
+            "crsp_nyse",
             "comp_tpci",
             "comp_exchg",
             "curcd",
@@ -1375,6 +1387,7 @@ class TestEdgeCases:
                 "common": [1, 1],
                 "primaryexch": ["N", "N"],
                 "conditionaltype": ["RW", "RW"],
+                "crsp_nyse": [1, 1],
                 "date": [date(2020, 2, 15), date(2019, 2, 15)],
                 "cfacshr": [1.0, 1.0],
                 "shrout": [100.0, 100.0],
@@ -1398,6 +1411,7 @@ class TestEdgeCases:
                 "common": pl.Int64,
                 "primaryexch": pl.Utf8,
                 "conditionaltype": pl.Utf8,
+                "crsp_nyse": pl.Int32,
                 "date": pl.Date,
             }
         )

--- a/tests/unit/test_combine_crsp_comp_sf.py
+++ b/tests/unit/test_combine_crsp_comp_sf.py
@@ -65,8 +65,9 @@ def _make_crsp_msf(tmp: Path, n_permnos: int = 500) -> None:
             "iid": iids,
             "exch_main": _RNG.choice([1, 2, 3], n).tolist(),
             "bidask": _RNG.choice([0, 1], n).tolist(),
-            "shrcd": _RNG.choice([10, 11, 12, 14, 31, None], n).tolist(),
-            "exchcd": _RNG.choice([1, 2, 3, 4], n).tolist(),
+            "common": _RNG.choice([0, 1], n).tolist(),
+            "primaryexch": _RNG.choice(["N", "A", "Q", None], n).tolist(),
+            "conditionaltype": _RNG.choice(["RW", "RW", "RW", None], n).tolist(),
             "date": dates,
             "cfacshr": _random_float_col(n, 0.02),
             "shrout": _random_float_col(n, 0.02),
@@ -89,8 +90,9 @@ def _make_crsp_msf(tmp: Path, n_permnos: int = 500) -> None:
             "iid": pl.Utf8,
             "exch_main": pl.Int64,
             "bidask": pl.Int64,
-            "shrcd": pl.Int64,
-            "exchcd": pl.Int64,
+            "common": pl.Int64,
+            "primaryexch": pl.Utf8,
+            "conditionaltype": pl.Utf8,
             "date": pl.Date,
         }
     )
@@ -197,7 +199,7 @@ def _make_crsp_dsf(tmp: Path, n_permnos: int = 200) -> None:
             "permno": permno,
             "exch_main": _RNG.choice([1, 2, 3], n).tolist(),
             "bidask": _RNG.choice([0, 1], n).tolist(),
-            "shrcd": _RNG.choice([10, 11, 12, 14, 31], n).tolist(),
+            "common": _RNG.choice([0, 1], n).tolist(),
             "date": dates,
             "cfacshr": _random_float_col(n, 0.02),
             "shrout": _random_float_col(n, 0.02),
@@ -215,7 +217,7 @@ def _make_crsp_dsf(tmp: Path, n_permnos: int = 200) -> None:
             "permno": pl.Int64,
             "exch_main": pl.Int64,
             "bidask": pl.Int64,
-            "shrcd": pl.Int64,
+            "common": pl.Int64,
             "date": pl.Date,
         }
     )
@@ -312,7 +314,7 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
             bidask=pl.col("bidask").cast(pl.Int32),
             id=pl.col("permno"),
             excntry=pl.lit("USA"),
-            common=(pl.col("shrcd").is_in([10, 11, 12]).fill_null(bo_false())).cast(pl.Int32),
+            common=pl.col("common").cast(pl.Int32),
             primary_sec=pl.lit(1),
             comp_tpci=pl.lit(None).cast(pl.Utf8),
             comp_exchg=pl.lit(None).cast(pl.Int64),
@@ -329,8 +331,6 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
         )
         .rename(
             {
-                "shrcd": "crsp_shrcd",
-                "exchcd": "crsp_exchcd",
                 "cfacshr": "adjfct",
                 "shrout": "shares",
             }
@@ -354,8 +354,8 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
             permco=pl.lit(None).cast(pl.Int64),
             common=pl.when(pl.col("tpci") == "0").then(pl.lit(1)).otherwise(pl.lit(0)),
             bidask=pl.when(pl.col("prcstd") == 4).then(pl.lit(1)).otherwise(pl.lit(0)),
-            crsp_shrcd=fl_none(),
-            crsp_exchcd=fl_none(),
+            primaryexch=pl.lit(None).cast(pl.Utf8),
+            conditionaltype=pl.lit(None).cast(pl.Utf8),
             me_company=pl.col("me"),
             source_crsp=pl.lit(0),
             ret_lag_dif=pl.col("ret_lag_dif").cast(pl.Int64),
@@ -384,8 +384,8 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
         "common",
         "primary_sec",
         "bidask",
-        "crsp_shrcd",
-        "crsp_exchcd",
+        "primaryexch",
+        "conditionaltype",
         "comp_tpci",
         "comp_exchg",
         "curcd",
@@ -450,7 +450,7 @@ def _polars_combine_crsp_comp_sf(tmp: Path) -> tuple[pl.DataFrame, pl.DataFrame]
         .with_columns(
             id=pl.col("permno"),
             excntry=pl.lit("USA"),
-            common=(pl.col("shrcd").is_in([10, 11, 12]).fill_null(bo_false())).cast(pl.Int32),
+            common=pl.col("common").cast(pl.Int32),
             primary_sec=pl.lit(1),
             curcd=pl.lit("USD"),
             fx=pl.lit(1.0),
@@ -618,11 +618,11 @@ class TestCrspNormalization:
             permno AS id, permno, permco, gvkey, iid,
             'USA' AS excntry,
             exch_main::INT AS exch_main,
-            CASE WHEN shrcd IN (10, 11, 12) THEN 1 ELSE 0 END AS common,
+            common::INT AS common,
             1 AS primary_sec,
             bidask::INT AS bidask,
-            shrcd::DOUBLE AS crsp_shrcd,
-            exchcd::DOUBLE AS crsp_exchcd,
+            primaryexch,
+            conditionaltype,
             NULL::VARCHAR AS comp_tpci,
             NULL::BIGINT AS comp_exchg,
             'USD' AS curcd,
@@ -656,7 +656,7 @@ class TestCrspNormalization:
     def test_crsp_msf_common_flag(self, toy_dir: Path) -> None:
         raw = pl.read_parquet(toy_dir / "crsp_msf.parquet")
         df = _run_cte_on_parquet(toy_dir, self._CRSP_MSF_CTE)
-        expected = raw["shrcd"].is_in([10, 11, 12]).fill_null(False).cast(pl.Int32)
+        expected = raw["common"].cast(pl.Int32)
         assert (df["common"] == expected).all()
 
     def test_crsp_msf_eom_is_month_end(self, toy_dir: Path) -> None:
@@ -688,14 +688,11 @@ class TestCrspNormalization:
         assert df["comp_tpci"].is_null().all()
         assert df["comp_exchg"].is_null().all()
 
-    def test_crsp_msf_column_renames(self, toy_dir: Path) -> None:
+    def test_crsp_msf_ciz_field_passthrough(self, toy_dir: Path) -> None:
         raw = pl.read_parquet(toy_dir / "crsp_msf.parquet")
         df = _run_cte_on_parquet(toy_dir, self._CRSP_MSF_CTE)
-        np.testing.assert_allclose(
-            df["crsp_shrcd"].to_numpy(),
-            raw["shrcd"].cast(pl.Float64).to_numpy(),
-            equal_nan=True,
-        )
+        assert (df["primaryexch"] == raw["primaryexch"]).all()
+        assert (df["conditionaltype"] == raw["conditionaltype"]).all()
         np.testing.assert_allclose(
             df["adjfct"].to_numpy(),
             raw["cfacshr"].cast(pl.Float64).to_numpy(),
@@ -707,7 +704,7 @@ class TestCrspNormalization:
             SELECT
                 permno AS id, 'USA' AS excntry,
                 exch_main::INT AS exch_main,
-                CASE WHEN shrcd IN (10, 11, 12) THEN 1 ELSE 0 END AS common,
+                common::INT AS common,
                 1 AS primary_sec, bidask::INT AS bidask,
                 'USD' AS curcd, 1.0 AS fx,
                 date, last_day(date) AS eom,
@@ -876,8 +873,8 @@ class TestUnionAndLead:
             "common",
             "primary_sec",
             "bidask",
-            "crsp_shrcd",
-            "crsp_exchcd",
+            "primaryexch",
+            "conditionaltype",
             "comp_tpci",
             "comp_exchg",
             "curcd",
@@ -1375,8 +1372,9 @@ class TestEdgeCases:
                 "iid": [None, None],
                 "exch_main": [1, 1],
                 "bidask": [0, 0],
-                "shrcd": [10, 10],
-                "exchcd": [1, 1],
+                "common": [1, 1],
+                "primaryexch": ["N", "N"],
+                "conditionaltype": ["RW", "RW"],
                 "date": [date(2020, 2, 15), date(2019, 2, 15)],
                 "cfacshr": [1.0, 1.0],
                 "shrout": [100.0, 100.0],
@@ -1397,8 +1395,9 @@ class TestEdgeCases:
                 "permco": pl.Int64,
                 "exch_main": pl.Int64,
                 "bidask": pl.Int64,
-                "shrcd": pl.Int64,
-                "exchcd": pl.Int64,
+                "common": pl.Int64,
+                "primaryexch": pl.Utf8,
+                "conditionaltype": pl.Utf8,
                 "date": pl.Date,
             }
         )


### PR DESCRIPTION
## Summary

Closes #202.

Finish the CRSP V2 (CIZ) migration by removing synthesized V1 compatibility columns (`shrcd`, `exchcd`, `crsp_shrcd`, `crsp_exchcd`) and defining universe screens directly from native CIZ fields.

- **`gen_crsp_sf`**: emit `common`, `primaryexch`, and `conditionaltype` instead of reconstructed `shrcd`/`exchcd`
- **`prepare_crsp_sf`**: NASDAQ volume adjustment uses `(primaryexch == "Q") & (conditionaltype == "RW")`
- **`combine_crsp_comp_sf`**: read `common` from upstream; pass through `primaryexch`/`conditionaltype` in monthly world output
- **NYSE logic** (`nyse_size_cutoffs`, `sort_ff_style`, `ap_factors`, `portfolios`): replace `crsp_exchcd == 1` with `primaryexch == "N"` and `conditionaltype == "RW"` on CRSP rows; Compustat NYSE remains `comp_exchg == 11`
- **Tests & docs**: update unit/portfolio fixtures and `documentation/documentation.tex` / release notes

## Note

The old `shrcd IN (10, 11, 12)` screen was effectively `shrcd == 10` only (the shim never emitted 11 or 12). The new `common` flag and NYSE/NASDAQ predicates are logically equivalent to the prior reconstructed codes, so universe membership should be unchanged.

## Equivalence check

Compared `data/processed/portfolios/hml.parquet` (new) against `data-old/processed/portfolios/hml.parquet` (old), plus company-level characteristics spot checks.

### `hml.parquet` (portfolio returns)

Identical keys: 2,712,115 rows, 71 countries, 153 characteristics, date range 1926-01 to 2025-12. Zero key mismatches.

| Series | Correlation | Exact match | Max \|diff\| |
|--------|-------------|-------------|--------------|
| `ret_ew` | 0.9999996 | 99.10% | 0.046 |
| `ret_vw` | 0.9999994 | 98.80% | 0.054 |
| `ret_vw_cap` | 0.9999994 | 98.88% | 0.054 |

Every country's minimum correlation across all three return series is > 0.9999. Worst countries are small markets (NZL, ZAF, GRC); USA is effectively bit-identical (max \|diff\| ≈ 2e-5).

~1.2% of rows have any non-zero diff, but almost all are floating-point noise: only 15 rows have \|diff\| > 1e-10, and only 6 rows have \|diff\| > 1e-2. All 10 rows with \|ret_vw diff\| > 1e-4 are in NZL, ZAF, or GRC across four characteristics (`iskew_ff3_21d`, `ni_ivol`, `dolvol_126d`, `dolvol_var_126d`) — thin-stock edge cases, not systematic drift.

Non-return columns: `n_stocks` mismatches = 6 (all ±1 stock); `signal` diffs = 13,511 (almost entirely tiny `dolvol_126d` float noise; overall corr = 1.0).

### Characteristics (company-level spot check)

Expected schema change from CIZ migration: removed `crsp_shrcd`/`crsp_exchcd`; added `conditionaltype`/`primaryexch`. Row membership unchanged (e.g. USA `common` flag: 0 changes).

| Country | Stock-level diffs (meaningful) |
|---------|-------------------------------|
| USA | Only 6 chars with any \|diff\| > 1e-6 (`dolvol_126d`, `zero_trades_*`); max 2.7e-5 |
| NZL | All focus chars identical at stock level |
| ZAF | `iskew_ff3_21d` only real diff (corr 0.9999, 128 rows > 1e-6) |
| GRC | All focus chars identical at stock level |

10-company USA subset: all characteristics match within machine precision.

**Bottom line:** new pipeline output matches old extremely closely. Return correlations > 0.999999 overall; meaningful differences isolated to small-market edge cases with thin stock counts.

## Test plan

- [x] `uv run ruff check src/jkp/data/ tests/`
- [x] `uv run ruff format --check src/jkp/data/ tests/`
- [x] `uv run pytest tests/unit/` (659 passed)
- [x] Grep `src/` and `tests/` for `shrcd`, `exchcd`, `crsp_shrcd`, `crsp_exchcd` — zero hits
- [x] Equivalence check: `hml.parquet` return correlations > 0.999999; characteristics spot check (USA, NZL, ZAF, GRC) — see above
```
