### PR TITLE
test: golden + unit tests for prepare_crsp_sf, market_beta, residual_momentum, firm_age

### DIFF
--- a/tests/golden/test_firm_age_golden.py
+++ b/tests/golden/test_firm_age_golden.py
@@ -1,0 +1,41 @@
+"""Golden-fixture regression test for firm_age.
+
+Run with --regen-golden to regenerate the fixture:
+    PYTHONPATH=src uv run --no-sync python -m pytest tests/golden/test_firm_age_golden.py --regen-golden -v
+
+Run without to verify against the committed fixture:
+    PYTHONPATH=src uv run --no-sync python -m pytest tests/golden/test_firm_age_golden.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import polars.testing
+import pytest
+
+from jkp.data.aux_functions import firm_age
+from tests.golden.firm_age_inputs import write_full_inputs
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "firm_age" / "firm_age.parquet"
+
+
+@pytest.mark.regression
+def test_firm_age_golden(test_paths, request: pytest.FixtureRequest) -> None:
+    """firm_age output matches the committed golden fixture (exact Int64 ages)."""
+    write_full_inputs(test_paths)
+
+    firm_age(test_paths, test_paths.interim_dir / "world_msf.parquet")
+
+    actual = pl.read_parquet(test_paths.interim_dir / "firm_age.parquet").sort(["id", "eom"])
+
+    if request.config.getoption("--regen-golden"):
+        FIXTURE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        actual.write_parquet(FIXTURE_PATH)
+        pytest.skip("regenerated golden fixture")
+
+    assert FIXTURE_PATH.exists(), f"missing golden fixture: {FIXTURE_PATH}"
+    expected = pl.read_parquet(FIXTURE_PATH).sort(["id", "eom"])
+
+    polars.testing.assert_frame_equal(actual, expected, check_exact=True)

--- a/tests/golden/test_market_beta_golden.py
+++ b/tests/golden/test_market_beta_golden.py
@@ -1,0 +1,67 @@
+"""Golden-fixture regression test for market_beta.
+
+Run with --regen-golden to regenerate the fixture:
+    PYTHONPATH=src uv run --no-sync python -m pytest tests/golden/test_market_beta_golden.py --regen-golden -v
+
+Run without to verify against the committed fixture:
+    PYTHONPATH=src uv run --no-sync python -m pytest tests/golden/test_market_beta_golden.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import polars.testing
+import pytest
+
+from jkp.data.aux_functions import market_beta
+from tests.golden.market_beta_inputs import (
+    build_ap_factors_monthly_input,
+    build_world_msf_input,
+)
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "market_beta" / "beta_60m.parquet"
+
+
+@pytest.mark.regression
+def test_market_beta_golden(
+    test_paths,
+    tolerance,
+    request: pytest.FixtureRequest,
+) -> None:
+    """market_beta output matches the committed golden fixture."""
+    data_path = test_paths.interim_dir / "world_msf.parquet"
+    fcts_path = test_paths.interim_dir / "ap_factors_monthly.parquet"
+    build_world_msf_input(seed=42).write_parquet(data_path)
+    build_ap_factors_monthly_input(seed=42).write_parquet(fcts_path)
+
+    out_path = test_paths.interim_dir / "beta_60m.parquet"
+    market_beta(test_paths, out_path, data_path, fcts_path, 60, 36)
+
+    actual = pl.read_parquet(out_path).sort(["id", "eom"])
+
+    if request.config.getoption("--regen-golden"):
+        FIXTURE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        actual.write_parquet(FIXTURE_PATH)
+        pytest.skip("regenerated golden fixture")
+
+    assert FIXTURE_PATH.exists(), f"missing golden fixture: {FIXTURE_PATH}"
+    expected = pl.read_parquet(FIXTURE_PATH)
+
+    # Key columns must match exactly (no tolerance).
+    key_cols = ["id", "eom"]
+    polars.testing.assert_frame_equal(
+        actual.select(key_cols),
+        expected.select(key_cols),
+        check_exact=True,
+    )
+
+    # Float columns: tight tolerance (same seed, same platform ops).
+    for col in ["beta_60m", "ivol_capm_60m"]:
+        polars.testing.assert_series_equal(
+            actual[col],
+            expected[col],
+            **tolerance.GOLDEN,
+            check_names=True,
+        )

--- a/tests/golden/test_prepare_crsp_sf_golden.py
+++ b/tests/golden/test_prepare_crsp_sf_golden.py
@@ -1,0 +1,58 @@
+"""Golden regression test for prepare_crsp_sf().
+
+Reconstructs the synthetic inputs from ``prepare_crsp_sf_inputs``, runs the real
+``prepare_crsp_sf`` for both freqs on a tmp DataPaths, and asserts every emitted
+parquet equals its committed fixture. Pass ``--regen-golden`` to overwrite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from jkp.data.aux_functions import prepare_crsp_sf
+from jkp.data.paths import DataPaths
+from tests.conftest import ToleranceSpec, assert_series_equal
+from tests.golden.prepare_crsp_sf_inputs import write_all_inputs
+
+GOLDEN_DIR = Path(__file__).parent / "fixtures" / "prepare_crsp_sf"
+
+
+def _assert_frames_equal(actual: pl.DataFrame, expected: pl.DataFrame) -> None:
+    """NaN/null-aware full-frame comparison (columns, dtypes, values)."""
+    actual = actual.sort(["permno", "date"])
+    expected = expected.sort(["permno", "date"])
+    assert actual.columns == expected.columns, (
+        f"Column mismatch:\n actual={actual.columns}\n expected={expected.columns}"
+    )
+    assert actual.schema == expected.schema, (
+        f"Dtype mismatch:\n actual={actual.schema}\n expected={expected.schema}"
+    )
+    assert actual.height == expected.height, (
+        f"Row count differs: {actual.height} vs {expected.height}"
+    )
+    for name in expected.columns:
+        a, e = actual[name], expected[name]
+        if a.dtype.is_numeric():
+            assert_series_equal(a.cast(pl.Float64), e.cast(pl.Float64), **ToleranceSpec.GOLDEN)
+        else:
+            assert a.to_list() == e.to_list(), f"Column {name} differs"
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("freq", ["m", "d"])
+def test_prepare_crsp_sf_golden(freq: str, tmp_path: Path, request: pytest.FixtureRequest) -> None:
+    paths = DataPaths(base_dir=tmp_path)
+    write_all_inputs(paths, freq)
+    prepare_crsp_sf(paths, freq)
+    actual = pl.read_parquet(paths.interim_dir / f"crsp_{freq}sf.parquet")
+
+    fixture_path = GOLDEN_DIR / f"crsp_{freq}sf.parquet"
+    if request.config.getoption("--regen-golden"):
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        actual.write_parquet(fixture_path)
+        pytest.skip(f"Regenerated {fixture_path}")
+
+    _assert_frames_equal(actual, pl.read_parquet(fixture_path))

--- a/tests/golden/test_residual_momentum_golden.py
+++ b/tests/golden/test_residual_momentum_golden.py
@@ -1,0 +1,75 @@
+"""Golden-fixture regression test for ``residual_momentum``.
+
+Run with --regen-golden to regenerate the fixtures:
+    PYTHONPATH=src uv run --no-sync python -m pytest \
+        tests/golden/test_residual_momentum_golden.py --regen-golden -v
+
+Run without to verify against the committed fixtures:
+    PYTHONPATH=src uv run --no-sync python -m pytest \
+        tests/golden/test_residual_momentum_golden.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import polars.testing
+import pytest
+
+from jkp.data.aux_functions import residual_momentum
+from tests.golden.residual_momentum_inputs import (
+    build_ap_factors_monthly_input,
+    build_world_msf_input,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "residual_momentum"
+_OUTPUT_STEM = "resmom_ff3"
+_N = 36
+_MIN = 24
+_VARIANTS = ((12, 1), (6, 1))
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(("incl", "skip"), _VARIANTS)
+def test_residual_momentum_golden(
+    test_paths,
+    tolerance,
+    request: pytest.FixtureRequest,
+    incl: int,
+    skip: int,
+) -> None:
+    """residual_momentum output matches the committed golden fixture."""
+    world_path = test_paths.interim_dir / "world_msf.parquet"
+    fcts_path = test_paths.interim_dir / "ap_factors_monthly.parquet"
+    build_world_msf_input(seed=42).write_parquet(world_path)
+    build_ap_factors_monthly_input(seed=42).write_parquet(fcts_path)
+
+    residual_momentum(test_paths, _OUTPUT_STEM, world_path, fcts_path, _N, _MIN, incl, skip)
+
+    name = f"{_OUTPUT_STEM}_{incl}_{skip}.parquet"
+    value_col = f"resff3_{incl}_{skip}"
+    actual = pl.read_parquet(test_paths.interim_dir / name).sort(["id", "eom"])
+
+    fixture_path = FIXTURE_DIR / name
+    if request.config.getoption("--regen-golden"):
+        FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+        actual.write_parquet(fixture_path)
+        pytest.skip(f"regenerated golden fixture: {name}")
+
+    assert fixture_path.exists(), f"missing golden fixture: {fixture_path}"
+    expected = pl.read_parquet(fixture_path).sort(["id", "eom"])
+
+    # Key columns must match exactly (no tolerance).
+    polars.testing.assert_frame_equal(
+        actual.select(["id", "eom"]),
+        expected.select(["id", "eom"]),
+        check_exact=True,
+    )
+    # Float column: tight golden tolerance (same seed, same platform ops).
+    polars.testing.assert_series_equal(
+        actual[value_col],
+        expected[value_col],
+        **tolerance.GOLDEN,
+        check_names=True,
+    )

--- a/tests/unit/test_firm_age.py
+++ b/tests/unit/test_firm_age.py
@@ -1,0 +1,283 @@
+"""Unit tests for firm_age() — semantic behaviour and edge cases.
+
+Each test writes minimal (all six) synthetic inputs via ``write_all_inputs``,
+runs the real ``firm_age`` on a ``test_paths`` DataPaths, and asserts the exact
+``age`` (Int64 whole months) per ``(id, eom)``. Ages are exact integers, so
+these use plain equality — never float tolerance.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+
+from jkp.data.aux_functions import firm_age
+from jkp.data.paths import DataPaths
+from tests.golden.firm_age_inputs import (
+    COMP_FUNDA_SCHEMA,
+    COMP_G_FUNDA_SCHEMA,
+    COMP_G_SECD_SCHEMA,
+    COMP_SECM_SCHEMA,
+    CRSP_MSF_V2_AUG_SCHEMA,
+    WORLD_MSF_SCHEMA,
+    build_comp_funda_input,
+    build_comp_g_funda_input,
+    build_comp_g_secd_input,
+    build_comp_secm_input,
+    build_crsp_msf_v2_aug_input,
+    build_world_msf_input,
+    write_all_inputs,
+)
+
+
+def _run(paths: DataPaths, **inputs: pl.DataFrame) -> dict[tuple[int, date], int]:
+    """Run firm_age and return an ``{(id, eom): age}`` map.
+
+    Description:
+        Write the supplied (and defaulted-empty) inputs, run ``firm_age``, and
+        collect its output into a lookup keyed by ``(id, eom)``.
+    Steps:
+        1) Write all six inputs (missing ones default to typed 0-row frames).
+        2) Run ``firm_age`` against the written ``world_msf``.
+        3) Read the output parquet and build the ``(id, eom) -> age`` dict.
+    Output:
+        Dict mapping each ``(id, eom)`` to its computed ``age``.
+    """
+    write_all_inputs(paths, **inputs)
+    firm_age(paths, paths.interim_dir / "world_msf.parquet")
+    out = pl.read_parquet(paths.interim_dir / "firm_age.parquet")
+    return {(r["id"], r["eom"]): r["age"] for r in out.iter_rows(named=True)}
+
+
+def _world(id_: int, permco: int | None, gvkey: str, eoms: list[date]) -> pl.DataFrame:
+    """Build a single-firm ``world_msf`` frame with one row per ``eom``."""
+    return pl.DataFrame(
+        {
+            "id": [id_] * len(eoms),
+            "permco": [permco] * len(eoms),
+            "gvkey": [gvkey] * len(eoms),
+            "eom": eoms,
+        },
+        schema=WORLD_MSF_SCHEMA,
+    )
+
+
+def test_all_three_sources_crsp_earliest_wins(test_paths: DataPaths) -> None:
+    """Entity A: CRSP is earliest of the three signals; comp_ret union spans US+global."""
+    ages = _run(
+        test_paths,
+        world_msf=_world(10001, 1001, "001000", [date(2015, 1, 31), date(2015, 2, 28)]),
+        crsp=pl.DataFrame(
+            {"permco": [1001, 1001], "mthcaldt": [date(2010, 1, 31), date(2011, 1, 31)]},
+            schema=CRSP_MSF_V2_AUG_SCHEMA,
+        ),
+        comp_funda=pl.DataFrame(
+            {"gvkey": ["001000"], "datadate": [date(2011, 6, 30)]}, schema=COMP_FUNDA_SCHEMA
+        ),
+        comp_secm=pl.DataFrame(
+            {"gvkey": ["001000"], "datadate": [date(2012, 3, 31)]}, schema=COMP_SECM_SCHEMA
+        ),
+        comp_g_secd=pl.DataFrame(
+            {"gvkey": ["001000"], "datadate": [date(2011, 1, 31)], "monthend": [1]},
+            schema=COMP_G_SECD_SCHEMA,
+        ),
+    )
+    assert ages[(10001, date(2015, 1, 31))] == 60
+    assert ages[(10001, date(2015, 2, 28))] == 61
+
+
+def test_comp_acc_wins_with_negative_month_diff(test_paths: DataPaths) -> None:
+    """Entity B: comp_acc is earliest; eom month < first-obs month gives a negative month term."""
+    ages = _run(
+        test_paths,
+        world_msf=_world(10002, 1002, "002000", [date(2015, 6, 30)]),
+        crsp=pl.DataFrame(
+            {"permco": [1002], "mthcaldt": [date(2013, 5, 31)]}, schema=CRSP_MSF_V2_AUG_SCHEMA
+        ),
+        comp_funda=pl.DataFrame(
+            {"gvkey": ["002000"], "datadate": [date(2009, 6, 30)]}, schema=COMP_FUNDA_SCHEMA
+        ),
+        comp_secm=pl.DataFrame(
+            {"gvkey": ["002000"], "datadate": [date(2012, 1, 31)]}, schema=COMP_SECM_SCHEMA
+        ),
+    )
+    # first_obs = 2008-12-31; (2015-2008)*12 + (6-12) = 78
+    assert ages[(10002, date(2015, 6, 30))] == 78
+
+
+def test_comp_ret_only_monthend_filter_is_load_bearing(test_paths: DataPaths) -> None:
+    """Entity C: comp_g_secd monthend=0 row must be dropped; flipping it changes the age."""
+    world = _world(10003, None, "003000", [date(2016, 9, 30)])
+
+    filtered = _run(
+        test_paths,
+        world_msf=world,
+        comp_g_secd=pl.DataFrame(
+            {
+                "gvkey": ["003000", "003000"],
+                "datadate": [date(2014, 8, 31), date(2012, 5, 15)],
+                "monthend": [1, 0],
+            },
+            schema=COMP_G_SECD_SCHEMA,
+        ),
+    )
+    # monthend=0 dropped: first_obs = 2013-12-31; (2016-2013)*12 + (9-12) = 33
+    assert filtered[(10003, date(2016, 9, 30))] == 33
+
+    leaked = _run(
+        test_paths,
+        world_msf=world,
+        comp_g_secd=pl.DataFrame(
+            {
+                "gvkey": ["003000", "003000"],
+                "datadate": [date(2014, 8, 31), date(2012, 5, 15)],
+                "monthend": [1, 1],
+            },
+            schema=COMP_G_SECD_SCHEMA,
+        ),
+    )
+    # both kept: min 2012-05-15 -> first_obs 2011-12-31; (2016-2011)*12 + (9-12) = 57
+    assert leaked[(10003, date(2016, 9, 30))] == 57
+
+
+def test_crsp_only_age_zero_at_first_month(test_paths: DataPaths) -> None:
+    """Entity D: CRSP-only firm; age is 0 at the first eom and increments monthly."""
+    ages = _run(
+        test_paths,
+        world_msf=_world(10004, 1004, "004000", [date(2018, 2, 28), date(2018, 3, 31)]),
+        crsp=pl.DataFrame(
+            {"permco": [1004], "mthcaldt": [date(2018, 2, 28)]}, schema=CRSP_MSF_V2_AUG_SCHEMA
+        ),
+    )
+    assert ages[(10004, date(2018, 2, 28))] == 0
+    assert ages[(10004, date(2018, 3, 31))] == 1
+
+
+def test_no_source_falls_back_to_first_alt(test_paths: DataPaths) -> None:
+    """Entity E: no signal matches; first_obs is null so age uses MIN(eom) per id."""
+    ages = _run(
+        test_paths,
+        world_msf=_world(10005, None, "005000", [date(2019, 7, 31), date(2019, 8, 31)]),
+    )
+    assert ages[(10005, date(2019, 7, 31))] == 0
+    assert ages[(10005, date(2019, 8, 31))] == 1
+
+
+def test_comp_g_funda_contributes_to_acc_union(test_paths: DataPaths) -> None:
+    """Entity F: global-only accounting (comp_g_funda) wins the acc union."""
+    ages = _run(
+        test_paths,
+        world_msf=_world(10006, 1006, "006000", [date(2015, 12, 31)]),
+        crsp=pl.DataFrame(
+            {"permco": [1006], "mthcaldt": [date(2010, 1, 31)]}, schema=CRSP_MSF_V2_AUG_SCHEMA
+        ),
+        comp_secm=pl.DataFrame(
+            {"gvkey": ["006000"], "datadate": [date(2009, 6, 30)]}, schema=COMP_SECM_SCHEMA
+        ),
+        comp_g_funda=pl.DataFrame(
+            {"gvkey": ["006000"], "datadate": [date(2007, 12, 31)]}, schema=COMP_G_FUNDA_SCHEMA
+        ),
+    )
+    # comp_acc_first = 2006-12-31 wins; (2015-2006)*12 + (12-12) = 108
+    assert ages[(10006, date(2015, 12, 31))] == 108
+
+
+def test_null_permco_does_not_match_crsp(test_paths: DataPaths) -> None:
+    """A null-permco Compustat firm yields null crsp_first but still ages from its comp signal."""
+    ages = _run(
+        test_paths,
+        world_msf=_world(20001, None, "099000", [date(2016, 1, 31)]),
+        # a CRSP row exists but the firm's permco is null -> no join match
+        crsp=pl.DataFrame(
+            {"permco": [1001], "mthcaldt": [date(2005, 1, 31)]}, schema=CRSP_MSF_V2_AUG_SCHEMA
+        ),
+        comp_funda=pl.DataFrame(
+            {"gvkey": ["099000"], "datadate": [date(2011, 6, 30)]}, schema=COMP_FUNDA_SCHEMA
+        ),
+    )
+    # crsp_first null; comp_acc_first = 2010-12-31; (2016-2010)*12 + (1-12) = 61
+    assert ages[(20001, date(2016, 1, 31))] == 61
+
+
+def test_comp_ret_union_min_across_files_is_symmetric(test_paths: DataPaths) -> None:
+    """comp_ret_first is the earlier of comp_secm and comp_g_secd regardless of which file holds it."""
+    world = _world(30001, 3001, "030000", [date(2016, 1, 31)])
+
+    global_earlier = _run(
+        test_paths,
+        world_msf=world,
+        comp_secm=pl.DataFrame(
+            {"gvkey": ["030000"], "datadate": [date(2012, 6, 30)]}, schema=COMP_SECM_SCHEMA
+        ),
+        comp_g_secd=pl.DataFrame(
+            {"gvkey": ["030000"], "datadate": [date(2010, 3, 31)], "monthend": [1]},
+            schema=COMP_G_SECD_SCHEMA,
+        ),
+    )
+    us_earlier = _run(
+        test_paths,
+        world_msf=world,
+        comp_secm=pl.DataFrame(
+            {"gvkey": ["030000"], "datadate": [date(2010, 3, 31)]}, schema=COMP_SECM_SCHEMA
+        ),
+        comp_g_secd=pl.DataFrame(
+            {"gvkey": ["030000"], "datadate": [date(2012, 6, 30)], "monthend": [1]},
+            schema=COMP_G_SECD_SCHEMA,
+        ),
+    )
+    # both: union min 2010-03-31 -> comp_ret_first 2009-12-31; (2016-2009)*12 + (1-12) = 73
+    assert global_earlier[(30001, date(2016, 1, 31))] == 73
+    assert us_earlier[(30001, date(2016, 1, 31))] == 73
+
+
+def test_empty_world_msf_yields_empty_typed_output(test_paths: DataPaths) -> None:
+    """Empty world_msf produces a 0-row output with the [id, eom, age] schema."""
+    write_all_inputs(test_paths)  # all six empty
+    firm_age(test_paths, test_paths.interim_dir / "world_msf.parquet")
+    out = pl.read_parquet(test_paths.interim_dir / "firm_age.parquet")
+    assert out.height == 0
+    assert out.columns == ["id", "eom", "age"]
+    assert out.schema["id"] == pl.Int64
+    assert out.schema["eom"] == pl.Date
+    assert out.schema["age"] == pl.Int64
+
+
+def test_first_alt_is_per_id_not_global(test_paths: DataPaths) -> None:
+    """first_alt = MIN(eom) PARTITION BY id: each id ages from its own earliest eom."""
+    world = pl.concat(
+        [
+            _world(40001, None, "040000", [date(2015, 3, 31), date(2015, 4, 30)]),
+            _world(40002, None, "040001", [date(2020, 9, 30), date(2020, 10, 31)]),
+        ]
+    )
+    ages = _run(test_paths, world_msf=world)  # no signals -> pure first_alt fallback
+    # each id: age 0 at its own min eom, 1 at the next month
+    assert ages[(40001, date(2015, 3, 31))] == 0
+    assert ages[(40001, date(2015, 4, 30))] == 1
+    assert ages[(40002, date(2020, 9, 30))] == 0
+    assert ages[(40002, date(2020, 10, 31))] == 1
+
+
+def test_full_six_entity_set_matches_expected(test_paths: DataPaths) -> None:
+    """Sanity check the full shared builder set against the documented ages."""
+    ages = _run(
+        test_paths,
+        world_msf=build_world_msf_input(),
+        comp_secm=build_comp_secm_input(),
+        comp_g_secd=build_comp_g_secd_input(),
+        comp_funda=build_comp_funda_input(),
+        comp_g_funda=build_comp_g_funda_input(),
+        crsp=build_crsp_msf_v2_aug_input(),
+    )
+    assert ages == {
+        (10001, date(2015, 1, 31)): 60,
+        (10001, date(2015, 2, 28)): 61,
+        (10002, date(2015, 6, 30)): 78,
+        (10003, date(2016, 9, 30)): 33,
+        (10004, date(2018, 2, 28)): 0,
+        (10004, date(2018, 3, 31)): 1,
+        (10005, date(2019, 7, 31)): 0,
+        (10005, date(2019, 8, 31)): 1,
+        (10006, date(2015, 12, 31)): 108,
+    }

--- a/tests/unit/test_market_beta.py
+++ b/tests/unit/test_market_beta.py
@@ -1,0 +1,214 @@
+"""Unit tests for market_beta (rolling CAPM beta + idiosyncratic vol).
+
+These assert the *semantics* of market_beta on small hand-built panels (CAPM
+math recovery, min-obs boundary, WHERE-filter gating, mktrf-null handling,
+multi-country join, output schema/ordering, horizon parametrization, empty
+input) — not golden bytes (see tests/golden/test_market_beta_golden.py for the
+byte-level regression).
+"""
+
+from __future__ import annotations
+
+import calendar
+from datetime import date
+
+import numpy as np
+import polars as pl
+import pytest
+
+from jkp.data.aux_functions import market_beta
+from jkp.data.paths import DataPaths
+from tests.golden.market_beta_inputs import (
+    AP_FACTORS_MONTHLY_INPUT_SCHEMA,
+    WORLD_MSF_INPUT_SCHEMA,
+)
+
+
+def _eom(i: int) -> date:
+    """Month-end date ``i`` months after 2010-01-31."""
+    year = 2010 + i // 12
+    month = i % 12 + 1
+    return date(year, month, calendar.monthrange(year, month)[1])
+
+
+def _factor_df(rows: list[tuple[str, int, float | None]]) -> pl.DataFrame:
+    """Build a factor frame from (excntry, month_index, mktrf) rows."""
+    return pl.DataFrame(
+        {
+            "excntry": [r[0] for r in rows],
+            "eom": [_eom(r[1]) for r in rows],
+            "mktrf": [r[2] for r in rows],
+            "hml": [0.01] * len(rows),
+            "smb_ff": [0.01] * len(rows),
+        },
+        schema=AP_FACTORS_MONTHLY_INPUT_SCHEMA,
+    )
+
+
+def _msf_df(rows: list[dict]) -> pl.DataFrame:
+    """Build a world_msf frame from a list of row dicts (id, excntry, i, ...)."""
+    return pl.DataFrame(
+        {
+            "id": [r["id"] for r in rows],
+            "excntry": [r["excntry"] for r in rows],
+            "eom": [_eom(r["i"]) for r in rows],
+            "ret_exc": [r["ret_exc"] for r in rows],
+            "ret_local": [
+                r.get("ret_local", (r["ret_exc"] + 0.02) if r["ret_exc"] is not None else 0.02)
+                for r in rows
+            ],
+            "ret_lag_dif": [r.get("ret_lag_dif", 1) for r in rows],
+        },
+        schema=WORLD_MSF_INPUT_SCHEMA,
+    )
+
+
+def _run(
+    paths: DataPaths, msf: pl.DataFrame, fac: pl.DataFrame, n: int, min_obs: int
+) -> pl.DataFrame:
+    """Write inputs, run market_beta, return the output frame."""
+    data_path = paths.interim_dir / "world_msf.parquet"
+    fcts_path = paths.interim_dir / "ap_factors_monthly.parquet"
+    out_path = paths.interim_dir / f"beta_{n}m.parquet"
+    msf.write_parquet(data_path)
+    fac.write_parquet(fcts_path)
+    market_beta(paths, out_path, data_path, fcts_path, n, min_obs)
+    return pl.read_parquet(out_path)
+
+
+@pytest.mark.unit
+def test_capm_math_recovery(test_paths, tolerance) -> None:
+    """ret_exc = 2*mktrf exactly recovers beta=2.0 and ivol=0 at the full window."""
+    mkt = np.random.default_rng(7).normal(0.0, 0.05, 12)
+    fac = _factor_df([("USA", i, float(mkt[i])) for i in range(12)])
+    msf = _msf_df(
+        [{"id": 1, "excntry": "USA", "i": i, "ret_exc": float(2.0 * mkt[i])} for i in range(12)]
+    )
+    out = _run(test_paths, msf, fac, 12, 6)
+    row = out.filter(pl.col("eom") == _eom(11))
+    assert row.height == 1
+    assert abs(row["beta_12m"][0] - 2.0) < 1e-9
+    assert abs(row["ivol_capm_12m"][0]) < 1e-9
+
+
+@pytest.mark.unit
+def test_min_obs_boundary(test_paths) -> None:
+    """Firm with exactly 6 obs is emitted; firm with 5 obs is dropped (min_obs=6)."""
+    mkt = np.random.default_rng(1).normal(0.0, 0.05, 6)
+    fac = _factor_df([("USA", i, float(mkt[i])) for i in range(6)])
+    rows = [{"id": 1, "excntry": "USA", "i": i, "ret_exc": float(mkt[i])} for i in range(6)]
+    rows += [{"id": 2, "excntry": "USA", "i": i, "ret_exc": float(mkt[i])} for i in range(5)]
+    out = _run(test_paths, _msf_df(rows), fac, 12, 6)
+    ids = set(out["id"].to_list())
+    assert 1 in ids  # 6 obs -> present
+    assert 2 not in ids  # 5 obs -> absent
+
+
+@pytest.mark.unit
+def test_where_filters_gate_obs_count(test_paths) -> None:
+    """ret_local=0 / ret_lag_dif!=1 / ret_exc=null rows do not count toward min_obs."""
+    mkt = np.random.default_rng(2).normal(0.0, 0.05, 9)
+    fac = _factor_df([("USA", i, float(mkt[i])) for i in range(9)])
+
+    def firm(fid: int, last: int) -> list[dict]:
+        rows: list[dict] = []
+        for i in range(last + 1):
+            r: dict = {"id": fid, "excntry": "USA", "i": i, "ret_exc": float(mkt[i])}
+            if i == 2:
+                r["ret_local"] = 0.0
+            elif i == 4:
+                r["ret_lag_dif"] = 2
+            elif i == 6:
+                r["ret_exc"] = None
+            rows.append(r)
+        return rows
+
+    # Firm 1: M0..M8 -> valid {0,1,3,5,7,8} = 6 -> present.
+    # Firm 2: M0..M7 -> valid {0,1,3,5,7}   = 5 -> absent.
+    out = _run(test_paths, _msf_df(firm(1, 8) + firm(2, 7)), fac, 12, 6)
+    ids = set(out["id"].to_list())
+    assert 1 in ids
+    assert 2 not in ids
+
+
+@pytest.mark.unit
+def test_mktrf_null_factor_month_drops_obs(test_paths) -> None:
+    """A factor month with mktrf=null removes that obs from the window count."""
+    mkt = np.random.default_rng(3).normal(0.0, 0.05, 6)
+    msf = _msf_df([{"id": 1, "excntry": "USA", "i": i, "ret_exc": float(mkt[i])} for i in range(6)])
+    full = _factor_df([("USA", i, float(mkt[i])) for i in range(6)])
+    holed = _factor_df([("USA", i, None if i == 2 else float(mkt[i])) for i in range(6)])
+
+    present = _run(test_paths, msf, full, 12, 6)
+    assert 1 in set(present["id"].to_list())  # 6 obs -> present
+
+    absent = _run(test_paths, msf, holed, 12, 6)
+    assert 1 not in set(absent["id"].to_list())  # 5 obs after null -> absent
+
+
+@pytest.mark.unit
+def test_multi_country_join(test_paths) -> None:
+    """Each firm's beta is computed against its own country's mktrf series."""
+    rng = np.random.default_rng(4)
+    mkt_us = rng.normal(0.0, 0.05, 12)
+    mkt_ca = rng.normal(0.0, 0.05, 12)
+    fac = _factor_df(
+        [("USA", i, float(mkt_us[i])) for i in range(12)]
+        + [("CAN", i, float(mkt_ca[i])) for i in range(12)]
+    )
+    msf = _msf_df(
+        [{"id": 1, "excntry": "USA", "i": i, "ret_exc": float(1.5 * mkt_us[i])} for i in range(12)]
+        + [
+            {"id": 2, "excntry": "CAN", "i": i, "ret_exc": float(0.5 * mkt_ca[i])}
+            for i in range(12)
+        ]
+    )
+    out = _run(test_paths, msf, fac, 12, 6)
+    us = out.filter((pl.col("id") == 1) & (pl.col("eom") == _eom(11)))
+    ca = out.filter((pl.col("id") == 2) & (pl.col("eom") == _eom(11)))
+    assert abs(us["beta_12m"][0] - 1.5) < 1e-9
+    assert abs(ca["beta_12m"][0] - 0.5) < 1e-9
+
+
+@pytest.mark.unit
+def test_output_schema_and_ordering(test_paths) -> None:
+    """Output is exactly [id, eom, beta_12m, ivol_capm_12m] sorted by (id, eom)."""
+    mkt = np.random.default_rng(5).normal(0.0, 0.05, 8)
+    fac = _factor_df([("USA", i, float(mkt[i])) for i in range(8)])
+    rows = [
+        {"id": fid, "excntry": "USA", "i": i, "ret_exc": float(fid * 0.1 * mkt[i] + mkt[i])}
+        for fid in (20, 10)
+        for i in range(8)
+    ]
+    out = _run(test_paths, _msf_df(rows), fac, 12, 6)
+    assert out.columns == ["id", "eom", "beta_12m", "ivol_capm_12m"]
+    assert out.schema == {
+        "id": pl.Int64,
+        "eom": pl.Date,
+        "beta_12m": pl.Float64,
+        "ivol_capm_12m": pl.Float64,
+    }
+    assert out.select(["id", "eom"]).equals(out.select(["id", "eom"]).sort(["id", "eom"]))
+
+
+@pytest.mark.unit
+def test_horizon_parametrization(test_paths) -> None:
+    """__n/__min are honored: columns are named beta_6m / ivol_capm_6m."""
+    mkt = np.random.default_rng(6).normal(0.0, 0.05, 8)
+    fac = _factor_df([("USA", i, float(mkt[i])) for i in range(8)])
+    msf = _msf_df(
+        [{"id": 1, "excntry": "USA", "i": i, "ret_exc": float(0.9 * mkt[i])} for i in range(8)]
+    )
+    out = _run(test_paths, msf, fac, 6, 3)
+    assert out.columns == ["id", "eom", "beta_6m", "ivol_capm_6m"]
+    assert out.height > 0
+
+
+@pytest.mark.unit
+def test_empty_input(test_paths) -> None:
+    """0-row world_msf yields a 0-row output with the correct schema."""
+    empty = pl.DataFrame(schema=WORLD_MSF_INPUT_SCHEMA)
+    fac = _factor_df([("USA", i, 0.01 * (i + 1)) for i in range(6)])
+    out = _run(test_paths, empty, fac, 12, 6)
+    assert out.height == 0
+    assert out.columns == ["id", "eom", "beta_12m", "ivol_capm_12m"]

--- a/tests/unit/test_prepare_crsp_sf.py
+++ b/tests/unit/test_prepare_crsp_sf.py
@@ -1,0 +1,225 @@
+"""Semantic unit tests for prepare_crsp_sf().
+
+These assert behaviour/edge cases (NASDAQ volume windows, div_tot, delret
+imputation, ret backfill, excess-return scale, company ME, delist joins, empty
+input, dedup/sort) rather than fixture bytes — the byte-parity check lives in
+tests/golden/test_prepare_crsp_sf_golden.py.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from jkp.data.aux_functions import prepare_crsp_sf
+from jkp.data.paths import DataPaths
+from tests.golden.prepare_crsp_sf_inputs import (
+    SCHEMA_CRSP_SF,
+    SCHEMA_FF,
+    SCHEMA_MCTI,
+    SCHEMA_SEDELIST,
+    _crsp_row,
+    _del_row,
+)
+
+
+def _run(
+    paths: DataPaths,
+    freq: str,
+    crsp_rows: list[dict[str, object]],
+    del_rows: list[dict[str, object]] | None = None,
+    mcti_rows: list[tuple[date, float]] | None = None,
+    ff_rows: list[tuple[date, float]] | None = None,
+) -> pl.DataFrame:
+    """Write minimal inputs, run prepare_crsp_sf(freq), return the output frame."""
+    raw = paths.interim_dir / "raw_data_dfs"
+    raw.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(crsp_rows, schema=SCHEMA_CRSP_SF).write_parquet(raw / f"__crsp_sf_{freq}.parquet")
+    pl.DataFrame(del_rows or [], schema=SCHEMA_SEDELIST).write_parquet(
+        raw / f"crsp_{freq}sedelist.parquet"
+    )
+    pl.DataFrame(
+        {"caldt": [r[0] for r in (mcti_rows or [])], "t30ret": [r[1] for r in (mcti_rows or [])]},
+        schema=SCHEMA_MCTI,
+    ).write_parquet(raw / "crsp_mcti_t30ret.parquet")
+    pl.DataFrame(
+        {"date": [r[0] for r in (ff_rows or [])], "rf": [r[1] for r in (ff_rows or [])]},
+        schema=SCHEMA_FF,
+    ).write_parquet(raw / "ff_factors_monthly.parquet")
+    prepare_crsp_sf(paths, freq)
+    return pl.read_parquet(paths.interim_dir / f"crsp_{freq}sf.parquet")
+
+
+def _val(df: pl.DataFrame, permno: int, d: date, col: str) -> object:
+    return df.filter((pl.col("permno") == permno) & (pl.col("date") == d))[col].item()
+
+
+def test_nasdaq_volume_windows(test_paths: DataPaths) -> None:
+    """Daily NASDAQ (Q/RW) volume is divided by 2 / 1.8 / 1.6 across the three
+    historic windows and unchanged after 2003-12-31; non-NASDAQ is unchanged."""
+    rows = [
+        _crsp_row(1, 1, date(2001, 1, 15), 10.0, 1.0, 0.0, 0.0, 1000, 1.0, nasdaq=True),  # /2
+        _crsp_row(1, 1, date(2001, 6, 15), 10.0, 1.0, 0.0, 0.0, 900, 1.0, nasdaq=True),  # /1.8
+        _crsp_row(1, 1, date(2003, 6, 15), 10.0, 1.0, 0.0, 0.0, 800, 1.0, nasdaq=True),  # /1.6
+        _crsp_row(1, 1, date(2004, 6, 15), 10.0, 1.0, 0.0, 0.0, 1234, 1.0, nasdaq=True),  # none
+        _crsp_row(2, 2, date(2001, 1, 15), 10.0, 1.0, 0.0, 0.0, 1000, 1.0, nasdaq=False),  # none
+    ]
+    df = _run(test_paths, "d", rows)
+    assert _val(df, 1, date(2001, 1, 15), "vol") == pytest.approx(500.0)
+    assert _val(df, 1, date(2001, 6, 15), "vol") == pytest.approx(500.0)
+    assert _val(df, 1, date(2003, 6, 15), "vol") == pytest.approx(500.0)
+    assert _val(df, 1, date(2004, 6, 15), "vol") == pytest.approx(1234.0)
+    assert _val(df, 2, date(2001, 1, 15), "vol") == pytest.approx(1000.0)
+
+
+def test_monthly_scaling_and_vol_dtype(test_paths: DataPaths) -> None:
+    """Monthly vol and dolvol are scaled by 100 and vol is promoted to Float64."""
+    rows = [_crsp_row(1, 1, date(2001, 1, 31), 10.0, 1.0, 0.0, 0.0, 1000, 1.0, nasdaq=True)]
+    df = _run(test_paths, "m", rows)
+    # 1000 vol / 2 (pre-2001-02 NASDAQ window) = 500, then monthly x100
+    expected_vol = pl.select(pl.lit(1000.0) / 2 * 100).item()
+    assert df.schema["vol"] == pl.Float64
+    assert _val(df, 1, date(2001, 1, 31), "vol") == pytest.approx(expected_vol)
+    assert _val(df, 1, date(2001, 1, 31), "dolvol") == pytest.approx(10.0 * 500.0 * 100)
+
+
+def test_div_tot(test_paths: DataPaths) -> None:
+    """div_tot is null on the first row per permno and when lagged cfacshr==0,
+    else (ret-retx)*prc_prev*(cfacshr/cfacshr_prev)."""
+    rows = [
+        _crsp_row(1, 1, date(2001, 1, 15), 10.0, 1.0, 0.05, 0.04, 100, 1.0, nasdaq=False),
+        _crsp_row(1, 1, date(2001, 1, 16), 20.0, 2.0, 0.06, 0.05, 100, 1.0, nasdaq=False),
+        _crsp_row(2, 2, date(2001, 1, 15), 10.0, 0.0, 0.0, 0.0, 100, 1.0, nasdaq=False),
+        _crsp_row(2, 2, date(2001, 1, 16), 11.0, 1.0, 0.03, 0.01, 100, 1.0, nasdaq=False),
+    ]
+    df = _run(test_paths, "d", rows)
+    assert _val(df, 1, date(2001, 1, 15), "div_tot") is None
+    assert _val(df, 1, date(2001, 1, 16), "div_tot") == pytest.approx(
+        (0.06 - 0.05) * 10.0 * (2.0 / 1.0)
+    )
+    assert _val(df, 2, date(2001, 1, 16), "div_tot") is None  # cfacshr_prev == 0
+
+
+@pytest.mark.parametrize(
+    ("reason", "action", "status", "payment"),
+    [("UNAV", "GDR", "VCL", "PRCF"), ("BKPY", "GDR", "VCL", "PRCF")],  # c2, c3
+)
+def test_bad_delist_imputes_minus_030(
+    test_paths: DataPaths, reason: str, action: str, status: str, payment: str
+) -> None:
+    """Null delret in a c2/c3 bucket is imputed to -0.30 then compounded."""
+    rows = [_crsp_row(1, 1, date(2001, 1, 31), 10.0, 1.0, 0.04, 0.04, 100, 1.0, nasdaq=False)]
+    dels = [_del_row(1, date(2001, 1, 15), None, action, status, reason, payment)]
+    df = _run(test_paths, "m", rows, dels)
+    assert _val(df, 1, date(2001, 1, 31), "ret") == pytest.approx((0.04 + 1) * (1 - 0.3) - 1)
+
+
+def test_non_bad_null_delist_not_imputed(test_paths: DataPaths) -> None:
+    """A delist with null delret but non-bad codes is NOT imputed; ret is
+    compounded with delret coalesced to 0 (i.e. unchanged)."""
+    rows = [_crsp_row(1, 1, date(2001, 1, 31), 10.0, 1.0, 0.04, 0.04, 100, 1.0, nasdaq=False)]
+    dels = [_del_row(1, date(2001, 1, 15), None, "MERG", None, None, None)]
+    df = _run(test_paths, "m", rows, dels)
+    assert _val(df, 1, date(2001, 1, 31), "ret") == pytest.approx(0.04)
+
+
+def test_ret_backfill_when_missing(test_paths: DataPaths) -> None:
+    """ret null + delret present -> ret set to 0 then compounded to equal delret."""
+    rows = [_crsp_row(1, 1, date(2001, 1, 31), 10.0, 1.0, None, None, 100, 1.0, nasdaq=False)]
+    dels = [_del_row(1, date(2001, 1, 15), -0.2, None, None, None, None)]
+    df = _run(test_paths, "m", rows, dels)
+    assert _val(df, 1, date(2001, 1, 31), "ret") == pytest.approx(-0.2)
+
+
+def test_no_delist_leaves_ret_unchanged(test_paths: DataPaths) -> None:
+    """No matching delist -> delret null, ret compounded with 0 (unchanged)."""
+    rows = [_crsp_row(1, 1, date(2001, 1, 31), 10.0, 1.0, 0.07, 0.07, 100, 1.0, nasdaq=False)]
+    df = _run(test_paths, "m", rows)
+    assert _val(df, 1, date(2001, 1, 31), "ret") == pytest.approx(0.07)
+
+
+def test_ret_exc_scale_and_coalesce(test_paths: DataPaths) -> None:
+    """ret_exc subtracts coalesce(t30ret, rf)/scale: scale 1 monthly, 21 daily;
+    t30ret preferred over rf; falls back to rf; both null -> null."""
+    d = date(2001, 1, 31)
+    rows = [_crsp_row(1, 1, d, 10.0, 1.0, 0.05, 0.05, 100, 1.0, nasdaq=False)]
+    # both present -> t30ret wins, monthly scale 1
+    m = _run(test_paths, "m", rows, mcti_rows=[(d, 0.004)], ff_rows=[(d, 0.002)])
+    assert _val(m, 1, d, "ret_exc") == pytest.approx(0.05 - 0.004)
+    # t30ret absent -> rf fallback
+    m2 = _run(test_paths, "m", rows, ff_rows=[(d, 0.002)])
+    assert _val(m2, 1, d, "ret_exc") == pytest.approx(0.05 - 0.002)
+    # both absent -> null
+    m3 = _run(test_paths, "m", rows)
+    assert _val(m3, 1, d, "ret_exc") is None
+    # daily scale 21
+    dd = date(2000, 1, 4)
+    drows = [_crsp_row(1, 1, dd, 10.0, 1.0, 0.05, 0.05, 100, 1.0, nasdaq=False)]
+    dsf = _run(test_paths, "d", drows, mcti_rows=[(dd, 0.004)])
+    assert _val(dsf, 1, dd, "ret_exc") == pytest.approx(0.05 - 0.004 / 21)
+
+
+def test_me_company(test_paths: DataPaths) -> None:
+    """me_company sums me across permnos within permco-date; single permno ->
+    its own me; a group whose only me is null -> null."""
+    d = date(2001, 1, 31)
+    rows = [
+        _crsp_row(1, 100, d, 10.0, 1.0, 0.0, 0.0, 100, 60.0, nasdaq=False),
+        _crsp_row(2, 100, d, 10.0, 1.0, 0.0, 0.0, 100, 40.0, nasdaq=False),
+        _crsp_row(3, 300, d, 10.0, 1.0, 0.0, 0.0, 100, 25.0, nasdaq=False),
+        _crsp_row(4, 400, d, 10.0, 1.0, 0.0, 0.0, 100, None, nasdaq=False),
+    ]
+    df = _run(test_paths, "m", rows)
+    assert _val(df, 1, d, "me_company") == pytest.approx(100.0)
+    assert _val(df, 2, d, "me_company") == pytest.approx(100.0)
+    assert _val(df, 3, d, "me_company") == pytest.approx(25.0)
+    assert _val(df, 4, d, "me_company") is None
+
+
+def test_daily_delist_exact_date_join(test_paths: DataPaths) -> None:
+    """Daily delist applies only on the exact day date==delistingdt."""
+    rows = [
+        _crsp_row(1, 1, date(2000, 1, 6), 10.0, 1.0, 0.03, 0.03, 100, 1.0, nasdaq=False),
+        _crsp_row(1, 1, date(2000, 1, 7), 10.0, 1.0, 0.04, 0.04, 100, 1.0, nasdaq=False),
+    ]
+    dels = [_del_row(1, date(2000, 1, 7), None, "GDR", "VCL", "UNAV", "PRCF")]
+    df = _run(test_paths, "d", rows, dels)
+    assert _val(df, 1, date(2000, 1, 6), "ret") == pytest.approx(0.03)  # unaffected
+    assert _val(df, 1, date(2000, 1, 7), "ret") == pytest.approx((0.04 + 1) * (1 - 0.3) - 1)
+
+
+@pytest.mark.parametrize("freq", ["m", "d"])
+def test_both_freq_filename_and_columns(test_paths: DataPaths, freq: str) -> None:
+    """Each freq writes crsp_{freq}sf.parquet with the full computed column set."""
+    rows = [_crsp_row(1, 1, date(2001, 1, 15), 10.0, 1.0, 0.01, 0.01, 100, 1.0, nasdaq=False)]
+    _run(test_paths, freq, rows)
+    out = test_paths.interim_dir / f"crsp_{freq}sf.parquet"
+    assert out.exists()
+    cols = pl.read_parquet(out).columns
+    for extra in ("dolvol", "div_tot", "ret_exc", "me_company"):
+        assert extra in cols
+    for dropped in ("delret", "rf", "t30ret", "merge_aux", "delistingdt"):
+        assert dropped not in cols
+
+
+def test_empty_input_yields_typed_empty_output(test_paths: DataPaths) -> None:
+    """A 0-row typed input produces a 0-row output carrying the full schema."""
+    df = _run(test_paths, "m", [])
+    assert df.height == 0
+    for col in ("permno", "date", "vol", "dolvol", "div_tot", "ret_exc", "me_company"):
+        assert col in df.columns
+
+
+def test_output_unique_and_sorted(test_paths: DataPaths) -> None:
+    """Output is deduplicated on (permno, date) and sorted by (permno, date)."""
+    rows = [
+        _crsp_row(2, 2, date(2001, 2, 15), 10.0, 1.0, 0.0, 0.0, 100, 1.0, nasdaq=False),
+        _crsp_row(1, 1, date(2001, 1, 15), 10.0, 1.0, 0.0, 0.0, 100, 1.0, nasdaq=False),
+        _crsp_row(1, 1, date(2001, 1, 15), 10.0, 1.0, 0.0, 0.0, 100, 1.0, nasdaq=False),  # dup
+    ]
+    df = _run(test_paths, "d", rows)
+    keys = df.select(["permno", "date"])
+    assert keys.is_duplicated().sum() == 0
+    assert df["permno"].to_list() == sorted(df["permno"].to_list())

--- a/tests/unit/test_residual_momentum.py
+++ b/tests/unit/test_residual_momentum.py
@@ -1,0 +1,187 @@
+"""Unit tests for ``residual_momentum`` (aux_functions).
+
+These assert SEMANTICS (min-obs gating, both horizon variants, the hml-null
+branch, empty input, and a numpy OLS value oracle), not fixture bytes. Inputs
+are the shared synthetic builders in ``tests.golden.residual_momentum_inputs``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from jkp.data.aux_functions import residual_momentum
+from tests.golden.residual_momentum_inputs import (
+    build_ap_factors_monthly_input,
+    build_world_msf_input,
+    month_grid,
+)
+
+_STEM = "resmom_ff3"
+_N = 36
+_MIN = 24
+_TERMINAL_IDX = 39  # m39 = 2016-04-30, terminal month of the fixture grid.
+_CHUNK_START_IDX = 4  # 36-month chunk ending at m39 spans m4..m39.
+
+
+def _write_inputs(paths, world_df: pl.DataFrame | None = None) -> tuple:
+    """Write world_msf + ap_factors inputs to interim_dir; return their paths."""
+    world = world_df if world_df is not None else build_world_msf_input(seed=42)
+    world_path = paths.interim_dir / "world_msf.parquet"
+    fcts_path = paths.interim_dir / "ap_factors_monthly.parquet"
+    world.write_parquet(world_path)
+    build_ap_factors_monthly_input(seed=42).write_parquet(fcts_path)
+    return world_path, fcts_path
+
+
+def _run(paths, incl: int, skip: int, world_df: pl.DataFrame | None = None) -> pl.DataFrame:
+    """Run residual_momentum for one variant and return the sorted output frame."""
+    world_path, fcts_path = _write_inputs(paths, world_df)
+    residual_momentum(paths, _STEM, world_path, fcts_path, _N, _MIN, incl, skip)
+    return pl.read_parquet(paths.interim_dir / f"{_STEM}_{incl}_{skip}.parquet").sort(["id", "eom"])
+
+
+def _oracle_resff3(sid: int, country: str, incl: int, skip: int) -> float:
+    """Numpy OLS oracle for the terminal-m39 chunk of a single stock.
+
+    Description:
+        Replicate ``resff3_{incl}_{skip}`` for the 36-month chunk ending at m39.
+    Steps:
+        1) Slice ret_exc / mktrf / hml / smb_ff over m4..m39 for (sid, country).
+        2) OLS ``ret_exc ~ 1 + mktrf + hml + smb_ff``; residuals = y - X@beta.
+        3) Average residuals over aux_date in (T-incl, T-skip]; divide by std(ddof=1).
+    Output:
+        Expected float value at (sid, m39).
+    """
+    world = build_world_msf_input(seed=42)
+    fcts = build_ap_factors_monthly_input(seed=42)
+    grid = month_grid()
+    aux = [g.year * 12 + g.month for g in grid]
+    terminal_aux = aux[_TERMINAL_IDX]
+
+    chunk_idx = list(range(_CHUNK_START_IDX, _TERMINAL_IDX + 1))
+    w = world.filter(pl.col("id") == sid)
+    ret_by_eom = dict(zip(w["eom"].to_list(), w["ret_exc"].to_list(), strict=True))
+    fc = fcts.filter(pl.col("excntry") == country)
+    fac_by_eom = {
+        e: (m, h, s)
+        for e, m, h, s in zip(
+            fc["eom"].to_list(),
+            fc["mktrf"].to_list(),
+            fc["hml"].to_list(),
+            fc["smb_ff"].to_list(),
+            strict=True,
+        )
+    }
+
+    ys, xs, auxs = [], [], []
+    for i in chunk_idx:
+        eom = grid[i]
+        m, h, s = fac_by_eom[eom]
+        if eom not in ret_by_eom or h is None or s is None or m is None:
+            continue  # mirrors res_mom dropping hml/smb-null rows and prep mktrf gate.
+        ys.append(ret_by_eom[eom])
+        xs.append([1.0, m, h, s])
+        auxs.append(aux[i])
+
+    y = np.array(ys)
+    x = np.array(xs)
+    auxs = np.array(auxs)
+    beta, *_ = np.linalg.lstsq(x, y, rcond=None)
+    res = y - x @ beta
+
+    mask = (auxs > terminal_aux - incl) & (auxs <= terminal_aux - skip)
+    window = res[mask]
+    return float(window.mean() / window.std(ddof=1))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("incl", "skip"), [(12, 1), (6, 1)])
+def test_output_schema_and_sort(test_paths, incl: int, skip: int) -> None:
+    """Both variants emit [id, eom, resff3_incl_skip] with correct dtypes, sorted."""
+    out = _run(test_paths, incl, skip)
+    value_col = f"resff3_{incl}_{skip}"
+    assert out.columns == ["id", "eom", value_col]
+    assert out.schema["id"] == pl.Int64
+    assert out.schema["eom"] == pl.Date
+    assert out.schema[value_col] == pl.Float64
+    assert out.sort(["id", "eom"]).equals(out)
+
+
+@pytest.mark.unit
+def test_value_correctness_12_1(test_paths, tolerance) -> None:
+    """id=1 terminal-m39 value for the 12/1 horizon matches the numpy OLS oracle."""
+    out = _run(test_paths, 12, 1)
+    row = out.filter((pl.col("id") == 1) & (pl.col("eom") == month_grid()[_TERMINAL_IDX]))
+    assert row.height == 1
+    expected = _oracle_resff3(1, "US", 12, 1)
+    np.testing.assert_allclose(row["resff3_12_1"][0], expected, **tolerance.STANDARD)
+
+
+@pytest.mark.unit
+def test_value_correctness_6_1(test_paths, tolerance) -> None:
+    """id=1 terminal-m39 value for the 6/1 horizon matches the numpy OLS oracle.
+
+    Same 36-month regression window as 12/1, only the averaging sub-window differs.
+    """
+    out = _run(test_paths, 6, 1)
+    row = out.filter((pl.col("id") == 1) & (pl.col("eom") == month_grid()[_TERMINAL_IDX]))
+    assert row.height == 1
+    expected = _oracle_resff3(1, "US", 6, 1)
+    np.testing.assert_allclose(row["resff3_6_1"][0], expected, **tolerance.STANDARD)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("incl", "skip"), [(12, 1), (6, 1)])
+def test_min_obs_exclusion(test_paths, incl: int, skip: int) -> None:
+    """id=2 (only 20 months) never reaches __min=24 obs → absent from both outputs."""
+    out = _run(test_paths, incl, skip)
+    assert 2 not in out["id"].to_list()
+
+
+@pytest.mark.unit
+def test_min_obs_boundary(test_paths) -> None:
+    """id=3 (exactly 24 months) passes the __min=24 gate → present at terminal m39."""
+    out = _run(test_paths, 12, 1)
+    row = out.filter(pl.col("id") == 3)
+    assert row.height >= 1
+    assert month_grid()[_TERMINAL_IDX] in row["eom"].to_list()
+    assert row["resff3_12_1"].is_finite().all()
+
+
+@pytest.mark.unit
+def test_hml_null_branch(test_paths) -> None:
+    """id=4 (CA, hml null at m20) still produces finite output; US id=1 is unaffected."""
+    out = _run(test_paths, 12, 1)
+    ca = out.filter(pl.col("id") == 4)
+    assert ca.height >= 1
+    assert ca["resff3_12_1"].is_finite().all()
+    # The CA-only null must not leak into the US oracle value for id=1.
+    us_row = out.filter((pl.col("id") == 1) & (pl.col("eom") == month_grid()[_TERMINAL_IDX]))
+    np.testing.assert_allclose(
+        us_row["resff3_12_1"][0], _oracle_resff3(1, "US", 12, 1), rtol=1e-6, atol=1e-10
+    )
+
+
+@pytest.mark.unit
+def test_horizons_distinct(test_paths) -> None:
+    """resff3_12_1 != resff3_6_1 for id=1 at m39 (different averaging windows)."""
+    out12 = _run(test_paths, 12, 1)
+    out6 = _run(test_paths, 6, 1)
+    terminal = month_grid()[_TERMINAL_IDX]
+    v12 = out12.filter((pl.col("id") == 1) & (pl.col("eom") == terminal))["resff3_12_1"][0]
+    v6 = out6.filter((pl.col("id") == 1) & (pl.col("eom") == terminal))["resff3_6_1"][0]
+    assert v12 != pytest.approx(v6)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("incl", "skip"), [(12, 1), (6, 1)])
+def test_empty_input(test_paths, incl: int, skip: int) -> None:
+    """Empty world_msf → output exists, 0 rows, correct columns/dtypes, no crash."""
+    empty_world = build_world_msf_input(empty=True)
+    out = _run(test_paths, incl, skip, world_df=empty_world)
+    assert out.height == 0
+    assert out.columns == ["id", "eom", f"resff3_{incl}_{skip}"]
+    assert out.schema["id"] == pl.Int64
+    assert out.schema["eom"] == pl.Date


### PR DESCRIPTION
## Simple explanation

Adds the actual **tests** for the four functions. Stacked on top of PR #220 (which added the synthetic inputs and golden fixtures) — this PR contains **only test files**, no fixture data. Base branch is `golden-fixtures-4-fns`; the diff shows just the 8 test files. **Merge #220 first**, then this retargets to `main` automatically.

## Technical details

Per function:
- `tests/golden/test_<func>_golden.py` — reconstructs the synthetic inputs (via the PR #220 `<func>_inputs.py` builders), reruns the real function on a tmp `DataPaths`, and asserts every emitted parquet equals the committed fixture. Float columns use the repo's tolerance-based `assert_series_equal` (`ToleranceSpec.GOLDEN`, rtol 1e-9); keys compared exact. Supports `--regen-golden`.
- `tests/unit/test_<func>.py` — focused semantic tests: exact CAPM/OLS recovery via independent numpy oracles, min-obs boundaries, per-filter obs gating, null/empty handling, single-source firms, and both freq/horizon variants.

**No `src/` changes. No new fixture data** — all committed parquets live in PR #220; this PR only consumes them.

## Test plan

```
PYTHONPATH=src uv run --no-sync python -m pytest tests/golden/test_{prepare_crsp_sf,market_beta,residual_momentum,firm_age}_golden.py tests/unit/test_{prepare_crsp_sf,market_beta,residual_momentum,firm_age}.py
# 51 passed
```
- `ruff check` / `ruff format --check` clean.
- Goldens confirmed deterministic: regenerating the PR #220 fixtures produces zero byte drift and these tests still pass.

Closes #212, #213, #214, #215, #216, #217, #218, #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)