### PR TITLE
fix: make residual_momentum byte-deterministic (fixes CI on main)

### DIFF
--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -8925,7 +8925,12 @@ def res_mom(df, sfx, __min, incl, skip):
         .over(["id_int", "group_number"])
     )
     df = (
-        df.filter(col("hml").is_not_null() & col("smb_ff").is_not_null())
+        # Fix within-group row order before the OLS: base_data comes from a
+        # multithreaded DuckDB scan whose row order is nondeterministic, and the
+        # least-squares solve is float-order-sensitive, so an unsorted input
+        # yields byte-different residuals across runs.
+        df.sort(["id_int", "group_number", "aux_date"])
+        .filter(col("hml").is_not_null() & col("smb_ff").is_not_null())
         .with_columns(
             res=res_exp.alias("res"),
             max_date_gn=pl.max("aux_date").over("group_number"),


### PR DESCRIPTION
## Simple explanation

CI on `main` went red right after #229 merged. The failing test is `tests/unit/test_residual_momentum.py::test_determinism_rerun`, which reruns `residual_momentum` on identical inputs and asserts the two outputs are byte-identical. They weren't. The failure is unrelated to #229's firm_age tests — #229 just happened to be the push that ran the suite.

## Technical details

`res_mom` gets its rows from `prep_data_factor_regs`, which builds `__msf2` in DuckDB with `threads=os.cpu_count()` and hands it back via `to_polars()`. That scan's **row order is nondeterministic** — the row *set* is identical every run (sorted frames compare equal), but the order isn't.

Downstream, `res_mom` runs a `polars-ols` least-squares residual solve `.over(["id_int","group_number"])` and then a `mean/std` reduction. Both are float-summation-order sensitive, so a different input order yields residuals that differ at ~1e-15. That's enough to break the exact `.equals()` in `test_determinism_rerun`.

The golden regression test didn't catch it because it compares the value column with `STANDARD` tolerance (rtol 1e-6), which absorbs the noise.

**Fix:** sort by `[id_int, group_number, aux_date]` before the OLS in `res_mom`, so the solver and the reduction always see a fixed row order. Output values are unchanged within tolerance; the committed golden fixture still matches.

## Test plan

- `test_determinism_rerun` failed 12/12 runs before, passes 10/10 after.
- Full `tests/unit/test_residual_momentum.py` + `tests/golden/test_residual_momentum_golden.py`: 26 passed.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
