### PR TITLE
fix: make market_beta byte-deterministic across runs

### DIFF
--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -9050,13 +9050,21 @@ def capm(df, sfx, __min):
     Output:
         LazyFrame with f'beta{sfx}' and f'ivol_capm{sfx}'.
     """
-    df = df.group_by(["id_int", "group_number"]).agg(
-        [
-            (pl.cov("ret_exc", "mktrf") / pl.var("mktrf")).alias(f"beta{sfx}"),
-            (col("ret_exc") - col("mktrf") * (pl.cov("ret_exc", "mktrf") / pl.var("mktrf")))
-            .std()
-            .alias(f"ivol_capm{sfx}"),
-        ]
+    # Fix within-group row order before the reductions: base_data comes from a
+    # multithreaded DuckDB scan whose row order is nondeterministic, and cov/var/
+    # std are float-order-sensitive, so an unsorted input yields byte-different
+    # betas across runs.
+    df = (
+        df.sort(["id_int", "group_number", "aux_date"])
+        .group_by(["id_int", "group_number"])
+        .agg(
+            [
+                (pl.cov("ret_exc", "mktrf") / pl.var("mktrf")).alias(f"beta{sfx}"),
+                (col("ret_exc") - col("mktrf") * (pl.cov("ret_exc", "mktrf") / pl.var("mktrf")))
+                .std()
+                .alias(f"ivol_capm{sfx}"),
+            ]
+        )
     )
     return df
 

--- a/tests/unit/test_rolling_daily_metrics.py
+++ b/tests/unit/test_rolling_daily_metrics.py
@@ -439,6 +439,7 @@ class TestCapm:
                 "group_number": [10, 10, 10, 10],
                 "mktrf": [1.0, 2.0, 3.0, 4.0],
                 "ret_exc": [2.0, 4.0, 6.0, 8.0],
+                "aux_date": [date(2020, 1, d) for d in (1, 2, 3, 4)],
             }
         )
 
@@ -465,6 +466,7 @@ class TestCapm:
                 "group_number": [10, 10, 10, 10],
                 "mktrf": [2.0, 2.0, 2.0, 2.0],
                 "ret_exc": [1.0, 2.0, 3.0, 4.0],
+                "aux_date": [date(2020, 1, d) for d in (1, 2, 3, 4)],
             }
         )
         result = capm(df, "_21d", __min=15)
@@ -479,6 +481,7 @@ class TestCapm:
                 "group_number": [10, 10, 10, 10, 20, 20, 20, 20],
                 "mktrf": [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0],
                 "ret_exc": [2.0, 4.0, 6.0, 8.0, 1.0, 2.0, 3.0, 5.0],
+                "aux_date": [date(2020, 1, d) for d in (1, 2, 3, 4, 1, 2, 3, 4)],
             }
         )
         low_min = capm(df, "_21d", __min=1).sort(["id_int", "group_number"])
@@ -492,6 +495,7 @@ class TestCapm:
                 "group_number": pl.Int64,
                 "mktrf": pl.Float64,
                 "ret_exc": pl.Float64,
+                "aux_date": pl.Date,
             }
         )
         result = capm(df, "_21d", __min=15)


### PR DESCRIPTION
## Simple explanation

Companion to #230. That PR fixed `residual_momentum`; this fixes the identical latent bug in `market_beta`. `market_beta` has no determinism test, so CI never went red on it, but the same non-reproducibility is present.

## Technical details

`capm` (called by `market_beta`) gets its rows from `prep_data_factor_regs`, which builds `__msf2` in DuckDB with `threads=os.cpu_count()` and returns it via `to_polars()`. That scan's **row order is nondeterministic** — the row set is identical every run, but the order isn't.

`capm` then computes `cov(ret_exc, mktrf) / var(mktrf)` and the residual `std` in a `group_by().agg()`. Those reductions are float-summation-order sensitive, so a different input order yields betas / ivol that differ at ~1e-15 run to run.

**Fix:** sort by `[id_int, group_number, aux_date]` before the `group_by`, mirroring the `res_mom` fix in #230. Output values are unchanged within tolerance; the committed golden fixture still matches.

## Test plan

- Added a local reproducer: `market_beta` output was byte-different across two runs before, byte-identical after.
- `tests/unit/test_market_beta.py` + `tests/golden/test_market_beta_golden.py`: 14 passed.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
