### PR TITLE
perf: parallelize WRDS raw-table downloads (#194)

### DIFF
--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -1003,12 +1003,13 @@ def _attach_download_worker(
     task_errors: list[str],
     attach_errors: list[str],
     errors_lock: threading.Lock,
+    stop_event: threading.Event,
 ) -> None:
     """One parallel worker: open a private ATTACH connection and drain the task queue.
 
     Each task is a whole table or one date-range chunk. The worker holds exactly one WRDS
     connection (``threads=1`` keeps DuckDB from opening extra connections for a parallel scan)
-    and reuses it.
+    and reuses it. It stops pulling new tasks once ``stop_event`` is set (used to unwind on Ctrl-C).
 
     Failures are recorded (password-redacted) instead of raised, so one bad task doesn't abandon
     the rest. Attach failures and download (task) failures are kept in separate lists: because the
@@ -1028,14 +1029,14 @@ def _attach_download_worker(
             with errors_lock:
                 attach_errors.append(str(e))
                 print(
-                    f"Warning: a WRDS download worker failed to attach ({e}); "
-                    "continuing with the remaining worker(s).",
+                    f"Warning: a WRDS download worker failed to attach ({e}); continuing with the "
+                    "remaining worker(s). Press Ctrl-C to cancel and re-run for full parallelism.",
                     file=sys.stderr,
                     flush=True,
                 )
             return
         try:
-            while True:
+            while not stop_event.is_set():
                 try:
                     task = task_queue.get_nowait()
                 except queue.Empty:
@@ -1105,18 +1106,48 @@ def _download_tables_parallel(
     task_errors: list[str] = []
     attach_errors: list[str] = []
     errors_lock = threading.Lock()
+    stop_event = threading.Event()
     threads = [
         threading.Thread(
             target=_attach_download_worker,
-            args=(task_queue, conninfo, password, task_errors, attach_errors, errors_lock),
+            args=(
+                task_queue,
+                conninfo,
+                password,
+                task_errors,
+                attach_errors,
+                errors_lock,
+                stop_event,
+            ),
             name=f"wrds-download-{i}",
         )
         for i in range(workers)
     ]
     for t in threads:
         t.start()
-    for t in threads:
-        t.join()
+    # Join with a timeout so the main thread stays responsive to Ctrl-C (a plain join() would defer
+    # the KeyboardInterrupt until the whole download finished). On Ctrl-C, ask the workers to stop
+    # pulling new tasks; they finish the download already in flight and exit.
+    #
+    # We deliberately do NOT call DuckDB's con.interrupt() to abort an in-flight COPY mid-transfer:
+    # it would require sharing every worker's connection with this thread plus telling a user-cancel
+    # apart from a real failure, and its effect on a COPY blocked in the postgres extension's network
+    # read is unverified. Consequently a Ctrl-C takes effect only after the currently-downloading
+    # task(s) finish -- bounded by one chunk, not the entire remaining download.
+    try:
+        for t in threads:
+            while t.is_alive():
+                t.join(timeout=0.5)
+    except KeyboardInterrupt:
+        print(
+            "\nInterrupted: stopping after the in-flight download(s) finish...",
+            file=sys.stderr,
+            flush=True,
+        )
+        stop_event.set()
+        for t in threads:
+            t.join()
+        raise
 
     # A download failure means a table is missing -> always fatal.
     if task_errors:

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -989,7 +989,9 @@ def _remove_chunk_parts(filename: str) -> None:
     ones. The final (non-part) file itself is left untouched.
     """
     p = Path(filename)
-    for f in p.parent.glob(f"{p.stem}.part*{p.suffix}"):
+    # Match exactly what _chunk_path writes (.part00..part99) rather than `part*`, which would also
+    # sweep an unrelated file like `<stem>.partial.parquet`.
+    for f in p.parent.glob(f"{p.stem}.part[0-9][0-9]{p.suffix}"):
         with contextlib.suppress(FileNotFoundError):
             f.unlink()
 

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import functools
 import operator
 import os
+import queue
 import re
 import shutil
+import sys
+import threading
 import time
 import warnings
 from datetime import date
@@ -759,6 +763,133 @@ def download_wrds_table(
     """)
 
 
+# WRDS enforces a per-role PostgreSQL CONNECTION LIMIT (currently 7 for our account; see
+# `SELECT rolconnlimit FROM pg_roles WHERE rolname = current_user`). Each parallel worker holds
+# exactly one client connection (verified: with `SET threads = 1` and these tables being views,
+# one ATTACH == one TCP socket to wrds-pgdata), so the pool is capped below the limit to leave a
+# slot of headroom for any other WRDS session under the same login.
+#
+# NOTE for debugging: WRDS fronts PostgreSQL with pgpool, so `pg_stat_activity` reports the
+# server-side backend pool (it showed ~21 backends for 6 workers) -- that is NOT the client
+# connection count. The number that matters for the role limit is the client connections, which
+# equal the worker count (confirmed via the process's own sockets, e.g. psutil/`ss`).
+WRDS_MAX_CONNECTIONS = 7
+
+
+def _effective_download_workers(requested: int, n_tables: int) -> int:
+    """Clamp the requested worker count to a safe, useful range.
+
+    Never more workers than there are tables, and never more than WRDS allows concurrent
+    connections (minus one for headroom). A value of 1 (or less) means sequential download.
+    """
+    if requested <= 1:
+        return 1
+    return max(1, min(requested, n_tables, WRDS_MAX_CONNECTIONS - 1))
+
+
+def _attach_download_worker(
+    table_queue: queue.Queue,
+    conninfo: str,
+    filenames: dict[str, str],
+    date_columns: dict[str, str],
+    end_date: date | None,
+    password: str,
+    errors: list[str],
+    errors_lock: threading.Lock,
+) -> None:
+    """One parallel worker: open a private ATTACH connection and drain the table queue.
+
+    Each worker holds exactly one WRDS backend connection (``threads=1`` keeps DuckDB from
+    opening extra connections for a parallel scan) and reuses it for every table it pulls.
+    Failures are recorded per-table (password-redacted) instead of raised, so one bad table
+    doesn't abandon the rest; the caller raises a single aggregated error afterward.
+    """
+    # `with duckdb.connect(...)` closes the connection on every exit path (return / exception).
+    with duckdb.connect(":memory:") as con:
+        con.execute("SET threads TO 1")
+        con.execute("INSTALL postgres; LOAD postgres;")
+        try:
+            con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
+        except Exception as e:
+            # DuckDB embeds the connection string (with password) in ATTACH errors.
+            reason = (
+                "check credentials and MFA approval" if password and password in str(e) else str(e)
+            )
+            with errors_lock:
+                errors.append(f"<attach>: {reason}")
+            return
+        try:
+            while True:
+                try:
+                    table = table_queue.get_nowait()
+                except queue.Empty:
+                    break
+                try:
+                    download_wrds_table_attached(
+                        con,
+                        "wrds",
+                        table,
+                        filenames[table],
+                        date_column=date_columns.get(table),
+                        end_date=end_date,
+                    )
+                except Exception as e:  # noqa: BLE001
+                    msg = str(e)
+                    if password and password in msg:
+                        msg = "<redacted>"
+                    with errors_lock:
+                        errors.append(f"{table}: {msg}")
+        finally:
+            with contextlib.suppress(Exception):
+                con.execute("DETACH wrds")
+
+
+def _download_tables_parallel(
+    table_names: list[str],
+    filenames: dict[str, str],
+    conninfo: str,
+    date_columns: dict[str, str],
+    end_date: date | None,
+    password: str,
+    workers: int,
+) -> None:
+    """Download all tables concurrently over ``workers`` private ATTACH connections.
+
+    Tables are pulled from a shared queue (dynamic load balancing), so fast tables don't wait
+    behind slow ones. Raises a single aggregated ``RuntimeError`` if any table failed.
+    """
+    table_queue: queue.Queue = queue.Queue()
+    for table in table_names:
+        table_queue.put(table)
+    errors: list[str] = []
+    errors_lock = threading.Lock()
+    threads = [
+        threading.Thread(
+            target=_attach_download_worker,
+            args=(
+                table_queue,
+                conninfo,
+                filenames,
+                date_columns,
+                end_date,
+                password,
+                errors,
+                errors_lock,
+            ),
+            name=f"wrds-download-{i}",
+        )
+        for i in range(workers)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    if errors:
+        raise RuntimeError(
+            f"{len(errors)} WRDS table download(s) failed:\n  " + "\n  ".join(sorted(errors))
+        )
+
+
 @measure_time
 def download_raw_data_tables(
     paths: DataPaths,
@@ -766,6 +897,7 @@ def download_raw_data_tables(
     password: str,
     end_date: date | None = None,
     persistent_connection: bool = False,
+    max_workers: int = 1,
 ) -> None:
     """
     Description:
@@ -775,16 +907,26 @@ def download_raw_data_tables(
         1) Connect to WRDS; iterate through a fixed list of library.tables.
         2) For each table: download to raw_tables/lib_table.parquet, applying date filtering
            when end_date is provided and the table has a known date column.
-        3) If persistent_connection: ATTACH a single postgres connection and download all tables.
-           Otherwise: use postgres_scan() which creates a new connection per query.
+        3) If max_workers > 1: download tables concurrently over a pool of persistent ATTACH
+           connections (one per worker). Otherwise download sequentially over a single
+           connection, using ATTACH when persistent_connection is set or postgres_scan() if not.
         4) Disconnect.
 
     Args:
         username: WRDS username
         password: WRDS password
-        persistent_connection: If True, use a single persistent connection via ATTACH.
-            This reduces MFA prompts on systems with NAT IP rotation (e.g., Yale Bouchet).
-            If False (default), use postgres_scan() which creates a new connection per query.
+        persistent_connection: If True, use a single persistent connection via ATTACH. This
+            reduces MFA prompts on systems with NAT IP rotation (e.g., Yale Bouchet). If False
+            (default), use postgres_scan() which creates a new connection per query. This flag
+            takes precedence over max_workers: when set, the download stays sequential (one
+            connection) so the single-MFA-prompt guarantee is preserved.
+        max_workers: Number of concurrent download connections. The download is single-threaded
+            and transfer-bound, so the tables are otherwise pulled one at a time over a single
+            stream; running several in parallel cuts wall time substantially. Clamped to the WRDS
+            per-account connection limit (see WRDS_MAX_CONNECTIONS). Default 1 (sequential).
+            Ignored when persistent_connection is set. NOTE: each worker opens its own connection,
+            so on NAT-rotated networks (e.g., Bouchet) parallel mode would trigger one MFA prompt
+            per worker at startup — which is exactly why persistent_connection forces sequential.
 
     Output:
         Parquet files under raw_tables/ (Compustat, CRSP, FF, etc.).
@@ -832,7 +974,32 @@ def download_raw_data_tables(
         "comp.g_fundq": "datadate",
     }
 
-    wrds_session_data = gen_wrds_connection_info(username, password)
+    conninfo = gen_wrds_connection_info(username, password)
+    filenames = {
+        table: str(paths.raw_tables_dir / (table.replace(".", "_") + ".parquet"))
+        for table in table_names
+    }
+
+    workers = _effective_download_workers(max_workers, len(table_names))
+    if persistent_connection and workers > 1:
+        # --persistent-connection exists to hold ONE connection so NAT-rotated networks
+        # (e.g. Bouchet) get a single MFA prompt. Parallel workers each open their own
+        # connection (one MFA prompt apiece), defeating that, so the single-connection request
+        # wins and we download sequentially.
+        print(
+            "Note: --persistent-connection uses a single WRDS connection; "
+            f"ignoring max_workers={max_workers} and downloading sequentially.",
+            file=sys.stderr,
+            flush=True,
+        )
+        workers = 1
+    if workers > 1:
+        # Parallel: each worker holds its own persistent ATTACH connection and drains a queue.
+        _download_tables_parallel(
+            table_names, filenames, conninfo, date_columns, end_date, password, workers
+        )
+        return
+
     con = duckdb.connect(":memory:")
     con.execute("INSTALL postgres; LOAD postgres;")
 
@@ -842,7 +1009,7 @@ def download_raw_data_tables(
         # in error messages. If the connection fails, suppress the original exception to
         # avoid leaking credentials in logs/tracebacks, and raise a generic error instead.
         try:
-            con.execute(f"ATTACH '{wrds_session_data}' AS wrds (TYPE postgres, READ_ONLY)")
+            con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
         except Exception as e:
             if password in str(e):
                 raise RuntimeError(
@@ -856,7 +1023,7 @@ def download_raw_data_tables(
                     con,
                     "wrds",
                     table,
-                    str(paths.raw_tables_dir / (table.replace(".", "_") + ".parquet")),
+                    filenames[table],
                     date_column=date_columns.get(table),
                     end_date=end_date,
                 )
@@ -866,10 +1033,10 @@ def download_raw_data_tables(
         # Use postgres_scan() which creates a new connection per query (default)
         for table in table_names:
             download_wrds_table(
-                wrds_session_data,
+                conninfo,
                 con,
                 table,
-                str(paths.raw_tables_dir / (table.replace(".", "_") + ".parquet")),
+                filenames[table],
                 date_column=date_columns.get(table),
                 end_date=end_date,
             )

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -978,6 +978,19 @@ def _concat_chunks(final_file: str, chunk_files: list[str]) -> None:
             os.remove(f)
 
 
+def _remove_chunk_parts(filename: str) -> None:
+    """Delete any existing chunk-part files for ``filename`` (see _chunk_path).
+
+    A prior interrupted run may have written chunk parts that were never concatenated — possibly
+    with a different worker count, hence different indices — so clear them all before writing fresh
+    ones. The final (non-part) file itself is left untouched.
+    """
+    p = Path(filename)
+    for f in p.parent.glob(f"{p.stem}.part*{p.suffix}"):
+        with contextlib.suppress(FileNotFoundError):
+            f.unlink()
+
+
 def _attach_download_worker(
     task_queue: queue.Queue,
     conninfo: str,
@@ -1061,6 +1074,13 @@ def _download_tables_parallel(
         table_names, filenames, date_columns, end_date, split_tables, n_chunks, histograms
     )
 
+    # Clear any stale chunk parts left by a prior interrupted run before the workers write fresh
+    # ones, so leftover parts (e.g. from a run with a different worker count) can't linger
+    # un-concatenated alongside this run's output.
+    for table in table_names:
+        if table in split_tables:
+            _remove_chunk_parts(filenames[table])
+
     task_queue: queue.Queue = queue.Queue()
     for task in tasks:
         task_queue.put(task)
@@ -1084,10 +1104,28 @@ def _download_tables_parallel(
         )
 
     # Concatenate each split table's chunks back into its single parquet. These are local
-    # (no WRDS connection) and independent, so run them concurrently.
+    # (no WRDS connection) and independent, so run them concurrently. Failures are aggregated
+    # like the download phase rather than aborting on the first error; chunks left behind by a
+    # failed concat are cleaned up by the stale-part sweep on the next run.
     if concat_map:
+        concat_errors: list[str] = []
+        concat_lock = threading.Lock()
+
+        def concat_one(item: tuple[str, list[str]]) -> None:
+            final_file, chunk_files = item
+            try:
+                _concat_chunks(final_file, chunk_files)
+            except Exception as e:  # noqa: BLE001
+                with concat_lock:
+                    concat_errors.append(f"{Path(final_file).name}: {e}")
+
         with ThreadPoolExecutor(max_workers=len(concat_map)) as ex:
-            list(ex.map(lambda item: _concat_chunks(*item), concat_map.items()))
+            list(ex.map(concat_one, concat_map.items()))
+        if concat_errors:
+            raise RuntimeError(
+                f"{len(concat_errors)} chunk concatenation(s) failed:\n  "
+                + "\n  ".join(sorted(concat_errors))
+            )
 
 
 @measure_time

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -968,11 +968,7 @@ def _build_download_tasks(
 
 def _concat_chunks(final_file: str, chunk_files: list[str]) -> None:
     """Concatenate ordered chunk parquets into one final parquet, then remove the chunks (local)."""
-    file_list = "[" + ", ".join(f"'{f}'" for f in chunk_files) + "]"
-    with duckdb.connect(":memory:") as con:
-        con.execute(
-            f"COPY (SELECT * FROM read_parquet({file_list})) TO '{final_file}' (FORMAT PARQUET)"  # noqa: S608
-        )
+    pl.scan_parquet(chunk_files).sink_parquet(final_file)
     for f in chunk_files:
         with contextlib.suppress(FileNotFoundError):
             os.remove(f)

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -851,6 +851,18 @@ def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str) -
         raise
 
 
+def _install_postgres_extension() -> None:
+    """Install the DuckDB postgres extension once, up front (idempotent).
+
+    Doing it in the main thread means the parallel workers only ``LOAD`` it (a per-connection,
+    no-download operation), which avoids a concurrent-INSTALL race across the pool writing the same
+    extension file, and surfaces a fetch failure as one clean error here rather than N worker
+    tracebacks.
+    """
+    with duckdb.connect(":memory:") as con:
+        con.execute("INSTALL postgres;")
+
+
 def _year_histogram(
     con: duckdb.DuckDBPyConnection,
     db_alias: str,
@@ -917,7 +929,7 @@ def _compute_histograms(
         lib, tbl = table.split(".")
         with duckdb.connect(":memory:") as con:
             con.execute("SET threads TO 1")
-            con.execute("INSTALL postgres; LOAD postgres;")
+            con.execute("LOAD postgres;")  # extension installed once up front by the caller
             _attach_wrds(con, conninfo, password)
             try:
                 return table, _year_histogram(con, "wrds", lib, tbl, date_columns[table], end_date)
@@ -1001,7 +1013,7 @@ def _attach_download_worker(
     conninfo: str,
     password: str,
     task_errors: list[str],
-    attach_errors: list[str],
+    startup_errors: list[str],
     errors_lock: threading.Lock,
     stop_event: threading.Event,
 ) -> None:
@@ -1012,24 +1024,25 @@ def _attach_download_worker(
     and reuses it. It stops pulling new tasks once ``stop_event`` is set (used to unwind on Ctrl-C).
 
     Failures are recorded (password-redacted) instead of raised, so one bad task doesn't abandon
-    the rest. Attach failures and download (task) failures are kept in separate lists: because the
-    task queue is shared, a worker that fails to attach is not fatal as long as the surviving
-    workers still drain the queue, whereas a failed download leaves a table missing. The caller
-    decides what to raise (see _download_tables_parallel).
+    the rest. Worker-startup failures (LOAD/ATTACH) and download (task) failures are kept in separate
+    lists: because the task queue is shared, a worker that fails to start is not fatal as long as the
+    surviving workers still drain the queue, whereas a failed download leaves a table missing. The
+    caller decides what to raise (see _download_tables_parallel).
     """
     # `with duckdb.connect(...)` closes the connection on every exit path (return / exception).
     with duckdb.connect(":memory:") as con:
-        con.execute("SET threads TO 1")
-        con.execute("INSTALL postgres; LOAD postgres;")
         try:
+            con.execute("SET threads TO 1")
+            con.execute("LOAD postgres;")  # extension installed once up front by the caller
             _attach_wrds(con, conninfo, password)
         except Exception as e:  # noqa: BLE001
-            # _attach_wrds already raises a password-free error; warn now so the user knows the
-            # run is proceeding under-provisioned rather than silently losing a worker.
+            # _attach_wrds already raises a password-free error, and LOAD/SET can't leak the
+            # password; warn now so the user knows the run is proceeding under-provisioned rather
+            # than silently losing a worker.
             with errors_lock:
-                attach_errors.append(str(e))
+                startup_errors.append(str(e))
                 print(
-                    f"Warning: a WRDS download worker failed to attach ({e}); continuing with the "
+                    f"Warning: a WRDS download worker failed to start ({e}); continuing with the "
                     "remaining worker(s). Press Ctrl-C to cancel and re-run for full parallelism.",
                     file=sys.stderr,
                     flush=True,
@@ -1079,6 +1092,10 @@ def _download_tables_parallel(
     a single giant table can't bottleneck the pool. Work is pulled from a shared queue (dynamic
     load balancing). Raises a single aggregated ``RuntimeError`` if any task failed.
     """
+    # Install the postgres extension once, in this thread, so the parallel workers (and histogram
+    # workers) only LOAD it -- no concurrent-INSTALL race, and a fetch failure surfaces here cleanly.
+    _install_postgres_extension()
+
     # Up front: concurrently compute per-year row histograms for the split tables to derive chunk
     # boundaries (the giant tables need a full COUNT scan; running them in parallel hides the cost).
     split_present = [
@@ -1104,7 +1121,7 @@ def _download_tables_parallel(
     for task in tasks:
         task_queue.put(task)
     task_errors: list[str] = []
-    attach_errors: list[str] = []
+    startup_errors: list[str] = []
     errors_lock = threading.Lock()
     stop_event = threading.Event()
     threads = [
@@ -1115,7 +1132,7 @@ def _download_tables_parallel(
                 conninfo,
                 password,
                 task_errors,
-                attach_errors,
+                startup_errors,
                 errors_lock,
                 stop_event,
             ),
@@ -1155,16 +1172,16 @@ def _download_tables_parallel(
             f"{len(task_errors)} WRDS download task(s) failed:\n  "
             + "\n  ".join(sorted(task_errors))
         )
-    # If the queue never drained, every worker failed to attach -> nothing was downloaded.
+    # If the queue never drained, every worker failed to start -> nothing was downloaded.
     if not task_queue.empty():
         raise RuntimeError(
-            f"all {workers} WRDS download worker(s) failed to attach:\n  "
-            + "\n  ".join(sorted(attach_errors))
+            f"all {workers} WRDS download worker(s) failed to start:\n  "
+            + "\n  ".join(sorted(startup_errors))
         )
-    # Some workers failed to attach, but the survivors completed every table -> note it, don't fail.
-    if attach_errors:
+    # Some workers failed to start, but the survivors completed every table -> note it, don't fail.
+    if startup_errors:
         print(
-            f"Note: {len(attach_errors)} of {workers} WRDS download worker(s) failed to attach; "
+            f"Note: {len(startup_errors)} of {workers} WRDS download worker(s) failed to start; "
             "the remaining worker(s) completed all tables.",
             file=sys.stderr,
             flush=True,

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -1037,9 +1037,8 @@ def _attach_download_worker(
                         start_date=task.start_date,
                     )
                 except Exception as e:  # noqa: BLE001
-                    msg = str(e)
-                    if password and password in msg:
-                        msg = "<redacted>"
+                    # Redact only the credential, keeping the rest of the error for diagnostics.
+                    msg = str(e).replace(password, "***") if password else str(e)
                     with errors_lock:
                         errors.append(f"{task.table} ({Path(task.out).name}): {msg}")
         finally:

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -1000,15 +1000,21 @@ def _attach_download_worker(
     task_queue: queue.Queue[_DownloadTask],
     conninfo: str,
     password: str,
-    errors: list[str],
+    task_errors: list[str],
+    attach_errors: list[str],
     errors_lock: threading.Lock,
 ) -> None:
     """One parallel worker: open a private ATTACH connection and drain the task queue.
 
     Each task is a whole table or one date-range chunk. The worker holds exactly one WRDS
     connection (``threads=1`` keeps DuckDB from opening extra connections for a parallel scan)
-    and reuses it. Failures are recorded (password-redacted) instead of raised, so one bad task
-    doesn't abandon the rest; the caller raises a single aggregated error afterward.
+    and reuses it.
+
+    Failures are recorded (password-redacted) instead of raised, so one bad task doesn't abandon
+    the rest. Attach failures and download (task) failures are kept in separate lists: because the
+    task queue is shared, a worker that fails to attach is not fatal as long as the surviving
+    workers still drain the queue, whereas a failed download leaves a table missing. The caller
+    decides what to raise (see _download_tables_parallel).
     """
     # `with duckdb.connect(...)` closes the connection on every exit path (return / exception).
     with duckdb.connect(":memory:") as con:
@@ -1017,8 +1023,16 @@ def _attach_download_worker(
         try:
             _attach_wrds(con, conninfo, password)
         except Exception as e:  # noqa: BLE001
+            # _attach_wrds already raises a password-free error; warn now so the user knows the
+            # run is proceeding under-provisioned rather than silently losing a worker.
             with errors_lock:
-                errors.append(f"<attach>: {e}")
+                attach_errors.append(str(e))
+                print(
+                    f"Warning: a WRDS download worker failed to attach ({e}); "
+                    "continuing with the remaining worker(s).",
+                    file=sys.stderr,
+                    flush=True,
+                )
             return
         try:
             while True:
@@ -1040,7 +1054,7 @@ def _attach_download_worker(
                     # Redact only the credential, keeping the rest of the error for diagnostics.
                     msg = str(e).replace(password, "***") if password else str(e)
                     with errors_lock:
-                        errors.append(f"{task.table} ({Path(task.out).name}): {msg}")
+                        task_errors.append(f"{task.table} ({Path(task.out).name}): {msg}")
         finally:
             with contextlib.suppress(Exception):
                 con.execute("DETACH wrds")
@@ -1088,12 +1102,13 @@ def _download_tables_parallel(
     task_queue: queue.Queue[_DownloadTask] = queue.Queue()
     for task in tasks:
         task_queue.put(task)
-    errors: list[str] = []
+    task_errors: list[str] = []
+    attach_errors: list[str] = []
     errors_lock = threading.Lock()
     threads = [
         threading.Thread(
             target=_attach_download_worker,
-            args=(task_queue, conninfo, password, errors, errors_lock),
+            args=(task_queue, conninfo, password, task_errors, attach_errors, errors_lock),
             name=f"wrds-download-{i}",
         )
         for i in range(workers)
@@ -1102,9 +1117,26 @@ def _download_tables_parallel(
         t.start()
     for t in threads:
         t.join()
-    if errors:
+
+    # A download failure means a table is missing -> always fatal.
+    if task_errors:
         raise RuntimeError(
-            f"{len(errors)} WRDS download task(s) failed:\n  " + "\n  ".join(sorted(errors))
+            f"{len(task_errors)} WRDS download task(s) failed:\n  "
+            + "\n  ".join(sorted(task_errors))
+        )
+    # If the queue never drained, every worker failed to attach -> nothing was downloaded.
+    if not task_queue.empty():
+        raise RuntimeError(
+            f"all {workers} WRDS download worker(s) failed to attach:\n  "
+            + "\n  ".join(sorted(attach_errors))
+        )
+    # Some workers failed to attach, but the survivors completed every table -> note it, don't fail.
+    if attach_errors:
+        print(
+            f"Note: {len(attach_errors)} of {workers} WRDS download worker(s) failed to attach; "
+            "the remaining worker(s) completed all tables.",
+            file=sys.stderr,
+            flush=True,
         )
 
     # Concatenate each split table's chunks back into its single parquet. These are local

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -781,6 +781,13 @@ def download_wrds_table(
     """)
 
 
+# The raw-data download is the one place in this pipeline that runs an explicit Python thread pool.
+# Elsewhere we follow an "engine-level parallelism only" convention: let Polars/DuckDB parallelize
+# internally rather than hand-rolling threads in compute code. This is a deliberate, narrow exception
+# -- the parallelism here is N concurrent client connections to WRDS, which the query engine cannot
+# provide (it parallelizes computation, not independent network connections). It is NOT a precedent
+# for introducing thread pools into characteristic/compute code.
+#
 # WRDS enforces a per-role PostgreSQL CONNECTION LIMIT (currently 7 for our account; see
 # `SELECT rolconnlimit FROM pg_roles WHERE rolname = current_user`). Each parallel worker holds
 # exactly one client connection (verified: with `SET threads = 1` and these tables being views,

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -1048,9 +1048,11 @@ def _download_tables_parallel(
             f"{len(errors)} WRDS download task(s) failed:\n  " + "\n  ".join(sorted(errors))
         )
 
-    # Concatenate each split table's chunks back into its single parquet (local, no WRDS).
-    for final_file, chunk_files in concat_map.items():
-        _concat_chunks(final_file, chunk_files)
+    # Concatenate each split table's chunks back into its single parquet. These are local
+    # (no WRDS connection) and independent, so run them concurrently.
+    if concat_map:
+        with ThreadPoolExecutor(max_workers=len(concat_map)) as ex:
+            list(ex.map(lambda item: _concat_chunks(*item), concat_map.items()))
 
 
 @measure_time

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -11,6 +11,8 @@ import sys
 import threading
 import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import date
 from math import exp, sqrt
 from pathlib import Path
@@ -693,6 +695,18 @@ def get_columns_attached(conn, db_alias, lib, table):
     return [c[0] for c in cols]
 
 
+def _date_where(date_column: str | None, start_date: date | None, end_date: date | None) -> str:
+    """Build an inclusive ``WHERE date_column BETWEEN ...`` clause (empty if no date column)."""
+    if not date_column:
+        return ""
+    conds = []
+    if start_date is not None:
+        conds.append(f"{date_column} >= '{start_date}'")
+    if end_date is not None:
+        conds.append(f"{date_column} <= '{end_date}'")
+    return ("WHERE " + " AND ".join(conds)) if conds else ""
+
+
 def download_wrds_table_attached(
     duckdb_conn,
     db_alias,
@@ -700,15 +714,19 @@ def download_wrds_table_attached(
     filename,
     date_column: str | None = None,
     end_date: date | None = None,
+    start_date: date | None = None,
 ):
-    """Download a WRDS table using an attached persistent connection."""
+    """Download a WRDS table (or an inclusive date-range slice) via an attached connection.
+
+    When ``start_date``/``end_date`` are given (and the table has a ``date_column``), only rows
+    with ``start_date <= date_column <= end_date`` are downloaded. ``start_date`` enables
+    date-range chunking of large tables across parallel workers.
+    """
     lib, table = table_name.split(".")
     cols = get_columns_attached(duckdb_conn, db_alias, lib, table)
     projection = build_projection(cols)
 
-    where_clause = ""
-    if date_column and end_date:
-        where_clause = f"WHERE {date_column} <= '{end_date}'"
+    where_clause = _date_where(date_column, start_date, end_date)
 
     duckdb_conn.execute(f"""
         COPY (
@@ -775,6 +793,11 @@ def download_wrds_table(
 # equal the worker count (confirmed via the process's own sockets, e.g. psutil/`ss`).
 WRDS_MAX_CONNECTIONS = 7
 
+# These daily security tables dominate the download (hundreds of millions of rows each). In
+# parallel mode they are split into row-balanced date-range chunks so a single giant table can't
+# bottleneck the worker pool; the chunks are concatenated back into one parquet afterward.
+SPLIT_TABLES = frozenset({"crsp.dsf_v2", "comp.secd", "comp.g_secd"})
+
 
 def _effective_download_workers(requested: int, n_tables: int) -> int:
     """Clamp the requested worker count to a safe, useful range.
@@ -787,21 +810,147 @@ def _effective_download_workers(requested: int, n_tables: int) -> int:
     return max(1, min(requested, n_tables, WRDS_MAX_CONNECTIONS - 1))
 
 
+@dataclass(frozen=True)
+class _DownloadTask:
+    """One unit of download work: a whole table, or one date-range chunk of a split table."""
+
+    table: str
+    out: str
+    date_column: str | None
+    start_date: date | None
+    end_date: date | None
+
+
+def _chunk_path(filename: str, i: int) -> str:
+    """Per-chunk parquet path, e.g. .../crsp_dsf_v2.parquet -> .../crsp_dsf_v2.part00.parquet."""
+    p = Path(filename)
+    return str(p.with_name(f"{p.stem}.part{i:02d}{p.suffix}"))
+
+
+def _year_histogram(con, db_alias, lib, table, date_column, end_date):
+    """Server-side per-year row counts for a date-filtered table: [(year, n), ...] sorted by year."""
+    where = _date_where(date_column, None, end_date)
+    rows = con.execute(
+        f"SELECT CAST(EXTRACT(YEAR FROM {date_column}) AS INTEGER) AS yr, COUNT(*) AS n "  # noqa: S608
+        f"FROM {db_alias}.{lib}.{table} {where} GROUP BY yr ORDER BY yr"
+    ).fetchall()
+    return [(int(yr), int(n)) for yr, n in rows if yr is not None]
+
+
+def _balanced_year_chunks(histogram, n_chunks, end_date):
+    """Split a year histogram into <= n_chunks contiguous inclusive (start, end) date ranges
+    holding ~equal row counts.
+
+    The first range's start is None (unbounded below) and the last range's end is the overall
+    end_date; ranges are non-overlapping and together cover every counted row. Cuts fall on
+    year boundaries, so chunks are only as balanced as the per-year granularity allows.
+    """
+    hist = [(y, n) for y, n in histogram if n > 0]
+    if n_chunks <= 1 or len(hist) <= 1:
+        return [(None, end_date)]
+    total = sum(n for _, n in hist)
+    target = total / n_chunks
+    cut_years: list[int] = []
+    acc = 0
+    for i, (yr, n) in enumerate(hist):
+        acc += n
+        last_year = i == len(hist) - 1
+        if len(cut_years) < n_chunks - 1 and not last_year and acc >= (len(cut_years) + 1) * target:
+            cut_years.append(yr)
+    starts = [None, *[cy + 1 for cy in cut_years]]
+    ends = [date(cy, 12, 31) for cy in cut_years] + [end_date]
+    return [
+        (date(s, 1, 1) if s is not None else None, e) for s, e in zip(starts, ends, strict=True)
+    ]
+
+
+def _compute_histograms(conninfo, tables, date_columns, end_date, max_conns):
+    """Concurrently compute per-year row histograms for ``tables`` (each over its own connection).
+
+    Returns {table: [(year, n), ...]}. Runs up to ``max_conns`` queries at once so the up-front
+    boundary scan of the giant tables doesn't serialize and leave the connection pool idle.
+    """
+    if not tables:
+        return {}
+
+    def one(table):
+        lib, tbl = table.split(".")
+        with duckdb.connect(":memory:") as con:
+            con.execute("SET threads TO 1")
+            con.execute("INSTALL postgres; LOAD postgres;")
+            con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
+            try:
+                return table, _year_histogram(con, "wrds", lib, tbl, date_columns[table], end_date)
+            finally:
+                with contextlib.suppress(Exception):
+                    con.execute("DETACH wrds")
+
+    with ThreadPoolExecutor(max_workers=min(len(tables), max_conns)) as ex:
+        return dict(ex.map(one, tables))
+
+
+def _build_download_tasks(
+    table_names, filenames, date_columns, end_date, split_tables, n_chunks, histograms
+):
+    """Expand the table list into download tasks, splitting ``split_tables`` into date chunks.
+
+    ``histograms`` maps a split table to its per-year row counts (see _compute_histograms).
+    Returns (tasks, concat_map), where concat_map maps a final parquet path to its ordered chunk
+    files (only for tables actually split into >1 chunk).
+    """
+    tasks: list[_DownloadTask] = []
+    concat_map: dict[str, list[str]] = {}
+    for table in table_names:
+        date_col = date_columns.get(table)
+        hist = histograms.get(table)
+        do_split = (
+            hist is not None
+            and n_chunks > 1
+            and table in split_tables
+            and date_col
+            and end_date is not None
+        )
+        if not do_split:
+            tasks.append(_DownloadTask(table, filenames[table], date_col, None, end_date))
+            continue
+        ranges = _balanced_year_chunks(hist, n_chunks, end_date)
+        if len(ranges) <= 1:
+            start, end = ranges[0]
+            tasks.append(_DownloadTask(table, filenames[table], date_col, start, end))
+            continue
+        chunk_files = []
+        for i, (start, end) in enumerate(ranges):
+            cf = _chunk_path(filenames[table], i)
+            chunk_files.append(cf)
+            tasks.append(_DownloadTask(table, cf, date_col, start, end))
+        concat_map[filenames[table]] = chunk_files
+    return tasks, concat_map
+
+
+def _concat_chunks(final_file: str, chunk_files: list[str]) -> None:
+    """Concatenate ordered chunk parquets into one final parquet, then remove the chunks (local)."""
+    file_list = "[" + ", ".join(f"'{f}'" for f in chunk_files) + "]"
+    with duckdb.connect(":memory:") as con:
+        con.execute(
+            f"COPY (SELECT * FROM read_parquet({file_list})) TO '{final_file}' (FORMAT PARQUET)"  # noqa: S608
+        )
+    for f in chunk_files:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(f)
+
+
 def _attach_download_worker(
-    table_queue: queue.Queue,
+    task_queue: queue.Queue,
     conninfo: str,
-    filenames: dict[str, str],
-    date_columns: dict[str, str],
-    end_date: date | None,
     password: str,
     errors: list[str],
     errors_lock: threading.Lock,
 ) -> None:
-    """One parallel worker: open a private ATTACH connection and drain the table queue.
+    """One parallel worker: open a private ATTACH connection and drain the task queue.
 
-    Each worker holds exactly one WRDS backend connection (``threads=1`` keeps DuckDB from
-    opening extra connections for a parallel scan) and reuses it for every table it pulls.
-    Failures are recorded per-table (password-redacted) instead of raised, so one bad table
+    Each task is a whole table or one date-range chunk. The worker holds exactly one WRDS
+    connection (``threads=1`` keeps DuckDB from opening extra connections for a parallel scan)
+    and reuses it. Failures are recorded (password-redacted) instead of raised, so one bad task
     doesn't abandon the rest; the caller raises a single aggregated error afterward.
     """
     # `with duckdb.connect(...)` closes the connection on every exit path (return / exception).
@@ -821,24 +970,25 @@ def _attach_download_worker(
         try:
             while True:
                 try:
-                    table = table_queue.get_nowait()
+                    task = task_queue.get_nowait()
                 except queue.Empty:
                     break
                 try:
                     download_wrds_table_attached(
                         con,
                         "wrds",
-                        table,
-                        filenames[table],
-                        date_column=date_columns.get(table),
-                        end_date=end_date,
+                        task.table,
+                        task.out,
+                        date_column=task.date_column,
+                        end_date=task.end_date,
+                        start_date=task.start_date,
                     )
                 except Exception as e:  # noqa: BLE001
                     msg = str(e)
                     if password and password in msg:
                         msg = "<redacted>"
                     with errors_lock:
-                        errors.append(f"{table}: {msg}")
+                        errors.append(f"{task.table} ({Path(task.out).name}): {msg}")
         finally:
             with contextlib.suppress(Exception):
                 con.execute("DETACH wrds")
@@ -852,30 +1002,39 @@ def _download_tables_parallel(
     end_date: date | None,
     password: str,
     workers: int,
+    split_tables: frozenset[str] = frozenset(),
+    n_chunks: int = 1,
 ) -> None:
     """Download all tables concurrently over ``workers`` private ATTACH connections.
 
-    Tables are pulled from a shared queue (dynamic load balancing), so fast tables don't wait
-    behind slow ones. Raises a single aggregated ``RuntimeError`` if any table failed.
+    Tables in ``split_tables`` are divided into ``n_chunks`` row-balanced date-range chunks
+    (boundaries computed up front over one short-lived connection) and concatenated afterward, so
+    a single giant table can't bottleneck the pool. Work is pulled from a shared queue (dynamic
+    load balancing). Raises a single aggregated ``RuntimeError`` if any task failed.
     """
-    table_queue: queue.Queue = queue.Queue()
-    for table in table_names:
-        table_queue.put(table)
+    # Up front: concurrently compute per-year row histograms for the split tables to derive chunk
+    # boundaries (the giant tables need a full COUNT scan; running them in parallel hides the cost).
+    split_present = [
+        t for t in table_names if t in split_tables and date_columns.get(t) and end_date is not None
+    ]
+    histograms = (
+        _compute_histograms(conninfo, split_present, date_columns, end_date, workers)
+        if split_present and n_chunks > 1
+        else {}
+    )
+    tasks, concat_map = _build_download_tasks(
+        table_names, filenames, date_columns, end_date, split_tables, n_chunks, histograms
+    )
+
+    task_queue: queue.Queue = queue.Queue()
+    for task in tasks:
+        task_queue.put(task)
     errors: list[str] = []
     errors_lock = threading.Lock()
     threads = [
         threading.Thread(
             target=_attach_download_worker,
-            args=(
-                table_queue,
-                conninfo,
-                filenames,
-                date_columns,
-                end_date,
-                password,
-                errors,
-                errors_lock,
-            ),
+            args=(task_queue, conninfo, password, errors, errors_lock),
             name=f"wrds-download-{i}",
         )
         for i in range(workers)
@@ -886,8 +1045,12 @@ def _download_tables_parallel(
         t.join()
     if errors:
         raise RuntimeError(
-            f"{len(errors)} WRDS table download(s) failed:\n  " + "\n  ".join(sorted(errors))
+            f"{len(errors)} WRDS download task(s) failed:\n  " + "\n  ".join(sorted(errors))
         )
+
+    # Concatenate each split table's chunks back into its single parquet (local, no WRDS).
+    for final_file, chunk_files in concat_map.items():
+        _concat_chunks(final_file, chunk_files)
 
 
 @measure_time
@@ -924,9 +1087,11 @@ def download_raw_data_tables(
             and transfer-bound, so the tables are otherwise pulled one at a time over a single
             stream; running several in parallel cuts wall time substantially. Clamped to the WRDS
             per-account connection limit (see WRDS_MAX_CONNECTIONS). Default 1 (sequential).
-            Ignored when persistent_connection is set. NOTE: each worker opens its own connection,
-            so on NAT-rotated networks (e.g., Bouchet) parallel mode would trigger one MFA prompt
-            per worker at startup — which is exactly why persistent_connection forces sequential.
+            Ignored when persistent_connection is set. In parallel mode the giant daily tables
+            (SPLIT_TABLES) are additionally split into max_workers date-range chunks so one huge
+            table can't bottleneck the pool. NOTE: each worker opens its own connection, so on
+            NAT-rotated networks (e.g., Bouchet) parallel mode would trigger one MFA prompt per
+            worker at startup — which is exactly why persistent_connection forces sequential.
 
     Output:
         Parquet files under raw_tables/ (Compustat, CRSP, FF, etc.).
@@ -995,8 +1160,18 @@ def download_raw_data_tables(
         workers = 1
     if workers > 1:
         # Parallel: each worker holds its own persistent ATTACH connection and drains a queue.
+        # The giant daily tables (SPLIT_TABLES) are split into `workers` date-range chunks so one
+        # huge table doesn't bottleneck the pool, then concatenated back into one parquet.
         _download_tables_parallel(
-            table_names, filenames, conninfo, date_columns, end_date, password, workers
+            table_names,
+            filenames,
+            conninfo,
+            date_columns,
+            end_date,
+            password,
+            workers,
+            split_tables=SPLIT_TABLES,
+            n_chunks=workers,
         )
         return
 

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -827,7 +827,31 @@ def _chunk_path(filename: str, i: int) -> str:
     return str(p.with_name(f"{p.stem}.part{i:02d}{p.suffix}"))
 
 
-def _year_histogram(con, db_alias, lib, table, date_column, end_date):
+def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str) -> None:
+    """ATTACH the WRDS Postgres database read-only on an existing DuckDB connection.
+
+    DuckDB's postgres extension embeds the full connection string (including the password) in
+    ATTACH error text, so on failure suppress the original exception and raise a generic,
+    password-free error. Errors that don't contain the password propagate unchanged.
+    """
+    try:
+        con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
+    except Exception as e:
+        if password and password in str(e):
+            raise RuntimeError(
+                "Failed to attach WRDS connection. Check credentials and MFA approval."
+            ) from None
+        raise
+
+
+def _year_histogram(
+    con: duckdb.DuckDBPyConnection,
+    db_alias: str,
+    lib: str,
+    table: str,
+    date_column: str,
+    end_date: date | None,
+) -> list[tuple[int, int]]:
     """Server-side per-year row counts for a date-filtered table: [(year, n), ...] sorted by year."""
     where = _date_where(date_column, None, end_date)
     rows = con.execute(
@@ -837,7 +861,9 @@ def _year_histogram(con, db_alias, lib, table, date_column, end_date):
     return [(int(yr), int(n)) for yr, n in rows if yr is not None]
 
 
-def _balanced_year_chunks(histogram, n_chunks, end_date):
+def _balanced_year_chunks(
+    histogram: list[tuple[int, int]], n_chunks: int, end_date: date | None
+) -> list[tuple[date | None, date | None]]:
     """Split a year histogram into <= n_chunks contiguous inclusive (start, end) date ranges
     holding ~equal row counts.
 
@@ -864,7 +890,14 @@ def _balanced_year_chunks(histogram, n_chunks, end_date):
     ]
 
 
-def _compute_histograms(conninfo, tables, date_columns, end_date, max_conns):
+def _compute_histograms(
+    conninfo: str,
+    tables: list[str],
+    date_columns: dict[str, str],
+    end_date: date | None,
+    max_conns: int,
+    password: str,
+) -> dict[str, list[tuple[int, int]]]:
     """Concurrently compute per-year row histograms for ``tables`` (each over its own connection).
 
     Returns {table: [(year, n), ...]}. Runs up to ``max_conns`` queries at once so the up-front
@@ -873,12 +906,12 @@ def _compute_histograms(conninfo, tables, date_columns, end_date, max_conns):
     if not tables:
         return {}
 
-    def one(table):
+    def one(table: str) -> tuple[str, list[tuple[int, int]]]:
         lib, tbl = table.split(".")
         with duckdb.connect(":memory:") as con:
             con.execute("SET threads TO 1")
             con.execute("INSTALL postgres; LOAD postgres;")
-            con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
+            _attach_wrds(con, conninfo, password)
             try:
                 return table, _year_histogram(con, "wrds", lib, tbl, date_columns[table], end_date)
             finally:
@@ -890,8 +923,14 @@ def _compute_histograms(conninfo, tables, date_columns, end_date, max_conns):
 
 
 def _build_download_tasks(
-    table_names, filenames, date_columns, end_date, split_tables, n_chunks, histograms
-):
+    table_names: list[str],
+    filenames: dict[str, str],
+    date_columns: dict[str, str],
+    end_date: date | None,
+    split_tables: frozenset[str],
+    n_chunks: int,
+    histograms: dict[str, list[tuple[int, int]]],
+) -> tuple[list[_DownloadTask], dict[str, list[str]]]:
     """Expand the table list into download tasks, splitting ``split_tables`` into date chunks.
 
     ``histograms`` maps a split table to its per-year row counts (see _compute_histograms).
@@ -910,7 +949,7 @@ def _build_download_tasks(
             and date_col
             and end_date is not None
         )
-        if not do_split:
+        if not do_split or hist is None:
             tasks.append(_DownloadTask(table, filenames[table], date_col, None, end_date))
             continue
         ranges = _balanced_year_chunks(hist, n_chunks, end_date)
@@ -958,14 +997,10 @@ def _attach_download_worker(
         con.execute("SET threads TO 1")
         con.execute("INSTALL postgres; LOAD postgres;")
         try:
-            con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
-        except Exception as e:
-            # DuckDB embeds the connection string (with password) in ATTACH errors.
-            reason = (
-                "check credentials and MFA approval" if password and password in str(e) else str(e)
-            )
+            _attach_wrds(con, conninfo, password)
+        except Exception as e:  # noqa: BLE001
             with errors_lock:
-                errors.append(f"<attach>: {reason}")
+                errors.append(f"<attach>: {e}")
             return
         try:
             while True:
@@ -1018,7 +1053,7 @@ def _download_tables_parallel(
         t for t in table_names if t in split_tables and date_columns.get(t) and end_date is not None
     ]
     histograms = (
-        _compute_histograms(conninfo, split_present, date_columns, end_date, workers)
+        _compute_histograms(conninfo, split_present, date_columns, end_date, workers, password)
         if split_present and n_chunks > 1
         else {}
     )
@@ -1182,18 +1217,7 @@ def download_raw_data_tables(
 
     if persistent_connection:
         # Use ATTACH for a single persistent connection (reduces MFA on NAT-rotated networks).
-        # DuckDB's postgres extension includes the full connection string (with password)
-        # in error messages. If the connection fails, suppress the original exception to
-        # avoid leaking credentials in logs/tracebacks, and raise a generic error instead.
-        try:
-            con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
-        except Exception as e:
-            if password in str(e):
-                raise RuntimeError(
-                    "Failed to attach persistent WRDS connection. "
-                    "Check credentials and MFA approval."
-                ) from None
-            raise
+        _attach_wrds(con, conninfo, password)
         try:
             for table in table_names:
                 download_wrds_table_attached(

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -11,11 +11,13 @@ import sys
 import threading
 import time
 import warnings
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from datetime import date
 from math import exp, sqrt
 from pathlib import Path
+from typing import TypeVar
 
 import duckdb
 import ibis
@@ -863,6 +865,38 @@ def _install_postgres_extension() -> None:
         con.execute("INSTALL postgres;")
 
 
+_MapT = TypeVar("_MapT")
+_MapR = TypeVar("_MapR")
+
+
+def _map_interruptible(
+    fn: Callable[[_MapT], _MapR], items: Iterable[_MapT], max_workers: int
+) -> list[_MapR]:
+    """Run ``[fn(item) for item in items]`` concurrently, staying responsive to Ctrl-C.
+
+    Like a ``ThreadPoolExecutor`` map, but a KeyboardInterrupt cancels not-yet-started work and
+    propagates promptly instead of blocking in the pool's ``shutdown(wait=True)``. In-flight calls
+    still finish (a running query/COPY can't be interrupted mid-call). Task exceptions and results
+    propagate in order, exactly like ``list(ex.map(fn, items))``.
+    """
+    ex = ThreadPoolExecutor(max_workers=max_workers)
+    try:
+        futures = [ex.submit(fn, item) for item in items]
+        pending = set(futures)
+        while pending:  # timed waits keep the main thread returning to Python so Ctrl-C can fire
+            _, pending = wait(pending, timeout=0.5)
+        return [f.result() for f in futures]
+    except KeyboardInterrupt:
+        print(
+            "\nInterrupted: stopping after in-flight work finishes...",
+            file=sys.stderr,
+            flush=True,
+        )
+        raise
+    finally:
+        ex.shutdown(wait=True, cancel_futures=True)
+
+
 def _year_histogram(
     con: duckdb.DuckDBPyConnection,
     db_alias: str,
@@ -937,8 +971,7 @@ def _compute_histograms(
                 with contextlib.suppress(Exception):
                     con.execute("DETACH wrds")
 
-    with ThreadPoolExecutor(max_workers=min(len(tables), max_conns)) as ex:
-        return dict(ex.map(one, tables))
+    return dict(_map_interruptible(one, tables, min(len(tables), max_conns)))
 
 
 def _build_download_tasks(
@@ -1203,8 +1236,7 @@ def _download_tables_parallel(
                 with concat_lock:
                     concat_errors.append(f"{Path(final_file).name}: {e}")
 
-        with ThreadPoolExecutor(max_workers=len(concat_map)) as ex:
-            list(ex.map(concat_one, concat_map.items()))
+        _map_interruptible(concat_one, list(concat_map.items()), len(concat_map))
         if concat_errors:
             raise RuntimeError(
                 f"{len(concat_errors)} chunk concatenation(s) failed:\n  "

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -988,7 +988,7 @@ def _remove_chunk_parts(filename: str) -> None:
 
 
 def _attach_download_worker(
-    task_queue: queue.Queue,
+    task_queue: queue.Queue[_DownloadTask],
     conninfo: str,
     password: str,
     errors: list[str],
@@ -1077,7 +1077,7 @@ def _download_tables_parallel(
         if table in split_tables:
             _remove_chunk_parts(filenames[table])
 
-    task_queue: queue.Queue = queue.Queue()
+    task_queue: queue.Queue[_DownloadTask] = queue.Queue()
     for task in tasks:
         task_queue.put(task)
     errors: list[str] = []

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -52,6 +52,18 @@ def build(
         "-p",
         help="Use a single persistent WRDS connection (reduces MFA prompts on NAT-rotated networks).",
     ),
+    download_workers: int = typer.Option(
+        1,
+        "--download-workers",
+        "-j",
+        help=(
+            "Number of concurrent WRDS download connections (default 1 = sequential). "
+            "Higher values download tables in parallel and cut wall time, capped at the WRDS "
+            "per-account connection limit. Ignored when --persistent-connection is set (which "
+            "forces a single connection). On NAT-rotated networks each worker may trigger its "
+            "own MFA prompt at startup; keep at 1 there."
+        ),
+    ),
     force: bool = typer.Option(
         False,
         "--force",
@@ -68,7 +80,11 @@ def build(
             abort=True,
         )
 
-    run_pipeline(persistent_connection=persistent_connection, output_dir=output_dir)
+    run_pipeline(
+        persistent_connection=persistent_connection,
+        max_workers=download_workers,
+        output_dir=output_dir,
+    )
 
 
 @app.command()

--- a/src/jkp/data/main.py
+++ b/src/jkp/data/main.py
@@ -50,7 +50,9 @@ from .paths import DataPaths
 from .wrds_credentials import get_wrds_credentials
 
 
-def run_pipeline(*, persistent_connection: bool = False, output_dir: Path) -> None:
+def run_pipeline(
+    *, persistent_connection: bool = False, max_workers: int = 1, output_dir: Path
+) -> None:
     """Run the full JKP data generation pipeline."""
     paths = DataPaths(base_dir=output_dir.resolve())
     creds = get_wrds_credentials()
@@ -64,6 +66,7 @@ def run_pipeline(*, persistent_connection: bool = False, output_dir: Path) -> No
         password=creds.password,
         end_date=END_DATE,
         persistent_connection=persistent_connection,
+        max_workers=max_workers,
     )
     gen_raw_data_dfs(paths)
     prepare_comp_sf(paths, "both")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -36,6 +36,7 @@ class TestCliHelp:
         result = runner.invoke(app, ["build", "--help"])
         assert result.exit_code == 0
         assert "--persistent-connection" in _strip_ansi(result.output)
+        assert "--download-workers" in _strip_ansi(result.output)
         assert "OUTPUT_DIR" in _strip_ansi(result.output)
 
     def test_portfolio_help(self):
@@ -83,19 +84,41 @@ class TestBuildCommand:
     def test_build_calls_run_pipeline(self, mock_run_pipeline, tmp_path):
         result = runner.invoke(app, ["build", str(tmp_path)])
         assert result.exit_code == 0
-        mock_run_pipeline.assert_called_once_with(persistent_connection=False, output_dir=tmp_path)
+        mock_run_pipeline.assert_called_once_with(
+            persistent_connection=False, max_workers=1, output_dir=tmp_path
+        )
 
     @patch("jkp.data.main.run_pipeline")
     def test_build_persistent_connection(self, mock_run_pipeline, tmp_path):
         result = runner.invoke(app, ["build", str(tmp_path), "--persistent-connection"])
         assert result.exit_code == 0
-        mock_run_pipeline.assert_called_once_with(persistent_connection=True, output_dir=tmp_path)
+        mock_run_pipeline.assert_called_once_with(
+            persistent_connection=True, max_workers=1, output_dir=tmp_path
+        )
 
     @patch("jkp.data.main.run_pipeline")
     def test_build_persistent_connection_short(self, mock_run_pipeline, tmp_path):
         result = runner.invoke(app, ["build", str(tmp_path), "-p"])
         assert result.exit_code == 0
-        mock_run_pipeline.assert_called_once_with(persistent_connection=True, output_dir=tmp_path)
+        mock_run_pipeline.assert_called_once_with(
+            persistent_connection=True, max_workers=1, output_dir=tmp_path
+        )
+
+    @patch("jkp.data.main.run_pipeline")
+    def test_build_download_workers(self, mock_run_pipeline, tmp_path):
+        result = runner.invoke(app, ["build", str(tmp_path), "--download-workers", "6"])
+        assert result.exit_code == 0
+        mock_run_pipeline.assert_called_once_with(
+            persistent_connection=False, max_workers=6, output_dir=tmp_path
+        )
+
+    @patch("jkp.data.main.run_pipeline")
+    def test_build_download_workers_short(self, mock_run_pipeline, tmp_path):
+        result = runner.invoke(app, ["build", str(tmp_path), "-j", "4"])
+        assert result.exit_code == 0
+        mock_run_pipeline.assert_called_once_with(
+            persistent_connection=False, max_workers=4, output_dir=tmp_path
+        )
 
     def test_build_missing_output_dir(self):
         result = runner.invoke(app, ["build"])

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -5,7 +5,9 @@ This module tests the download_raw_data_tables function and its helper functions
 particularly the persistent connection feature that uses ATTACH instead of postgres_scan().
 """
 
+import datetime as dt
 import threading
+from collections import Counter
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -368,3 +370,170 @@ class TestParallelDownload:
         assert mock.connect.call_count == 1
         # The override notice is a warning -> stderr.
         assert "single WRDS connection" in capsys.readouterr().err
+
+
+class TestDateRangeSplitting:
+    """Tests for splitting the giant daily tables into row-balanced date-range chunks."""
+
+    def test_date_where_clause(self):
+        from jkp.data.aux_functions import _date_where
+
+        assert _date_where(None, None, None) == ""
+        assert _date_where("d", None, dt.date(2025, 12, 31)) == "WHERE d <= '2025-12-31'"
+        assert _date_where("d", dt.date(2020, 1, 1), None) == "WHERE d >= '2020-01-01'"
+        assert (
+            _date_where("d", dt.date(2020, 1, 1), dt.date(2025, 12, 31))
+            == "WHERE d >= '2020-01-01' AND d <= '2025-12-31'"
+        )
+
+    def test_download_attached_emits_date_range(self):
+        from jkp.data.aux_functions import download_wrds_table_attached
+
+        con = MagicMock()
+        result = MagicMock()
+        result.description = [("dlycaldt",), ("x",)]
+        con.execute.return_value = result
+
+        download_wrds_table_attached(
+            con,
+            "wrds",
+            "crsp.dsf_v2",
+            "/tmp/c.parquet",
+            date_column="dlycaldt",
+            start_date=dt.date(2020, 1, 1),
+            end_date=dt.date(2025, 12, 31),
+        )
+
+        copy_sql = next(
+            str(c[0][0]) for c in con.execute.call_args_list if c[0] and "COPY" in str(c[0][0])
+        )
+        assert "dlycaldt >= '2020-01-01'" in copy_sql
+        assert "dlycaldt <= '2025-12-31'" in copy_sql
+
+    def test_balanced_chunks_cover_and_balance(self):
+        from jkp.data.aux_functions import _balanced_year_chunks
+
+        # Increasing rows per year (recent years denser), like the real daily tables.
+        hist = [(y, y - 1924) for y in range(1925, 2026)]
+        end = dt.date(2025, 12, 31)
+        ranges = _balanced_year_chunks(hist, 6, end)
+
+        assert len(ranges) == 6
+        assert ranges[0][0] is None  # unbounded below
+        assert ranges[-1][1] == end  # last bounded by overall end_date
+        # Contiguous and non-overlapping (year boundaries line up).
+        for (_s1, e1), (s2, _e2) in zip(ranges[:-1], ranges[1:], strict=True):
+            assert s2.year == e1.year + 1
+
+        def rows(start, end_):
+            return sum(n for y, n in hist if (start is None or y >= start.year) and y <= end_.year)
+
+        sizes = [rows(s, e) for s, e in ranges]
+        assert sum(sizes) == sum(n for _, n in hist)  # complete coverage, no double count
+        target = sum(sizes) / 6
+        assert max(sizes) <= 1.5 * target  # reasonably balanced
+
+    def test_balanced_chunks_degenerate_cases(self):
+        from jkp.data.aux_functions import _balanced_year_chunks
+
+        end = dt.date(2025, 12, 31)
+        assert _balanced_year_chunks([], 6, end) == [(None, end)]
+        assert _balanced_year_chunks([(2025, 100)], 6, end) == [(None, end)]  # single year
+        assert _balanced_year_chunks([(y, 1) for y in range(2000, 2010)], 1, end) == [(None, end)]
+
+    def test_build_tasks_splits_only_split_tables(self):
+        from jkp.data.aux_functions import _build_download_tasks
+
+        end = dt.date(2025, 12, 31)
+        hist = [(y, 10) for y in range(2010, 2022)]  # 12 equal years
+        tables = ["ff.factors_monthly", "crsp.dsf_v2"]
+        filenames = {
+            "ff.factors_monthly": "/o/ff_factors_monthly.parquet",
+            "crsp.dsf_v2": "/o/crsp_dsf_v2.parquet",
+        }
+        tasks, concat_map = _build_download_tasks(
+            tables,
+            filenames,
+            {"crsp.dsf_v2": "dlycaldt"},
+            end,
+            frozenset({"crsp.dsf_v2"}),
+            4,
+            {"crsp.dsf_v2": hist},
+        )
+
+        ff = [t for t in tasks if t.table == "ff.factors_monthly"]
+        dsf = [t for t in tasks if t.table == "crsp.dsf_v2"]
+        assert len(ff) == 1 and ff[0].out == filenames["ff.factors_monthly"]
+        assert len(dsf) == 4  # split into 4 chunks
+        assert all(".part" in t.out for t in dsf)
+        assert dsf[0].start_date is None and dsf[-1].end_date == end
+        assert concat_map[filenames["crsp.dsf_v2"]] == [t.out for t in dsf]
+
+    def test_build_tasks_no_split_without_histogram(self):
+        from jkp.data.aux_functions import _build_download_tasks
+
+        # No histogram (e.g. end_date was None upstream) -> single whole-table task, no concat.
+        tasks, concat_map = _build_download_tasks(
+            ["crsp.dsf_v2"],
+            {"crsp.dsf_v2": "/o/crsp_dsf_v2.parquet"},
+            {"crsp.dsf_v2": "dlycaldt"},
+            None,
+            frozenset({"crsp.dsf_v2"}),
+            4,
+            {},
+        )
+        assert len(tasks) == 1
+        assert tasks[0].out == "/o/crsp_dsf_v2.parquet"
+        assert not concat_map
+
+    def test_concat_chunks_combines_and_removes(self, tmp_path):
+        import polars as pl
+
+        from jkp.data.aux_functions import _concat_chunks
+
+        c0 = tmp_path / "t.part00.parquet"
+        c1 = tmp_path / "t.part01.parquet"
+        pl.DataFrame({"a": [1, 2], "b": ["x", "y"]}).write_parquet(c0)
+        pl.DataFrame({"a": [3], "b": ["z"]}).write_parquet(c1)
+        final = tmp_path / "t.parquet"
+
+        _concat_chunks(str(final), [str(c0), str(c1)])
+
+        out = pl.read_parquet(final)
+        assert out.height == 3
+        assert out["a"].to_list() == [1, 2, 3]  # chunk order preserved
+        assert not c0.exists() and not c1.exists()  # chunks cleaned up
+
+    @patch("jkp.data.aux_functions._compute_histograms")
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_parallel_download_splits_giant_tables(self, mock_dl, mock_hist, test_paths):
+        """End-to-end (mocked): with an end_date, the giant tables expand into max_workers chunks."""
+        from jkp.data.aux_functions import SPLIT_TABLES, download_raw_data_tables
+
+        hist = [(y, 10) for y in range(2010, 2022)]
+        mock_hist.return_value = dict.fromkeys(SPLIT_TABLES, hist)
+
+        recorded: list[str] = []
+        lock = threading.Lock()
+
+        def record(con, alias, table, out, **kwargs):
+            with lock:
+                recorded.append(table)
+
+        mock_dl.side_effect = record
+
+        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
+            conns = [MagicMock(name=f"c{i}") for i in range(40)]
+            for c in conns:
+                c.__enter__.return_value = c
+            mock_duckdb.connect.side_effect = conns
+            download_raw_data_tables(
+                test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
+            )
+
+        counts = Counter(recorded)
+        for split_table in SPLIT_TABLES:
+            assert counts[split_table] == 4, (
+                f"{split_table}: expected 4 chunks, got {counts[split_table]}"
+            )
+        assert counts["ff.factors_monthly"] == 1  # non-split table downloaded once

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -542,9 +542,12 @@ class TestDateRangeSplitting:
                     test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
                 )
 
+    @patch("jkp.data.aux_functions._concat_chunks")
     @patch("jkp.data.aux_functions._compute_histograms")
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
-    def test_parallel_download_splits_giant_tables(self, mock_dl, mock_hist, test_paths):
+    def test_parallel_download_splits_giant_tables(
+        self, mock_dl, mock_hist, mock_concat, test_paths
+    ):
         """End-to-end (mocked): with an end_date, the giant tables expand into max_workers chunks."""
         from jkp.data.aux_functions import SPLIT_TABLES, download_raw_data_tables
 

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -5,6 +5,7 @@ This module tests the download_raw_data_tables function and its helper functions
 particularly the persistent connection feature that uses ATTACH instead of postgres_scan().
 """
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -204,3 +205,166 @@ class TestDownloadWrdsTableAttached:
         assert "wrds.crsp.msf" in copy_sql
         assert "/tmp/test.parquet" in copy_sql
         assert "FORMAT PARQUET" in copy_sql
+
+
+class TestEffectiveDownloadWorkers:
+    """Tests for _effective_download_workers() clamping logic."""
+
+    def test_one_or_less_means_sequential(self):
+        from jkp.data.aux_functions import _effective_download_workers
+
+        assert _effective_download_workers(1, 25) == 1
+        assert _effective_download_workers(0, 25) == 1
+        assert _effective_download_workers(-3, 25) == 1
+
+    def test_clamped_to_connection_limit(self):
+        from jkp.data.aux_functions import WRDS_MAX_CONNECTIONS, _effective_download_workers
+
+        # Leaves one connection of headroom under the WRDS per-account limit.
+        assert _effective_download_workers(100, 25) == WRDS_MAX_CONNECTIONS - 1
+
+    def test_never_more_workers_than_tables(self):
+        from jkp.data.aux_functions import _effective_download_workers
+
+        assert _effective_download_workers(6, 3) == 3
+
+    def test_passthrough_within_bounds(self):
+        from jkp.data.aux_functions import _effective_download_workers
+
+        assert _effective_download_workers(4, 25) == 4
+
+
+class TestParallelDownload:
+    """Tests for the parallel (max_workers > 1) download path."""
+
+    @pytest.fixture
+    def mock_duckdb_multi(self):
+        """Patch duckdb so each connect() returns a distinct mock connection.
+
+        Each mock's __enter__ returns itself, mirroring a real DuckDB connection used as a
+        context manager (``with duckdb.connect() as con`` binds con to the connection), so the
+        worker's ATTACH/DETACH calls are recorded on the same mock and __exit__ closes it.
+        """
+        with patch("jkp.data.aux_functions.duckdb") as mock:
+            conns = [MagicMock(name=f"conn{i}") for i in range(32)]
+            for c in conns:
+                c.__enter__.return_value = c
+            mock.connect.side_effect = conns
+            yield mock, conns
+
+    def _record_tables(self, mock_dl):
+        """Make download_wrds_table_attached record the tables it's asked to download."""
+        recorded: list[str] = []
+        lock = threading.Lock()
+
+        def record(con, alias, table, filename, **kwargs):
+            with lock:
+                recorded.append(table)
+
+        mock_dl.side_effect = record
+        return recorded
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_parallel_covers_same_tables_as_sequential(
+        self, mock_dl, mock_duckdb_multi, test_paths
+    ):
+        """Parallel download must cover exactly the same tables, each once, as the sequential path."""
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        seq = self._record_tables(mock_dl)
+        download_raw_data_tables(
+            test_paths, "user", "pass", persistent_connection=True, max_workers=1
+        )
+        sequential_tables = set(seq)
+
+        mock_dl.reset_mock()
+        par = self._record_tables(mock_dl)
+        download_raw_data_tables(test_paths, "user", "pass", max_workers=4)
+
+        assert len(par) == len(set(par)), "a table was downloaded more than once"
+        assert set(par) == sequential_tables
+        assert len(sequential_tables) > 0
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_one_connection_per_worker_with_attach_detach(
+        self, mock_dl, mock_duckdb_multi, test_paths
+    ):
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        mock, conns = mock_duckdb_multi
+        self._record_tables(mock_dl)
+
+        download_raw_data_tables(test_paths, "user", "pass", max_workers=3)
+
+        assert mock.connect.call_count == 3, "should open exactly one connection per worker"
+        for con in conns[:3]:
+            sqls = " ".join(
+                str(c[0][0])
+                for c in con.execute.call_args_list
+                if c[0] and isinstance(c[0][0], str)
+            )
+            assert "ATTACH" in sqls
+            assert "DETACH" in sqls
+            # Connection is closed via the context manager (`with duckdb.connect()`), i.e. __exit__.
+            con.__exit__.assert_called()
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_worker_count_clamped_to_connection_limit(self, mock_dl, mock_duckdb_multi, test_paths):
+        from jkp.data.aux_functions import WRDS_MAX_CONNECTIONS, download_raw_data_tables
+
+        mock, _ = mock_duckdb_multi
+        self._record_tables(mock_dl)
+
+        download_raw_data_tables(test_paths, "user", "pass", max_workers=50)
+
+        assert mock.connect.call_count == WRDS_MAX_CONNECTIONS - 1
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_table_failure_is_aggregated(self, mock_dl, mock_duckdb_multi, test_paths):
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        def maybe_fail(con, alias, table, filename, **kwargs):
+            if table == "crsp.dsf_v2":
+                raise ValueError("simulated download failure")
+
+        mock_dl.side_effect = maybe_fail
+
+        with pytest.raises(RuntimeError, match="download.*failed"):
+            download_raw_data_tables(test_paths, "user", "pass", max_workers=4)
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_password_not_leaked_in_aggregated_error(self, mock_dl, mock_duckdb_multi, test_paths):
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        def fail_with_secret(con, alias, table, filename, **kwargs):
+            raise ValueError("connection failed for password=hunter2secret while reading")
+
+        mock_dl.side_effect = fail_with_secret
+
+        with pytest.raises(RuntimeError) as exc_info:
+            download_raw_data_tables(test_paths, "user", "hunter2secret", max_workers=2)
+
+        assert "hunter2secret" not in str(exc_info.value)
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_persistent_connection_forces_sequential(
+        self, mock_dl, mock_duckdb_multi, test_paths, capsys
+    ):
+        """--persistent-connection must win over max_workers: a single connection, no parallelism.
+
+        Parallel workers would each open a connection (one MFA prompt apiece), defeating the
+        single-MFA-prompt purpose of --persistent-connection, so it stays sequential.
+        """
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        mock, _ = mock_duckdb_multi
+        self._record_tables(mock_dl)
+
+        download_raw_data_tables(
+            test_paths, "user", "pass", persistent_connection=True, max_workers=6
+        )
+
+        # One connection (sequential ATTACH path), not six (parallel pool).
+        assert mock.connect.call_count == 1
+        # The override notice is a warning -> stderr.
+        assert "single WRDS connection" in capsys.readouterr().err

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -346,7 +346,10 @@ class TestParallelDownload:
         with pytest.raises(RuntimeError) as exc_info:
             download_raw_data_tables(test_paths, "user", "hunter2secret", max_workers=2)
 
-        assert "hunter2secret" not in str(exc_info.value)
+        err = str(exc_info.value)
+        assert "hunter2secret" not in err  # credential redacted
+        assert "***" in err  # ... replaced in place
+        assert "connection failed" in err and "while reading" in err  # ... diagnostic preserved
 
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_persistent_connection_forces_sequential(

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -390,6 +390,28 @@ class TestParallelDownload:
         mock_dl.assert_not_called()  # no table was ever downloaded
 
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    @patch("jkp.data.aux_functions._attach_wrds")
+    @patch("jkp.data.aux_functions.duckdb")
+    def test_worker_respects_stop_event(self, mock_duckdb, mock_attach, mock_dl):
+        """A set stop_event makes a worker exit its drain loop without pulling any task (Ctrl-C path)."""
+        import queue as _queue
+
+        from jkp.data.aux_functions import _attach_download_worker, _DownloadTask
+
+        con = MagicMock()
+        con.__enter__.return_value = con
+        mock_duckdb.connect.return_value = con
+        task_queue: _queue.Queue = _queue.Queue()
+        task_queue.put(_DownloadTask("crsp.dsf_v2", "/tmp/x.parquet", None, None, None))
+        stop_event = threading.Event()
+        stop_event.set()  # already asked to stop
+
+        _attach_download_worker(task_queue, "conninfo", "pw", [], [], threading.Lock(), stop_event)
+
+        mock_dl.assert_not_called()  # nothing pulled/downloaded
+        assert task_queue.qsize() == 1  # task left un-pulled
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_persistent_connection_forces_sequential(
         self, mock_dl, mock_duckdb_multi, test_paths, capsys
     ):

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -504,6 +504,44 @@ class TestDateRangeSplitting:
         assert out["a"].to_list() == [1, 2, 3]  # chunk order preserved
         assert not c0.exists() and not c1.exists()  # chunks cleaned up
 
+    def test_remove_chunk_parts(self, tmp_path):
+        from jkp.data.aux_functions import _remove_chunk_parts
+
+        final = tmp_path / "crsp_dsf_v2.parquet"
+        final.write_bytes(b"keep")
+        (tmp_path / "crsp_dsf_v2.part00.parquet").write_bytes(b"x")
+        (tmp_path / "crsp_dsf_v2.part09.parquet").write_bytes(b"x")  # high index from a prior run
+        (tmp_path / "comp_secd.part00.parquet").write_bytes(b"other")  # different table
+
+        _remove_chunk_parts(str(final))
+
+        assert not (tmp_path / "crsp_dsf_v2.part00.parquet").exists()
+        assert not (tmp_path / "crsp_dsf_v2.part09.parquet").exists()
+        assert final.exists()  # the final (non-part) file is left untouched
+        assert (tmp_path / "comp_secd.part00.parquet").exists()  # other tables untouched
+
+    @patch("jkp.data.aux_functions._concat_chunks")
+    @patch("jkp.data.aux_functions._compute_histograms")
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_parallel_download_aggregates_concat_failures(
+        self, mock_dl, mock_hist, mock_concat, test_paths
+    ):
+        """A concat failure surfaces as one aggregated error, not a raw first-failure exception."""
+        from jkp.data.aux_functions import SPLIT_TABLES, download_raw_data_tables
+
+        mock_hist.return_value = dict.fromkeys(SPLIT_TABLES, [(y, 10) for y in range(2010, 2022)])
+        mock_concat.side_effect = RuntimeError("disk full")
+
+        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
+            conns = [MagicMock(name=f"c{i}") for i in range(40)]
+            for c in conns:
+                c.__enter__.return_value = c
+            mock_duckdb.connect.side_effect = conns
+            with pytest.raises(RuntimeError, match="concatenation"):
+                download_raw_data_tables(
+                    test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
+                )
+
     @patch("jkp.data.aux_functions._compute_histograms")
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_parallel_download_splits_giant_tables(self, mock_dl, mock_hist, test_paths):

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -749,3 +749,33 @@ class TestAttachWrds:
         # A non-credential error (no password in it) propagates unchanged.
         with pytest.raises(RuntimeError, match="too many connections"):
             _attach_wrds(con, "host=x password=hunter2", "hunter2")
+
+
+class TestMapInterruptible:
+    """The interrupt-responsive concurrent map used by the histogram and concat phases."""
+
+    def test_preserves_order_and_returns_results(self):
+        from jkp.data.aux_functions import _map_interruptible
+
+        assert _map_interruptible(lambda x: x * 2, [1, 2, 3, 4], max_workers=3) == [2, 4, 6, 8]
+
+    def test_propagates_task_exception(self):
+        from jkp.data.aux_functions import _map_interruptible
+
+        def boom(x):
+            if x == 2:
+                raise ValueError("boom")
+            return x
+
+        with pytest.raises(ValueError, match="boom"):
+            _map_interruptible(boom, [1, 2, 3], max_workers=3)
+
+    def test_propagates_keyboard_interrupt(self):
+        """A Ctrl-C during the wait loop unwinds promptly rather than blocking in shutdown."""
+        from jkp.data.aux_functions import _map_interruptible
+
+        with (
+            patch("jkp.data.aux_functions.wait", side_effect=KeyboardInterrupt),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            _map_interruptible(lambda x: x, [1, 2, 3], max_workers=2)

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -352,6 +352,44 @@ class TestParallelDownload:
         assert "connection failed" in err and "while reading" in err  # ... diagnostic preserved
 
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    @patch("jkp.data.aux_functions._attach_wrds")
+    def test_one_attach_failure_is_non_fatal_when_queue_drains(
+        self, mock_attach, mock_dl, mock_duckdb_multi, test_paths, capsys
+    ):
+        """One worker failing to attach must not fail the run if survivors download every table."""
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        seen = {"n": 0}
+        seen_lock = threading.Lock()
+
+        def attach(con, conninfo, password):
+            with seen_lock:
+                seen["n"] += 1
+                first = seen["n"] == 1
+            if first:  # exactly one worker fails to attach
+                raise RuntimeError("Failed to attach WRDS connection. Check credentials and MFA.")
+
+        mock_attach.side_effect = attach
+        self._record_tables(mock_dl)
+
+        # Must NOT raise: the other workers drain the shared queue.
+        download_raw_data_tables(test_paths, "user", "pass", max_workers=3)
+
+        err = capsys.readouterr().err
+        assert "failed to attach" in err  # warned (immediately + in the summary)
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    @patch("jkp.data.aux_functions._attach_wrds")
+    def test_all_attach_failures_raise(self, mock_attach, mock_dl, mock_duckdb_multi, test_paths):
+        """If every worker fails to attach, the queue never drains -> raise (nothing downloaded)."""
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        mock_attach.side_effect = RuntimeError("Failed to attach WRDS connection.")
+        with pytest.raises(RuntimeError, match="failed to attach"):
+            download_raw_data_tables(test_paths, "user", "pass", max_workers=3)
+        mock_dl.assert_not_called()  # no table was ever downloaded
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_persistent_connection_forces_sequential(
         self, mock_dl, mock_duckdb_multi, test_paths, capsys
     ):

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -511,6 +511,7 @@ class TestDateRangeSplitting:
         final.write_bytes(b"keep")
         (tmp_path / "crsp_dsf_v2.part00.parquet").write_bytes(b"x")
         (tmp_path / "crsp_dsf_v2.part09.parquet").write_bytes(b"x")  # high index from a prior run
+        (tmp_path / "crsp_dsf_v2.partial.parquet").write_bytes(b"nope")  # must NOT be swept
         (tmp_path / "comp_secd.part00.parquet").write_bytes(b"other")  # different table
 
         _remove_chunk_parts(str(final))
@@ -518,6 +519,7 @@ class TestDateRangeSplitting:
         assert not (tmp_path / "crsp_dsf_v2.part00.parquet").exists()
         assert not (tmp_path / "crsp_dsf_v2.part09.parquet").exists()
         assert final.exists()  # the final (non-part) file is left untouched
+        assert (tmp_path / "crsp_dsf_v2.partial.parquet").exists()  # `part[0-9][0-9]` excludes this
         assert (tmp_path / "comp_secd.part00.parquet").exists()  # other tables untouched
 
     @patch("jkp.data.aux_functions._concat_chunks")

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -298,8 +298,15 @@ class TestParallelDownload:
 
         download_raw_data_tables(test_paths, "user", "pass", max_workers=3)
 
-        assert mock.connect.call_count == 3, "should open exactly one connection per worker"
-        for con in conns[:3]:
+        # One up-front connection to INSTALL the extension, then one per worker.
+        assert mock.connect.call_count == 1 + 3
+        install_sqls = " ".join(
+            str(c[0][0])
+            for c in conns[0].execute.call_args_list
+            if c[0] and isinstance(c[0][0], str)
+        )
+        assert "INSTALL" in install_sqls and "ATTACH" not in install_sqls  # install-only, no WRDS
+        for con in conns[1:4]:  # the three worker connections
             sqls = " ".join(
                 str(c[0][0])
                 for c in con.execute.call_args_list
@@ -319,7 +326,8 @@ class TestParallelDownload:
 
         download_raw_data_tables(test_paths, "user", "pass", max_workers=50)
 
-        assert mock.connect.call_count == WRDS_MAX_CONNECTIONS - 1
+        # Clamped worker connections, plus the one up-front extension-install connection.
+        assert mock.connect.call_count == (WRDS_MAX_CONNECTIONS - 1) + 1
 
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_table_failure_is_aggregated(self, mock_dl, mock_duckdb_multi, test_paths):
@@ -376,7 +384,7 @@ class TestParallelDownload:
         download_raw_data_tables(test_paths, "user", "pass", max_workers=3)
 
         err = capsys.readouterr().err
-        assert "failed to attach" in err  # warned (immediately + in the summary)
+        assert "failed to start" in err  # warned (immediately + in the summary)
 
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     @patch("jkp.data.aux_functions._attach_wrds")
@@ -385,7 +393,7 @@ class TestParallelDownload:
         from jkp.data.aux_functions import download_raw_data_tables
 
         mock_attach.side_effect = RuntimeError("Failed to attach WRDS connection.")
-        with pytest.raises(RuntimeError, match="failed to attach"):
+        with pytest.raises(RuntimeError, match="failed to start"):
             download_raw_data_tables(test_paths, "user", "pass", max_workers=3)
         mock_dl.assert_not_called()  # no table was ever downloaded
 

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -537,3 +537,101 @@ class TestDateRangeSplitting:
                 f"{split_table}: expected 4 chunks, got {counts[split_table]}"
             )
         assert counts["ff.factors_monthly"] == 1  # non-split table downloaded once
+
+    def test_balanced_chunks_skewed_distribution(self):
+        # One year dwarfs the rest (its count exceeds the per-chunk target): chunks must still
+        # cover everything exactly once with contiguous, non-empty year ranges.
+        from jkp.data.aux_functions import _balanced_year_chunks
+
+        end = dt.date(2025, 12, 31)
+        hist = [(2000, 1), (2001, 1), (2002, 1000), (2003, 1), (2004, 1)]
+        ranges = _balanced_year_chunks(hist, 4, end)
+
+        assert ranges[0][0] is None
+        assert ranges[-1][1] == end
+        for (_s1, e1), (s2, _e2) in zip(ranges[:-1], ranges[1:], strict=True):
+            assert s2.year == e1.year + 1  # contiguous, non-overlapping
+        for s, e in ranges:
+            if s is not None:
+                assert s <= e  # no empty/inverted spans
+
+        def rows(start, end_):
+            return sum(n for y, n in hist if (start is None or y >= start.year) and y <= end_.year)
+
+        assert sum(rows(s, e) for s, e in ranges) == sum(n for _, n in hist)  # complete coverage
+
+    @patch("jkp.data.aux_functions._concat_chunks")
+    @patch("jkp.data.aux_functions._compute_histograms")
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_parallel_download_concatenates_each_split_table(
+        self, mock_dl, mock_hist, mock_concat, test_paths
+    ):
+        """The concat_map -> ThreadPoolExecutor wiring invokes _concat_chunks once per split table."""
+        from jkp.data.aux_functions import SPLIT_TABLES, download_raw_data_tables
+
+        mock_hist.return_value = dict.fromkeys(SPLIT_TABLES, [(y, 10) for y in range(2010, 2022)])
+        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
+            conns = [MagicMock(name=f"c{i}") for i in range(40)]
+            for c in conns:
+                c.__enter__.return_value = c
+            mock_duckdb.connect.side_effect = conns
+            download_raw_data_tables(
+                test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
+            )
+
+        assert mock_concat.call_count == len(SPLIT_TABLES)
+        for call in mock_concat.call_args_list:
+            _final_file, chunk_files = call.args
+            assert len(chunk_files) == 4
+            assert chunk_files == sorted(chunk_files)  # chunks concatenated in part00..part03 order
+            assert all(".part" in cf for cf in chunk_files)
+
+    def test_compute_histograms_attach_failure_is_redacted(self):
+        """A histogram-phase ATTACH failure must not leak the password (regression for M1)."""
+        from jkp.data.aux_functions import _compute_histograms
+
+        password = "topsecret"  # noqa: S105
+
+        def execute(sql, *args):
+            if "ATTACH" in sql:
+                raise RuntimeError(f"Connection failed: host=x password={password} dbname=wrds")
+            return MagicMock()
+
+        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
+            con = MagicMock()
+            con.__enter__.return_value = con
+            con.execute.side_effect = execute
+            mock_duckdb.connect.return_value = con
+            with pytest.raises(Exception) as exc_info:  # noqa: PT011
+                _compute_histograms(
+                    f"host=x password={password}",
+                    ["crsp.dsf_v2"],
+                    {"crsp.dsf_v2": "dlycaldt"},
+                    dt.date(2025, 12, 31),
+                    4,
+                    password,
+                )
+        assert password not in str(exc_info.value)
+
+
+class TestAttachWrds:
+    """The shared WRDS ATTACH helper (password redaction)."""
+
+    def test_redacts_password_on_attach_error(self):
+        from jkp.data.aux_functions import _attach_wrds
+
+        con = MagicMock()
+        con.execute.side_effect = RuntimeError("ATTACH failed: host=x password=hunter2 dbname=wrds")
+        with pytest.raises(RuntimeError) as exc_info:
+            _attach_wrds(con, "host=x password=hunter2", "hunter2")
+        assert "hunter2" not in str(exc_info.value)
+        assert "credentials" in str(exc_info.value).lower()
+
+    def test_passes_through_non_password_error(self):
+        from jkp.data.aux_functions import _attach_wrds
+
+        con = MagicMock()
+        con.execute.side_effect = RuntimeError("FATAL: too many connections for role")
+        # A non-credential error (no password in it) propagates unchanged.
+        with pytest.raises(RuntimeError, match="too many connections"):
+            _attach_wrds(con, "host=x password=hunter2", "hunter2")


### PR DESCRIPTION
## Summary

Addresses #194 (raw-table download slowed from ~30 min to 60–120 min). Diagnosis on the Yale SOM
HPC showed the download is single-threaded and transfer-bound, and that WRDS↔cluster throughput
became degraded/variable after the maintenance windows (environmental, not our code). A single
sequential stream is maximally exposed to that, so this PR **parallelizes the download** to recover
the time.

`download_raw_data_tables()` gains a `max_workers` parameter (CLI: `jkp build --download-workers/-j`,
default `1` = current sequential behavior, fully backward-compatible):

- **Across-table parallelism** — the ~26 tables download concurrently over a pool of persistent
  `ATTACH` connections (one per worker), drained from a shared queue for load balancing. Clamped to
  the WRDS per-account connection limit (`WRDS_MAX_CONNECTIONS`, pool ≤ 6).
- **Date-range splitting** — the three giant daily tables (`crsp.dsf_v2`, `comp.secd`,
  `comp.g_secd`; 110–300 M rows) are split into `max_workers` row-balanced date-range chunks
  (boundaries from concurrent per-year row histograms), downloaded as a mix of whole-table and chunk
  tasks, then concatenated back into one parquet per table.
- `--persistent-connection` takes precedence and forces a single sequential connection (preserving
  its single-MFA-prompt behavior on NAT-rotated networks); a notice goes to stderr if both are set.

## Change Type

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [ ] Infrastructure change (CI, config, dependencies)
- [ ] Documentation only
- [x] Performance-impacting change

## Methodological Impact

None. No factor definitions or calculations are touched — only how the raw WRDS tables are fetched.

## Data Impact

**None of practical significance**, confirmed by a full 3-way determinism experiment on Yale — three
complete `jkp build` runs (`main`, this branch at `--download-workers 1`, and at
`--download-workers 4`), with an order-independent diff of every `interim/` and `processed/` output.

- **Raw is reproduced exactly:** all 26 raw tables are identical (order-independent, by row count and
  per-column fingerprint), including the 110–300 M-row giants — the split/parallel download yields the
  same raw row *set* as sequential.
- **Final outputs:** the parallel run matches the sequential runs on every output file and column
  except one — `other_output/market_returns.parquet`'s `dolvol_lag1` (a dollar-volume sum over
  securities), which differs by at most **5.9e-16 relative (machine epsilon / last-bit float)**,
  because a different security order changes the order of a floating-point summation.

The experiment also surfaced **potential pre-existing determinism problems in the pipeline that are
unrelated to this change** — two *sequential* runs with byte-identical raw input already differ on a
number of downstream files (float-reduction noise, plus an order-sensitivity in the industry-history
expansion). The parallel download stays within that existing run-to-run variation. These are **not
introduced by this PR and should be investigated/fixed separately, in their own PR** — flagged here
only so the reviewer knows the observed downstream differences don't come from this change.

## Breaking Changes

None. `max_workers` defaults to 1, so existing invocations are unchanged.

## Tests

679 unit tests pass. New tests in `tests/unit/test_wrds_download.py` cover:
- worker-count clamping to the WRDS connection limit; parallel path covers the same tables; one
  connection per worker (ATTACH/DETACH/close); error aggregation; password redaction;
  `--persistent-connection` forcing sequential.
- date-range splitting: row-balanced chunk boundaries (coverage, balance, no overlap, degenerate
  cases), task building (split vs whole-table), chunk concatenation, the `start_date` date-range
  clause, and an end-to-end (mocked) check that giants expand into `max_workers` chunks.

Connection safety and end-to-end correctness/speedup were verified on live WRDS (see notes).

## Checklist

- [x] I have run the tests locally (`pytest`)
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [x] I have verified the pipeline runs successfully after my changes
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

(`jkp build` was run end-to-end three times on Yale for the determinism experiment — see Data
Impact. `jkp portfolio` was not separately re-run; the one observed difference is machine-epsilon
and within the pipeline's existing run-to-run variation, so re-running it would not change the
conclusion.)

## Additional Notes

Verified on Yale (full 26-table history, `max_workers=6`):

| | sequential | parallel | speedup |
|---|---|---|---|
| across-table only | 85 min | 53 min | 1.6× |
| + date-range splitting | 64 min | 25 min | **2.6×** |

- **Connection safety** (measured client-side with `psutil`): `max_workers=N` opens exactly N client
  connections — the boundary phase uses ≤3, the workers 6, non-overlapping — so the peak stays at 6,
  one under the WRDS limit of 7. (Server-side `pg_stat_activity` over-reports because WRDS fronts
  PostgreSQL with pgpool; the client socket count is the real number.)
- No `CHANGELOG_DATA.md` entry: this changes *how* tables are downloaded, not *what* is written.


