### PR TITLE
feat: support ~/.pgpass for WRDS credentials, replacing the plaintext keyring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,6 @@ Static reference data (`data/cluster_labels.csv`, `data/country_classification.x
 - **`pl.col()`, not bare `col()`.** Use `pl.col(...)` in new code. Existing code uses `from polars import col` with bare `col(...)`, but the standard Polars convention is the namespaced form.
 - **Ruff:** Used for linting and formatting — abide by all rules specified in `pyproject.toml`
 - **Python target:** See `requires-python` and `target-version` in `pyproject.toml`
-- **No decorative comment banners.** Do not add dashed section-separator comments (e.g. `# --------- #`) inside `src/jkp/data/`; rely on function docstrings for structure.
 
 ## Development Guidelines
 
@@ -105,7 +104,6 @@ Output:
 - Add type annotations to new functions (parameters and return types), even though older code in `aux_functions.py` lacks them
 
 **Testing:**
-- **Use test-driven development (TDD).** Write the failing test first, watch it fail, then write the minimum code to make it pass. Commit the test alongside the code it covers.
 - New functions should have corresponding unit tests in `tests/unit/`; see [tests/README.md](tests/README.md) for detailed patterns, conventions, fixture usage, and numerical tolerance guidance
 
 **DRY / reuse:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The pipeline has two entry points that run sequentially:
 - `src/jkp/data/main.py` — Pipeline orchestration; calls functions from `aux_functions` in sequence
 - `src/jkp/data/aux_functions.py` — Core library: all characteristic calculations, data transformations, and I/O utilities
 - `src/jkp/data/portfolio.py` — Standalone factor portfolio construction script
-- `src/jkp/data/wrds_credentials.py` — Keyring-based WRDS credential management
+- `src/jkp/data/wrds_credentials.py` — WRDS credential resolution (env vars, system keyring, and the libpq `~/.pgpass` file)
 
 ### Data flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Static reference data (`data/cluster_labels.csv`, `data/country_classification.x
 - **`pl.col()`, not bare `col()`.** Use `pl.col(...)` in new code. Existing code uses `from polars import col` with bare `col(...)`, but the standard Polars convention is the namespaced form.
 - **Ruff:** Used for linting and formatting — abide by all rules specified in `pyproject.toml`
 - **Python target:** See `requires-python` and `target-version` in `pyproject.toml`
+- **No decorative comment banners.** Do not add dashed section-separator comments (e.g. `# --------- #`) inside `src/jkp/data/`; rely on function docstrings for structure.
 
 ## Development Guidelines
 
@@ -104,6 +105,7 @@ Output:
 - Add type annotations to new functions (parameters and return types), even though older code in `aux_functions.py` lacks them
 
 **Testing:**
+- **Use test-driven development (TDD).** Write the failing test first, watch it fail, then write the minimum code to make it pass. Commit the test alongside the code it covers.
 - New functions should have corresponding unit tests in `tests/unit/`; see [tests/README.md](tests/README.md) for detailed patterns, conventions, fixture usage, and numerical tolerance guidance
 
 **DRY / reuse:**

--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
      Note: If you need to change your password or credentials, run `jkp connect --reset` and then `jkp connect`
 
    - **Credential precedence.** When the pipeline needs WRDS credentials, it
-     resolves them from environment variables, then the system keyring, then an
-     opt-in file-backed keyring. Run `jkp connect --help` for the full
-     precedence order and the `JKP_ALLOW_PLAINTEXT_KEYRING` opt-in details.
+     resolves them from the `WRDS_USERNAME`/`WRDS_PASSWORD` environment
+     variables, then the system keyring, then a libpq password file
+     (`$PGPASSFILE`, else `~/.pgpass`). Run `jkp connect --help` for details.
 
-   On a Slurm/HPC compute node, run `jkp connect` once on the login node
-   under `JKP_ALLOW_PLAINTEXT_KEYRING=1` to populate the file keyring, then
-   set the same variable in the batch script before invoking `jkp build`.
+   On a Slurm/HPC compute node, run `jkp connect` once on the login node — it
+   has no system keyring but does have a terminal, so it writes `~/.pgpass`
+   (mode 600). Because `$HOME` is shared with the compute nodes, the batch job
+   reads it via libpq with no further setup; you do not run `jkp connect`
+   inside the job.
 
 3. **Run the script**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,13 @@ dependencies = [
     "fastexcel>=0.16.0",
     "ibis-framework[duckdb,postgres]>=12.0",
     "keyring>=25.6.0",
-    "keyrings-alt>=5.0.2",
     "numba>=0.61",
     "numpy>=1.26.4",
+    "platformdirs>=4.9.6",
     "polars>=1.40",
     "polars-ds>=0.11.2",
     "polars-ols>=0.3.5",
     "pyarrow>=16.1.0",
-    "pycryptodomex>=3.23.0",
     "sqlalchemy>=1.4.49",
     "tqdm>=4.66.5",
     "typer>=0.15.0",
@@ -104,7 +103,6 @@ markers = [
 source = ["jkp.data"]
 branch = true
 omit = [
-    "*/wrds_credentials.py",
     "*/__pycache__/*",
 ]
 

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -41,9 +41,7 @@ source .venv/bin/activate
 # separate copy. Point PGPASSFILE at a non-default location if you prefer.
 #
 # Fully non-interactive alternative (no login-node terminal): export
-# WRDS_USERNAME / WRDS_PASSWORD, or create ~/.pgpass yourself (chmod 600):
-#
-#     wrds-pgdata.wharton.upenn.edu:9737:wrds:<user>:<password>
+# WRDS_USERNAME / WRDS_PASSWORD.
 
 # Create char data
 # Set PERSISTENT_WRDS_CONNECTION=1 to use a single WRDS connection (reduces MFA on NAT-rotated networks)

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -30,17 +30,20 @@ export NUMEXPR_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 # Activate the project's virtual environment so the jkp CLI is on PATH
 source .venv/bin/activate
 
-# WRDS credentials. Compute nodes don't have a system keyring daemon, so the
-# pipeline needs an alternate source. The default below opts in to the
-# file-backed keyring (a mode-600 file under ~/.local/share/python_keyring/);
-# populate it once on the login node by running:
+# WRDS credentials. Compute nodes have no system keyring daemon, so provision
+# credentials ONCE on a login node (which has an interactive terminal) BEFORE
+# submitting this job -- $HOME is shared with the compute nodes, so the batch
+# job sees the file:
 #
-#     JKP_ALLOW_PLAINTEXT_KEYRING=1 jkp connect
+#     jkp connect          # prompts, writes ~/.pgpass (mode 600)
 #
-# Alternative (for shared service accounts or container deployments): unset
-# JKP_ALLOW_PLAINTEXT_KEYRING and export WRDS_USERNAME / WRDS_PASSWORD instead,
-# e.g. by sourcing a mode-600 ~/.wrds_secrets file with `export WRDS_USERNAME=...`.
-export JKP_ALLOW_PLAINTEXT_KEYRING=1
+# The pipeline reads the password from ~/.pgpass via libpq; jkp never stores a
+# separate copy. Point PGPASSFILE at a non-default location if you prefer.
+#
+# Fully non-interactive alternative (no login-node terminal): export
+# WRDS_USERNAME / WRDS_PASSWORD, or create ~/.pgpass yourself (chmod 600):
+#
+#     wrds-pgdata.wharton.upenn.edu:9737:wrds:<user>:<password>
 
 # Create char data
 # Set PERSISTENT_WRDS_CONNECTION=1 to use a single WRDS connection (reduces MFA on NAT-rotated networks)

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -675,6 +675,28 @@ def gen_crsp_sf(paths: DataPaths, freq):
     return result
 
 
+def _pg_escape_value(value: str) -> str:
+    """libpq-escape a conninfo value (user or password) for a single-quoted field.
+
+    libpq accepts single-quoted values with backslash-escaped ``\\`` and ``'``,
+    so quoting lets a value hold spaces or special characters without breaking the
+    conninfo. For the password this is also the form that appears in any error text
+    echoing the connection string, so the credential-masking checks reuse it rather
+    than matching the raw password.
+    """
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _sql_literal(value: str) -> str:
+    """Escape a string for embedding inside a single-quoted DuckDB SQL literal.
+
+    The conninfo is interpolated into ``ATTACH '...'`` / ``postgres_scan('...')``
+    SQL, so any single quote it contains (e.g. around a libpq-quoted password)
+    must be doubled or it terminates the SQL string literal.
+    """
+    return value.replace("'", "''")
+
+
 def gen_wrds_connection_info(user, password: str | None = None) -> str:
     """Build a libpq conninfo for WRDS.
 
@@ -685,18 +707,49 @@ def gen_wrds_connection_info(user, password: str | None = None) -> str:
         f"host={WRDS_HOST}",
         f"port={WRDS_PORT}",
         f"dbname={WRDS_DB}",
-        f"user={user}",
+        # Quote the username too: a space or quote in it would otherwise break
+        # libpq's conninfo parsing exactly as an unquoted password would.
+        f"user='{_pg_escape_value(user)}'",
     ]
     if password is not None:
-        parts.append(f"password={password}")
+        # Single-quote and escape so a password containing spaces or special
+        # characters can't break the conninfo (or split the value, which would
+        # defeat the password-masking check in _attach_wrds). The conninfo is
+        # itself embedded in a single-quoted SQL literal at each use site, so
+        # callers must additionally pass it through _sql_literal.
+        parts.append(f"password='{_pg_escape_value(password)}'")
     parts.append("sslmode=require")
     return " ".join(parts)
+
+
+def _password_forms(password: str) -> tuple[str, str, str]:
+    """The forms the password can take on its way into an error message: raw, the
+    libpq-escaped conninfo form (echoed by a connection IOException), and the
+    SQL-escaped-then-libpq-escaped form (echoed from the raw statement text by a
+    parser error). Ordered most-escaped first so redaction replaces the longest
+    match before its shorter substrings."""
+    escaped = _pg_escape_value(password)
+    return (_sql_literal(escaped), escaped, password)
+
+
+def _password_in_error(text: str, password: str) -> bool:
+    """True if the password appears in ``text`` in any of the forms it can take in
+    an error message (see :func:`_password_forms`)."""
+    return any(form in text for form in _password_forms(password))
+
+
+def _redact_password(text: str, password: str) -> str:
+    """Replace the password with ``***`` in every form it can take in an error
+    message (see :func:`_password_forms`)."""
+    for form in _password_forms(password):
+        text = text.replace(form, "***")
+    return text
 
 
 def get_columns(conn, conninfo, lib, table):
     cols = conn.execute(f"""
         SELECT *
-        FROM postgres_scan('{conninfo}', '{lib}', '{table}')
+        FROM postgres_scan('{_sql_literal(conninfo)}', '{lib}', '{table}')
         LIMIT 0
     """).description
     return [c[0] for c in cols]
@@ -791,7 +844,7 @@ def download_wrds_table(
     duckdb_conn.execute(f"""
         COPY (
           SELECT {projection}
-          FROM postgres_scan('{conninfo}', '{lib}', '{table}')
+          FROM postgres_scan('{_sql_literal(conninfo)}', '{lib}', '{table}')
           {where_clause}
         )
         TO '{filename}' (FORMAT PARQUET);
@@ -859,9 +912,9 @@ def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str | 
     password-free error. Errors that don't contain the password propagate unchanged.
     """
     try:
-        con.execute(f"ATTACH '{conninfo}' AS wrds (TYPE postgres, READ_ONLY)")
+        con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
     except Exception as e:
-        if password and password in str(e):
+        if password and _password_in_error(str(e), password):
             raise RuntimeError(
                 "Failed to attach WRDS connection. Check credentials and MFA approval."
             ) from None
@@ -1114,7 +1167,7 @@ def _attach_download_worker(
                     )
                 except Exception as e:  # noqa: BLE001
                     # Redact only the credential, keeping the rest of the error for diagnostics.
-                    msg = str(e).replace(password, "***") if password else str(e)
+                    msg = _redact_password(str(e), password) if password else str(e)
                     with errors_lock:
                         task_errors.append(f"{task.table} ({Path(task.out).name}): {msg}")
         finally:

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -34,6 +34,7 @@ from .compustat_correction import (
 from .config import COLLECT_CHUNK_SIZE, CORRECTION_SPILL_COMPRESSION, END_DATE, MAIN_FILTERS
 from .output_writer import write_dataframe
 from .paths import DataPaths
+from .wrds_credentials import WRDS_DB, WRDS_HOST, WRDS_PORT
 
 
 def fl_none():
@@ -674,12 +675,22 @@ def gen_crsp_sf(paths: DataPaths, freq):
     return result
 
 
-def gen_wrds_connection_info(user, password):
-    return (
-        f"host=wrds-pgdata.wharton.upenn.edu "
-        f"port=9737 dbname=wrds "
-        f"user={user} password={password} sslmode=require"
-    )
+def gen_wrds_connection_info(user, password: str | None = None) -> str:
+    """Build a libpq conninfo for WRDS.
+
+    When ``password`` is ``None`` the ``password=`` field is omitted, so libpq
+    authenticates from ``$PGPASSFILE`` / ``~/.pgpass`` instead.
+    """
+    parts = [
+        f"host={WRDS_HOST}",
+        f"port={WRDS_PORT}",
+        f"dbname={WRDS_DB}",
+        f"user={user}",
+    ]
+    if password is not None:
+        parts.append(f"password={password}")
+    parts.append("sslmode=require")
+    return " ".join(parts)
 
 
 def get_columns(conn, conninfo, lib, table):
@@ -840,7 +851,7 @@ def _chunk_path(filename: str, i: int) -> str:
     return str(p.with_name(f"{p.stem}.part{i:02d}{p.suffix}"))
 
 
-def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str) -> None:
+def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str | None) -> None:
     """ATTACH the WRDS Postgres database read-only on an existing DuckDB connection.
 
     DuckDB's postgres extension embeds the full connection string (including the password) in
@@ -953,7 +964,7 @@ def _compute_histograms(
     date_columns: dict[str, str],
     end_date: date | None,
     max_conns: int,
-    password: str,
+    password: str | None,
 ) -> dict[str, list[tuple[int, int]]]:
     """Concurrently compute per-year row histograms for ``tables`` (each over its own connection).
 
@@ -1048,7 +1059,7 @@ def _remove_chunk_parts(filename: str) -> None:
 def _attach_download_worker(
     task_queue: queue.Queue[_DownloadTask],
     conninfo: str,
-    password: str,
+    password: str | None,
     task_errors: list[str],
     startup_errors: list[str],
     errors_lock: threading.Lock,
@@ -1117,7 +1128,7 @@ def _download_tables_parallel(
     conninfo: str,
     date_columns: dict[str, str],
     end_date: date | None,
-    password: str,
+    password: str | None,
     workers: int,
     split_tables: frozenset[str] = frozenset(),
     n_chunks: int = 1,
@@ -1252,7 +1263,7 @@ def _download_tables_parallel(
 def download_raw_data_tables(
     paths: DataPaths,
     username: str,
-    password: str,
+    password: str | None,
     end_date: date | None = None,
     persistent_connection: bool = False,
     max_workers: int = 1,

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -121,17 +121,19 @@ def connect(
     Credential precedence (highest first):
 
       1. WRDS_USERNAME and WRDS_PASSWORD environment variables. Useful for
-         containers and shared service accounts.
+         containers, CI, and shared service accounts.
       2. The system keyring (Keychain on macOS, Secret Service on Linux desktop,
-         Credential Vault on Windows). Default for interactive sessions.
-      3. The file-backed keyring (keyrings.alt.file.PlaintextKeyring), which
-         stores the password in a mode-600 file under
-         ~/.local/share/python_keyring/. Selected only when
-         JKP_ALLOW_PLAINTEXT_KEYRING is set to exactly "1" ("true", "yes", etc.
-         are treated as not set); appropriate for headless environments (HPC
-         compute nodes, minimal Docker images) where no system keyring daemon
-         is available. A warning is emitted on first use (once per process) so
-         the backend change is never silent.
+         Credential Vault on Windows). Default for interactive desktop sessions.
+      3. A libpq password file: $PGPASSFILE, else ~/.pgpass
+         (%APPDATA%\\postgresql\\pgpass.conf on Windows). The standard
+         Postgres/WRDS mechanism, ideal for headless HPC nodes — jkp omits the
+         password from the connection string and libpq reads the file.
+
+    Running `jkp connect` stores the password in the system keyring where one is
+    available. On a headless login node (no keyring, but an interactive
+    terminal) it writes ~/.pgpass (mode 600) instead; because $HOME is shared
+    with the compute nodes, batch jobs then read it without any further setup.
+    The selected source is printed to stderr on every run.
     """
     from .wrds_credentials import get_wrds_credentials, reset_credentials
 

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -137,13 +137,20 @@ def connect(
     """
     from .wrds_credentials import get_wrds_credentials, reset_credentials
 
-    if reset:
-        reset_credentials(full_reset=True)
-        typer.echo("Credentials reset.")
-        return
+    try:
+        if reset:
+            reset_credentials(full_reset=True)
+            typer.echo("Credentials reset.")
+            return
 
-    creds = get_wrds_credentials()
-    typer.echo(f"Connected as: {creds.username}")
+        creds = get_wrds_credentials()
+        typer.echo(f"Connected as: {creds.username}")
+    except RuntimeError as exc:
+        # Credential resolution raises RuntimeError for anticipated, actionable
+        # conditions (no/empty username, an unreadable ~/.pgpass). Surface the
+        # message and exit non-zero rather than dumping a traceback.
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
 
 
 if __name__ == "__main__":

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -135,13 +135,27 @@ def _keyring_set(username: str, password: str) -> bool:
         return False
 
 
-def _keyring_delete(username: str) -> bool:
-    """Delete the keyring entry; return False if absent or no backend."""
+def _keyring_delete(username: str) -> bool | None:
+    """Delete the keyring entry.
+
+    Returns True if one was removed, False when there is definitively nothing to
+    delete (no entry, or no keyring backend at all — in both cases nothing
+    survives), and None when the backend is present but unreachable (locked): the
+    entry may still exist, so we warn and let the caller avoid claiming a clean
+    success it can't guarantee.
+    """
     try:
         keyring.delete_password(SERVICE_NAME, username)
         return True
     except (keyring.errors.NoKeyringError, keyring.errors.PasswordDeleteError):
-        return False
+        return False  # no keyring, or nothing to delete
+    except keyring.errors.KeyringError as exc:
+        print(
+            f"Warning: could not reach the system keyring ({exc}); a stored entry may still exist.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
 
 
 # --------------------------------------------------------------------------- #
@@ -562,7 +576,10 @@ def reset_credentials(full_reset: bool = False) -> None:
             print(f"Deleted password for '{username}' from the system keyring")
         if removed_pgpass:
             print(f"Removed WRDS entry for '{username}' from {_pgpass_path()}")
-        if not (removed_keyring or removed_pgpass):
+        # Only claim nothing was found when the keyring answer was definitive
+        # (False, not None): an unreachable backend already warned that an entry
+        # may survive, so a "nothing found" line here would contradict it.
+        if removed_keyring is False and not removed_pgpass:
             print(f"No stored password found for '{username}'")
 
 

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -425,18 +425,23 @@ def _migrate_legacy_keyring(username: str) -> None:
 
 
 def _resolve_username(env_user: str | None = None) -> str:
-    if env_user:
+    if env_user and env_user.strip():  # ignore a whitespace-only WRDS_USERNAME
         return env_user.strip()
     if LAST_USER_FILE.exists():
-        return LAST_USER_FILE.read_text().strip()
+        cached = LAST_USER_FILE.read_text().strip()
+        if cached:  # treat an empty cache as missing rather than user ''
+            return cached
     if _LEGACY_USER_FILE.exists():  # migrate ~/.wrds_user -> state dir
         username = _LEGACY_USER_FILE.read_text().strip()
-        _persist_username(username)
-        with contextlib.suppress(OSError):
-            _LEGACY_USER_FILE.unlink()
-        return username
+        if username:  # an empty legacy file is treated as missing, not cached as ''
+            _persist_username(username)
+            with contextlib.suppress(OSError):
+                _LEGACY_USER_FILE.unlink()
+            return username
     if _interactive():
         username = input(f"Username for {SERVICE_NAME}: ").strip()
+        if not username:  # don't cache an empty username entered by mistake
+            raise RuntimeError(f"Empty username entered for {SERVICE_NAME}.")
         _persist_username(username)
         return username
     raise RuntimeError(
@@ -448,6 +453,15 @@ def _resolve_username(env_user: str | None = None) -> str:
 def _prompt_and_store(username: str) -> Credentials:
     """Interactively obtain a password and persist it to the best available store."""
     password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
+    if not password:
+        # An empty password would be stored as a junk ``…:username:`` pgpass line
+        # that later "resolves" while auth silently fails — reject it, mirroring
+        # the empty-username guard.
+        raise RuntimeError(f"Empty password entered for {username}; nothing stored.")
+    # Cache the username alongside the stored password, so a credential provisioned
+    # for an env-provided WRDS_USERNAME (which _resolve_username does not persist)
+    # is still revocable via `jkp connect --reset` rather than orphaned.
+    _persist_username(username)
     if _keyring_set(username, password):
         print(
             f"Stored WRDS password for '{username}' in the system keyring.",
@@ -485,14 +499,16 @@ def get_wrds_credentials() -> Credentials:
       4. If nothing is found and a terminal is available, prompt and store;
          otherwise raise with actionable guidance.
     """
-    env_user = os.environ.get(ENV_USERNAME)
+    # Strip before the truthiness check so WRDS_USERNAME="   " is treated as
+    # unset rather than accepted as username="".
+    env_user = (os.environ.get(ENV_USERNAME) or "").strip() or None
     env_pw = os.environ.get(ENV_PASSWORD)
     if env_user and env_pw:
         # Literal env-var names in the log message (not the ENV_* constants) so no
         # "password"-named identifier flows into a logging sink — the value is
         # never logged, only the source label.
         _log_source("the WRDS_USERNAME/WRDS_PASSWORD environment variables")
-        return Credentials(env_user.strip(), env_pw)
+        return Credentials(env_user, env_pw)  # env_user already stripped/non-empty
 
     username = _resolve_username(env_user)
 

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -387,19 +387,15 @@ def _migrate_legacy_keyring(username: str) -> None:
         )
         return
 
-    value = None
+    # Only migrate jkp's own exact-key entry. Since jkp always stored the entry
+    # via keyring.set_password (the same escaping _escape_keyring_option
+    # reproduces), the exact-key lookup covers everything jkp ever wrote; a
+    # fallback for a mismatched key would only serve a hypothetical rename and
+    # risks migrating another user's password under the resolved username.
     option = _escape_keyring_option(username)
-    if cp.has_option(SERVICE_NAME, option):
-        value = cp.get(SERVICE_NAME, option)
-    else:
-        items = cp.items(SERVICE_NAME)
-        if len(items) == 1:
-            # Exactly one stored user: take it even if the key doesn't match the
-            # resolved username. jkp only ever stored the current user's entry,
-            # so this rescues a renamed/re-escaped username. Risk if the file
-            # somehow holds one *other* user's entry: its password migrates under
-            # the resolved username and auth fails (recoverable via `jkp connect`).
-            value = items[0][1]
+    if not cp.has_option(SERVICE_NAME, option):
+        return
+    value = cp.get(SERVICE_NAME, option)
     if not value:
         return
     try:

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -1,207 +1,564 @@
 """WRDS credential resolution.
 
-Credentials are resolved in a defined precedence order: environment variables,
-then the system keyring, then an opt-in file-backed keyring. Run
-``jkp connect --help`` for the full order and the ``JKP_ALLOW_PLAINTEXT_KEYRING``
-opt-in details.
+Username and password are resolved independently:
 
-The file-backed keyring is never selected automatically: the user opts in with
-``JKP_ALLOW_PLAINTEXT_KEYRING=1``, and the swap happens only inside this module's
-credential-resolution functions — importing ``jkp.data`` never changes the
-process-wide keyring backend.
+* **Username** — ``WRDS_USERNAME`` → saved state file → interactive prompt.
+* **Password** — ``WRDS_PASSWORD`` → system keyring → ``$PGPASSFILE`` / ``~/.pgpass``.
+
+When the password comes from a libpq password file, jkp never handles it: the
+connection string omits ``password=`` and libpq reads the file itself
+(:attr:`Credentials.password` is ``None``). The resolved source is printed to
+stderr on every run so it is always clear which one was used.
+
+On a headless node with no system keyring daemon, provision credentials by
+running ``jkp connect`` on a login node (it writes ``~/.pgpass``), by exporting
+``WRDS_USERNAME``/``WRDS_PASSWORD``, or by creating ``~/.pgpass`` directly — it
+is the standard Postgres/WRDS mechanism and any tool can populate it.
+
+Migration (one-time, automatic, non-interactive): a legacy plaintext-keyring
+entry (``~/.local/share/python_keyring/keyring_pass.cfg``, written by the removed
+``JKP_ALLOW_PLAINTEXT_KEYRING`` opt-in) is moved to ``~/.pgpass`` — reading only
+jkp's own ``[WRDS]`` entry and deleting only that entry, never the shared file.
+The username cache moves from ``~/.wrds_user`` to a per-OS state directory.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
+import configparser
 import contextlib
-import functools
 import getpass
+import io
 import os
-import warnings
-from collections.abc import Iterator
+import re
+import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
 import keyring
 import keyring.errors
+import platformdirs
+from keyring.util.platform_ import data_root as _keyring_data_root
 
-SERVICE_NAME = "WRDS"
-LAST_USER_FILE = Path.home() / ".wrds_user"  # remembers last username
+# WRDS Postgres endpoint. Shared with aux_functions.gen_wrds_connection_info so
+# the conninfo host/port/db and the ~/.pgpass match key can never drift apart.
+WRDS_HOST = "wrds-pgdata.wharton.upenn.edu"
+WRDS_PORT = "9737"
+WRDS_DB = "wrds"
 
-# Environment variable names.
+SERVICE_NAME = "WRDS"  # keyring service name and legacy plaintext-keyring section
+
 ENV_USERNAME = "WRDS_USERNAME"
 ENV_PASSWORD = "WRDS_PASSWORD"
-ENV_ALLOW_PLAINTEXT = "JKP_ALLOW_PLAINTEXT_KEYRING"
+ENV_PGPASSFILE = "PGPASSFILE"
 
-# Shown when no keyring backend is available, in place of keyring's generic
-# NoKeyringError ("No recommended backend was available ..."), which gives the
-# user no way forward. The env-var names are interpolated (not their values) so
-# the guidance stays in sync if a name ever changes.
-_NO_BACKEND_GUIDANCE = (
-    "No usable keyring backend is available on this system. On a headless "
-    "machine (HPC compute node, minimal container) choose one of:\n"
-    f"  - set {ENV_USERNAME} and {ENV_PASSWORD} in the environment, or\n"
-    f"  - set {ENV_ALLOW_PLAINTEXT}=1 to use a mode-600 file-backed keyring "
-    "under ~/.local/share/python_keyring/."
-)
+# Username cache: a per-OS state file (auto-migrated from the old ~/.wrds_user).
+LAST_USER_FILE = Path(platformdirs.user_state_dir("jkp")) / "wrds_user"
+_LEGACY_USER_FILE = Path.home() / ".wrds_user"
+
+# Legacy plaintext-keyring store. Its location is decided by *keyring's* own path
+# logic (keyrings.alt writes to ``keyring.util.platform_.data_root()``), which
+# differs from platformdirs on macOS/Windows — so we must use keyring's function,
+# not platformdirs, to find the file keyrings.alt actually wrote.
+_LEGACY_KEYRING_FILE = Path(_keyring_data_root()) / "keyring_pass.cfg"
 
 
 @dataclass(frozen=True)
 class Credentials:
     username: str
-    password: str
+    password: str | None  # None => authenticate via ~/.pgpass (omit password=)
 
 
-@functools.cache
-def _ensure_keyring_backend() -> None:
-    """Select the keyring backend for this process, applying the opt-in
-    file-backed swap if (and only if) the user asked for it.
-
-    Opt-in: set the ``JKP_ALLOW_PLAINTEXT_KEYRING`` environment variable to
-    exactly the string ``"1"``. Any other value (including ``"true"``,
-    ``"yes"``, ``"True"``, or ``"0"``) is treated as not set and the system
-    keyring is used. We use a strict comparison rather than truthy parsing so
-    that the opt-in is unambiguous and matches the documented form.
-
-    Cached so the swap runs at most once per process: every keyring operation
-    routes through this, but the env var is read and the warning emitted only on
-    the first call. Called at credential-resolution time, never at import. The
-    backend stores the password in a mode-600 file under
-    ``~/.local/share/python_keyring/``; the security posture is the same as any
-    other user-private dotfile.
-    """
-    if os.environ.get(ENV_ALLOW_PLAINTEXT) != "1":
-        return
-    warnings.warn(
-        f"{ENV_ALLOW_PLAINTEXT}=1 is set: switching the keyring backend to "
-        "keyrings.alt.file.PlaintextKeyring for this process. The WRDS "
-        "password will be read from / written to a mode-600 file under "
-        "~/.local/share/python_keyring/.",
-        stacklevel=2,
-    )
-    from keyrings.alt.file import PlaintextKeyring  # noqa: PLC0415
-
-    keyring.set_keyring(PlaintextKeyring())
+# --------------------------------------------------------------------------- #
+# Small helpers
+# --------------------------------------------------------------------------- #
+def _interactive() -> bool:
+    return sys.stdin.isatty()
 
 
-@dataclass(frozen=True)
-class _WrdsKeyring:
-    """WRDS-scoped wrapper over the keyring library.
-
-    The one place that speaks keyring's vocabulary for credential storage:
-    callers get/set/delete the WRDS password without naming ``SERVICE_NAME`` or
-    handling keyring's exception types. Handed out only via ``_keyring_backend``.
-    """
-
-    def get_password(self, username: str) -> str | None:
-        return keyring.get_password(SERVICE_NAME, username)
-
-    def set_password(self, username: str, password: str) -> None:
-        keyring.set_password(SERVICE_NAME, username, password)
-
-    def delete_password(self, username: str) -> bool:
-        """Delete the stored password; return ``False`` if there was nothing to
-        delete (or the keyring declined).
-
-        ``NoKeyringError`` is intentionally not caught here, so the
-        missing-backend case still propagates to ``_keyring_backend`` for
-        translation rather than being reported as an absent entry.
-        """
-        try:
-            keyring.delete_password(SERVICE_NAME, username)
-        except keyring.errors.PasswordDeleteError:
-            return False
-        return True
+def _log_source(desc: str) -> None:
+    """Announce which credential source authenticated (never the secret itself)."""
+    print(f"Using WRDS credentials from {desc}.", file=sys.stderr, flush=True)
 
 
-@contextlib.contextmanager
-def _keyring_backend() -> Iterator[_WrdsKeyring]:
-    """Single entry point for any keyring access.
+def _persist_username(username: str) -> None:
+    LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    LAST_USER_FILE.write_text(username)
 
-    Ensures the opt-in backend is selected (once), then yields a WRDS-scoped
-    handle for credential storage. Translates keyring's generic
-    ``NoKeyringError`` into actionable guidance pointing at the env-var and
-    plaintext-opt-in escape hatches. All keyring access goes through the yielded
-    handle, so callers never touch the keyring library directly.
-    """
-    _ensure_keyring_backend()
+
+def _atomic_write(path: Path, text: str, mode: int = 0o600) -> None:
+    """Write ``text`` to ``path`` atomically with restrictive permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent))
     try:
-        yield _WrdsKeyring()
-    except keyring.errors.NoKeyringError as exc:
-        raise keyring.errors.NoKeyringError(_NO_BACKEND_GUIDANCE) from exc
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, mode)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
-def _credentials_from_env() -> Credentials | None:
-    """Return env-var credentials if both ``WRDS_USERNAME`` and ``WRDS_PASSWORD`` are set to
-    non-empty values."""
-    user = os.environ.get(ENV_USERNAME)
-    password = os.environ.get(ENV_PASSWORD)
-    if user and password:
-        return Credentials(user, password)
-    return None
+# --------------------------------------------------------------------------- #
+# System keyring (encrypted OS store only; no file-backed fallback)
+# --------------------------------------------------------------------------- #
+def _keyring_get(username: str) -> str | None:
+    try:
+        return keyring.get_password(SERVICE_NAME, username)
+    except keyring.errors.NoKeyringError:
+        return None
+
+
+def _keyring_set(username: str, password: str) -> bool:
+    """Store the password in the system keyring; return False if none is available."""
+    try:
+        keyring.set_password(SERVICE_NAME, username, password)
+        return True
+    except keyring.errors.NoKeyringError:
+        return False
+
+
+def _keyring_delete(username: str) -> bool:
+    """Delete the keyring entry; return False if absent or no backend."""
+    try:
+        keyring.delete_password(SERVICE_NAME, username)
+        return True
+    except (keyring.errors.NoKeyringError, keyring.errors.PasswordDeleteError):
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# libpq password file (~/.pgpass / $PGPASSFILE)
+# --------------------------------------------------------------------------- #
+def _pgpass_path() -> Path:
+    """The file libpq reads: $PGPASSFILE if set, else the per-OS default."""
+    env = os.environ.get(ENV_PGPASSFILE)
+    if env:
+        return Path(env)
+    if sys.platform.startswith("win"):
+        base = os.environ.get("APPDATA") or str(Path.home())
+        return Path(base) / "postgresql" / "pgpass.conf"
+    return Path.home() / ".pgpass"
+
+
+def _perms_too_open(path: Path) -> bool:
+    """True if libpq would ignore the file for lax permissions (Unix only)."""
+    if sys.platform.startswith("win"):
+        return False
+    return bool(path.stat().st_mode & 0o077)
+
+
+def _split_pgpass(line: str) -> list[str]:
+    """Split a .pgpass line into its fields, honoring backslash escapes."""
+    fields: list[str] = []
+    cur: list[str] = []
+    escaped = False
+    for ch in line:
+        if escaped:
+            cur.append(ch)
+            escaped = False
+        elif ch == "\\":
+            escaped = True
+        elif ch == ":":
+            fields.append("".join(cur))
+            cur = []
+        else:
+            cur.append(ch)
+    fields.append("".join(cur))
+    return fields
+
+
+def _esc_pgpass(value: str) -> str:
+    return value.replace("\\", "\\\\").replace(":", "\\:")
+
+
+def _pgpass_line(username: str, password: str) -> str:
+    return ":".join(_esc_pgpass(v) for v in (WRDS_HOST, WRDS_PORT, WRDS_DB, username, password))
+
+
+def _is_wrds_line(fields: list[str], username: str) -> bool:
+    """True if a parsed line is jkp's own exact WRDS entry for ``username``."""
+    return (
+        len(fields) == 5
+        and fields[0] == WRDS_HOST
+        and fields[1] == WRDS_PORT
+        and fields[2] == WRDS_DB
+        and fields[3] == username
+    )
+
+
+def _pgpass_has_entry(username: str) -> bool:
+    """True if libpq would find a usable WRDS password for ``username``.
+
+    Returns False (rather than raising) if the file cannot be read — an
+    unreadable ~/.pgpass is, for libpq's purposes, no usable entry.
+    """
+    path = _pgpass_path()
+    try:
+        if not path.exists():
+            return False
+        if _perms_too_open(path):
+            print(
+                f"Warning: {path} has permissions looser than 0600; libpq ignores it. "
+                f"Run: chmod 600 {path}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return False
+        lines = path.read_text().splitlines()
+    except OSError:
+        return False
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        fields = _split_pgpass(stripped)
+        if len(fields) != 5:
+            continue
+        host, port, db, user, _pw = fields
+        if (
+            host in ("*", WRDS_HOST)
+            and port in ("*", WRDS_PORT)
+            and db in ("*", WRDS_DB)
+            and user in ("*", username)
+        ):
+            return True
+    return False
+
+
+def _write_pgpass(username: str, password: str) -> Path:
+    """Append or replace jkp's WRDS line, leaving every other entry untouched."""
+    if "\n" in password or "\r" in password:
+        # A .pgpass entry is one line; a newline in the password would inject a
+        # spurious second line. libpq's format cannot represent it, so reject it.
+        raise ValueError("WRDS password contains a newline, which ~/.pgpass cannot store.")
+    path = _pgpass_path()
+    new_line = _pgpass_line(username, password)
+    out: list[str] = []
+    replaced = False
+    if path.exists():
+        for raw in path.read_text().splitlines():
+            if _is_wrds_line(_split_pgpass(raw.strip()), username):
+                if not replaced:
+                    out.append(new_line)
+                    replaced = True
+                # drop any duplicate WRDS lines for this user
+            else:
+                out.append(raw)
+    if not replaced:
+        out.append(new_line)
+    _atomic_write(path, "\n".join(out) + "\n")
+    return path
+
+
+def _remove_pgpass_entry(username: str) -> bool:
+    """Remove jkp's WRDS line; return True if one was removed. Preserves others."""
+    path = _pgpass_path()
+    if not path.exists():
+        return False
+    out: list[str] = []
+    removed = False
+    for raw in path.read_text().splitlines():
+        if _is_wrds_line(_split_pgpass(raw.strip()), username):
+            removed = True
+        else:
+            out.append(raw)
+    if not removed:
+        return False
+    if any(line.strip() for line in out):
+        _atomic_write(path, "\n".join(out) + "\n")
+    else:
+        with contextlib.suppress(OSError):
+            path.unlink()
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# One-time migration off the legacy plaintext keyring
+# --------------------------------------------------------------------------- #
+def _escape_keyring_option(username: str) -> str:
+    """Reproduce keyrings.alt's option-key escaping for a username.
+
+    keyrings.alt stores each option name as ``escape_for_ini(username)`` — every
+    non-alphanumeric character becomes ``_`` followed by the zero-padded 2-digit
+    hex of each of its UTF-8 bytes (``_%02X``; e.g. ``a.b`` → ``a_2Eb``,
+    tab → ``_09``) — and configparser then lowercases it. We escape here (using
+    lowercase hex, which configparser's ``optionxform`` also produces) so
+    migration finds entries for usernames containing dots, hyphens, uppercase, or
+    non-ASCII characters, not just plain lowercase-alnum ones.
+    """
+    return re.sub(
+        r"[^A-Za-z0-9]",
+        lambda m: "".join(f"_{b:02x}" for b in m.group(0).encode("utf-8")),
+        username,
+    )
+
+
+def _drop_legacy_keyring_section(cp: configparser.RawConfigParser, path: Path) -> None:
+    """Remove only jkp's ``[WRDS]`` section, preserving any other tools' sections;
+    delete the file if ours was the last section."""
+    cp.remove_section(SERVICE_NAME)
+    if cp.sections():
+        buf = io.StringIO()
+        cp.write(buf)
+        _atomic_write(path, buf.getvalue())
+    else:
+        with contextlib.suppress(OSError):
+            path.unlink()
+
+
+def _cleanup_legacy_keyring_section() -> None:
+    """Best-effort removal of a lingering ``[WRDS]`` section from the legacy
+    plaintext keyring — used when the password now comes from another source (env
+    or system keyring) so the obsolete plaintext copy does not linger on disk.
+    Never raises."""
+    path = _LEGACY_KEYRING_FILE
+    if not path.exists():
+        return
+    try:
+        cp = configparser.RawConfigParser()
+        cp.read(path, encoding="utf-8")
+        if cp.has_section(SERVICE_NAME):
+            _drop_legacy_keyring_section(cp, path)
+    except (configparser.Error, UnicodeDecodeError, OSError):
+        pass
+
+
+def _migrate_legacy_keyring(username: str) -> None:
+    """Move jkp's legacy plaintext-keyring entry to ~/.pgpass, non-interactively.
+
+    ``keyring_pass.cfg`` is the shared keyrings.alt store; its values are plain
+    ``base64(password)`` (PlaintextKeyring does no encryption). We read only the
+    ``[WRDS]`` section, write the equivalent ~/.pgpass line, and delete only that
+    section — never the file, which may hold other tools' credentials.
+
+    An existing ~/.pgpass entry for the user is their current credential and is
+    never overwritten; in that case we only drop the superseded legacy section.
+    """
+    path = _LEGACY_KEYRING_FILE
+    if not path.exists():
+        return
+    cp = configparser.RawConfigParser()
+    try:
+        cp.read(path, encoding="utf-8")
+    except (configparser.Error, UnicodeDecodeError):
+        # A corrupt or non-UTF8 legacy file is not migratable; skip it and let
+        # normal resolution (env / ~/.pgpass / prompt) proceed. (An OSError on
+        # read propagates to the best-effort wrapper in get_wrds_credentials.)
+        return
+    if not cp.has_section(SERVICE_NAME):
+        return
+
+    # If ~/.pgpass already resolves for this user, that is their current
+    # credential — never clobber it with the (possibly stale) legacy value.
+    # Just drop the now-superseded legacy [WRDS] section.
+    if _pgpass_has_entry(username):
+        _drop_legacy_keyring_section(cp, path)
+        print(
+            "Removed a superseded WRDS entry from the legacy plaintext keyring; "
+            "kept your existing ~/.pgpass entry.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+
+    value = None
+    option = _escape_keyring_option(username)
+    if cp.has_option(SERVICE_NAME, option):
+        value = cp.get(SERVICE_NAME, option)
+    else:
+        items = cp.items(SERVICE_NAME)
+        if len(items) == 1:
+            # Exactly one stored user: take it even if the key doesn't match the
+            # resolved username. jkp only ever stored the current user's entry,
+            # so this rescues a renamed/re-escaped username. Risk if the file
+            # somehow holds one *other* user's entry: its password migrates under
+            # the resolved username and auth fails (recoverable via `jkp connect`).
+            value = items[0][1]
+    if not value:
+        return
+    try:
+        password = base64.decodebytes(value.encode()).decode("utf-8")
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return
+
+    try:
+        pgpass = _write_pgpass(username, password)
+    except ValueError as exc:
+        # The legacy password can't be stored in ~/.pgpass (e.g. it contains a
+        # newline) — it's unusable, and libpq could never authenticate with it.
+        # Drop the dead section so we don't decode-and-fail on every future run,
+        # and let resolution surface a clean "no credentials" path instead.
+        _drop_legacy_keyring_section(cp, path)
+        print(
+            f"Discarded an unusable legacy WRDS credential ({exc}); "
+            "run `jkp connect` to re-provision.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    _drop_legacy_keyring_section(cp, path)
+    print(
+        f"Migrated WRDS credential from the legacy plaintext keyring to {pgpass}.",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Username / password resolution
+# --------------------------------------------------------------------------- #
+def _resolve_username(env_user: str | None = None) -> str:
+    if env_user:
+        return env_user.strip()
+    if LAST_USER_FILE.exists():
+        return LAST_USER_FILE.read_text().strip()
+    if _LEGACY_USER_FILE.exists():  # migrate ~/.wrds_user -> state dir
+        username = _LEGACY_USER_FILE.read_text().strip()
+        _persist_username(username)
+        with contextlib.suppress(OSError):
+            _LEGACY_USER_FILE.unlink()
+        return username
+    if _interactive():
+        username = input(f"Username for {SERVICE_NAME}: ").strip()
+        _persist_username(username)
+        return username
+    raise RuntimeError(
+        f"No WRDS username available and no terminal to prompt at. Set "
+        f"{ENV_USERNAME}, or run `jkp connect` on a login node to store one."
+    )
+
+
+def _prompt_and_store(username: str) -> Credentials:
+    """Interactively obtain a password and persist it to the best available store."""
+    password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
+    if _keyring_set(username, password):
+        print(
+            f"Stored WRDS password for '{username}' in the system keyring.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return Credentials(username, password)
+    pgpass = _write_pgpass(username, password)
+    print(
+        f"No system keyring available; wrote WRDS credentials to {pgpass} (mode 600).",
+        file=sys.stderr,
+        flush=True,
+    )
+    return Credentials(username, None)
+
+
+def _no_credentials_error(username: str) -> RuntimeError:
+    return RuntimeError(
+        f"No WRDS password found for '{username}' and no terminal to prompt at. "
+        f"Provide credentials one of these ways:\n"
+        f"  - set {ENV_USERNAME} and {ENV_PASSWORD} in the environment, or\n"
+        f"  - run `jkp connect` on a login node (writes ~/.pgpass on headless "
+        f"machines), or\n"
+        f"  - create a ~/.pgpass / $PGPASSFILE entry for {WRDS_HOST}."
+    )
 
 
 def get_wrds_credentials() -> Credentials:
     """Resolve WRDS credentials following the documented precedence order.
 
     Steps:
-      1. If ``WRDS_USERNAME`` and ``WRDS_PASSWORD`` are both set, return those.
-      2. Otherwise, look up the saved username in ``~/.wrds_user`` (prompt
-         interactively on first run).
-      3. Fetch the password from the (possibly plaintext-opt-in) keyring;
-         prompt and store on first run.
+      1. If ``WRDS_USERNAME`` and ``WRDS_PASSWORD`` are both set, use those.
+      2. Resolve the username (env, saved state file, or prompt).
+      3. Password: ``WRDS_PASSWORD`` → system keyring → ``~/.pgpass``/``$PGPASSFILE``.
+      4. If nothing is found and a terminal is available, prompt and store;
+         otherwise raise with actionable guidance.
     """
-    env_creds = _credentials_from_env()
-    if env_creds is not None:
-        return env_creds
+    env_user = os.environ.get(ENV_USERNAME)
+    env_pw = os.environ.get(ENV_PASSWORD)
+    if env_user and env_pw:
+        _log_source(f"the {ENV_USERNAME}/{ENV_PASSWORD} environment variables")
+        return Credentials(env_user.strip(), env_pw)
 
-    if LAST_USER_FILE.exists():
-        username = LAST_USER_FILE.read_text().strip()
-    else:
-        username = input(f"Username for {SERVICE_NAME}: ").strip()
-        LAST_USER_FILE.write_text(username)
+    username = _resolve_username(env_user)
 
-    with _keyring_backend() as kr:
-        password = kr.get_password(username)
+    if env_pw:
+        _log_source(f"the {ENV_PASSWORD} environment variable")
+        return Credentials(username, env_pw)
 
-        if not password:
-            password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
-            kr.set_password(username, password)
-            print(f"Stored credentials for '{username}' in keyring under '{SERVICE_NAME}'")
+    keyring_pw = _keyring_get(username)
+    if keyring_pw:
+        # The keyring supersedes any legacy plaintext copy; clean it up.
+        _cleanup_legacy_keyring_section()
+        _log_source("the system keyring")
+        return Credentials(username, keyring_pw)
 
-    return Credentials(username, password)
+    # One-time migration off the legacy plaintext keyring, reached only when
+    # neither an env password nor a system-keyring entry supplied the password.
+    # It no-ops unless a legacy keyring_pass.cfg with a [WRDS] entry exists. A
+    # migration I/O failure must not abort resolution: env / existing ~/.pgpass /
+    # an interactive prompt may still provide credentials.
+    try:
+        _migrate_legacy_keyring(username)
+    except (OSError, ValueError) as exc:
+        print(
+            f"Warning: could not migrate the legacy WRDS credential ({exc}); "
+            "continuing without it.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    if _pgpass_has_entry(username):
+        _log_source(f"{_pgpass_path()} (libpq password file)")
+        return Credentials(username, None)
+
+    if _interactive():
+        return _prompt_and_store(username)
+
+    raise _no_credentials_error(username)
 
 
 def reset_credentials(full_reset: bool = False) -> None:
-    """Clear the stored username and (optionally) remove the password from the keyring."""
-    if LAST_USER_FILE.exists():
-        username = LAST_USER_FILE.read_text().strip()
-        LAST_USER_FILE.unlink()
-        print(f"Removed stored username '{username}'")
+    """Clear the stored username and (optionally) the stored password.
 
-        if full_reset:
-            with _keyring_backend() as kr:
-                if kr.delete_password(username):
-                    print(f"Deleted password for '{username}' from keyring under '{SERVICE_NAME}'")
-                else:
-                    print(f"No keyring entry found for '{username}'")
+    With ``full_reset``, removes the password from both the system keyring and
+    jkp's ``~/.pgpass`` line (leaving any other ``.pgpass`` entries intact).
+    """
+    username: str | None = None
+    for user_file in (LAST_USER_FILE, _LEGACY_USER_FILE):
+        if user_file.exists():
+            if username is None:
+                username = user_file.read_text().strip()
+            user_file.unlink()
 
-    else:
+    if username is None:
         print("No stored username found — nothing to reset.")
+        return
+    print(f"Removed stored username '{username}'")
+
+    if full_reset:
+        removed_keyring = _keyring_delete(username)
+        removed_pgpass = _remove_pgpass_entry(username)
+        if removed_keyring:
+            print(f"Deleted password for '{username}' from the system keyring")
+        if removed_pgpass:
+            print(f"Removed WRDS entry for '{username}' from {_pgpass_path()}")
+        if not (removed_keyring or removed_pgpass):
+            print(f"No stored password found for '{username}'")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Manage stored wrds credentials.")
+    parser = argparse.ArgumentParser(description="Manage stored WRDS credentials.")
     parser.add_argument(
         "--reset",
         action="store_true",
-        help="Remove both stored username and password from keyring.",
+        help="Remove stored username and password (keyring and ~/.pgpass entry).",
     )
     args = parser.parse_args()
 
     if args.reset:
-        reset_credentials(full_reset=args.reset)
+        reset_credentials(full_reset=True)
     else:
         creds = get_wrds_credentials()
         print(f"Using credentials for '{creds.username}'")

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -112,15 +112,26 @@ def _keyring_get(username: str) -> str | None:
     try:
         return keyring.get_password(SERVICE_NAME, username)
     except keyring.errors.NoKeyringError:
+        return None  # no backend at all — the normal headless case
+    except keyring.errors.KeyringError as exc:
+        # Backend present but unusable (a locked SecretService/KWallet on headless
+        # SSH, or an init failure). Warn so a genuinely-stored-but-locked password
+        # isn't silently ignored, then fall through to the other sources.
+        print(
+            f"Warning: the system keyring is present but unusable ({exc}); "
+            "falling back to other credential sources.",
+            file=sys.stderr,
+            flush=True,
+        )
         return None
 
 
 def _keyring_set(username: str, password: str) -> bool:
-    """Store the password in the system keyring; return False if none is available."""
+    """Store the password in the system keyring; return False if it is unusable."""
     try:
         keyring.set_password(SERVICE_NAME, username, password)
         return True
-    except keyring.errors.NoKeyringError:
+    except keyring.errors.KeyringError:
         return False
 
 

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -224,21 +224,21 @@ def _is_wrds_line(fields: list[str], username: str) -> bool:
     )
 
 
-def _pgpass_has_entry(username: str, *, check_perms: bool = True) -> bool:
-    """True if a WRDS entry for ``username`` exists in the pgpass file.
+def _pgpass_scan(username: str, *, check_perms: bool = True) -> tuple[bool, bool]:
+    """Scan the pgpass file for WRDS entries, returning ``(matched, has_exact)``.
 
-    With ``check_perms`` (the default), the file must also be usable by libpq —
-    a too-open file is treated as no entry. Pass ``check_perms=False`` to ask
-    only whether an entry *exists* (e.g. to avoid overwriting a user's current
-    line just because its permissions are loose).
-
-    Returns False (rather than raising) if the file cannot be read — an
-    unreadable ~/.pgpass is, for libpq's purposes, no usable entry.
+    ``matched`` is whether libpq would find a usable WRDS password (via an exact
+    line or a wildcard); ``has_exact`` is whether the *first* matching line — the
+    one libpq actually uses — is jkp's own exact entry (so `jkp connect` can
+    manage it). A wildcard sitting above an exact line therefore yields
+    ``(True, False)``. With ``check_perms`` (the default), a too-open file counts
+    as no entry (libpq ignores it); pass ``check_perms=False`` to ask only whether
+    an entry exists. Returns ``(False, False)`` if the file is missing or unreadable.
     """
     path = _pgpass_path()
     try:
         if not path.exists():
-            return False
+            return False, False
         if check_perms and _perms_too_open(path):
             print(
                 f"Warning: {path} has permissions looser than 0600; libpq ignores it. "
@@ -246,10 +246,11 @@ def _pgpass_has_entry(username: str, *, check_perms: bool = True) -> bool:
                 file=sys.stderr,
                 flush=True,
             )
-            return False
+            return False, False
         lines = path.read_text().splitlines()
     except OSError:
-        return False
+        return False, False
+    matched = has_exact = False
     for raw in lines:
         stripped = raw.strip()
         if not stripped or stripped.startswith("#"):
@@ -264,8 +265,21 @@ def _pgpass_has_entry(username: str, *, check_perms: bool = True) -> bool:
             and db in ("*", WRDS_DB)
             and user in ("*", username)
         ):
-            return True
-    return False
+            # libpq uses the FIRST matching line, so only that one decides whether
+            # the effective credential is jkp's exact entry or a wildcard. A
+            # wildcard sitting above jkp's exact line wins, and jkp cannot manage
+            # it — exactly the case the wildcard warning needs to catch.
+            matched = True
+            has_exact = _is_wrds_line(fields, username)
+            break
+    return matched, has_exact
+
+
+def _pgpass_has_entry(username: str, *, check_perms: bool = True) -> bool:
+    """True if libpq would find a usable WRDS password for ``username`` (exact or
+    wildcard). Pass ``check_perms=False`` to ask only whether an entry exists,
+    ignoring whether the file's permissions would make libpq skip it."""
+    return _pgpass_scan(username, check_perms=check_perms)[0]
 
 
 def _write_pgpass(username: str, password: str) -> Path:
@@ -576,8 +590,16 @@ def get_wrds_credentials() -> Credentials:
             flush=True,
         )
 
-    if _pgpass_has_entry(username):
+    matched, has_exact = _pgpass_scan(username)
+    if matched:
         _log_source(f"{_pgpass_path()} (libpq password file)")
+        if not has_exact:
+            print(
+                f"Warning: WRDS is served by a catch-all entry in {_pgpass_path()}, "
+                "not a WRDS-specific line, so `jkp connect` cannot set or change it.",
+                file=sys.stderr,
+                flush=True,
+            )
         return Credentials(username, None)
 
     if _interactive():

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -265,7 +265,15 @@ def _write_pgpass(username: str, password: str) -> Path:
     out: list[str] = []
     replaced = False
     if path.exists():
-        for raw in path.read_text().splitlines():
+        try:
+            existing = path.read_text().splitlines()
+        except OSError as exc:
+            # e.g. a root-owned ~/.pgpass from an old sudo — surface an actionable
+            # message rather than a raw error after the user typed their password.
+            raise RuntimeError(
+                f"Cannot read existing {path} ({exc}); fix its permissions and retry."
+            ) from exc
+        for raw in existing:
             if _is_wrds_line(_split_pgpass(raw.strip()), username):
                 if not replaced:
                     out.append(new_line)
@@ -284,9 +292,15 @@ def _remove_pgpass_entry(username: str) -> bool:
     path = _pgpass_path()
     if not path.exists():
         return False
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as exc:
+        raise RuntimeError(
+            f"Cannot read existing {path} ({exc}); fix its permissions and retry."
+        ) from exc
     out: list[str] = []
     removed = False
-    for raw in path.read_text().splitlines():
+    for raw in lines:
         if _is_wrds_line(_split_pgpass(raw.strip()), username):
             removed = True
         else:
@@ -530,9 +544,15 @@ def get_wrds_credentials() -> Credentials:
     # It no-ops unless a legacy keyring_pass.cfg with a [WRDS] entry exists. A
     # migration I/O failure must not abort resolution: env / existing ~/.pgpass /
     # an interactive prompt may still provide credentials.
+    #
+    # Note: if the keyring was merely *locked* (not absent), we reached here
+    # without consulting it, so migrating the legacy plaintext copy could activate
+    # a password the user has since rotated in the keyring. That's inherent to
+    # falling through a locked keyring; `jkp connect --reset` clears the legacy
+    # copy, and the ~/.pgpass entry (if any) is preferred over the legacy value.
     try:
         _migrate_legacy_keyring(username)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         print(
             f"Warning: could not migrate the legacy WRDS credential ({exc}); "
             "continuing without it.",
@@ -556,27 +576,29 @@ def reset_credentials(full_reset: bool = False) -> None:
     With ``full_reset``, removes the password from both the system keyring and
     jkp's ``~/.pgpass`` line (leaving any other ``.pgpass`` entries intact).
     """
+    # Read the username but do NOT delete the cache files yet (see the unlink at
+    # the end). Treat an empty/whitespace cache as missing, so we don't reset
+    # user '' and don't consume the legacy ~/.wrds_user unread.
     username: str | None = None
     for user_file in (LAST_USER_FILE, _LEGACY_USER_FILE):
-        if user_file.exists():
-            if username is None:
-                username = user_file.read_text().strip()
-            user_file.unlink()
+        if user_file.exists() and username is None:
+            username = user_file.read_text().strip() or None
 
     if username is None:
         print("No stored username found — nothing to reset.")
         return
-    print(f"Removed stored username '{username}'")
 
     if full_reset:
         removed_keyring = _keyring_delete(username)
-        removed_pgpass = _remove_pgpass_entry(username)
-        # Also drop any legacy plaintext-keyring [WRDS] section: otherwise the
-        # next resolution would migrate the just-revoked password back into
-        # ~/.pgpass, undoing the reset.
+        # Drop any legacy plaintext-keyring [WRDS] section before removing the
+        # ~/.pgpass line (otherwise the next resolution would migrate the
+        # just-revoked password back into ~/.pgpass). Cleanup never raises, so
+        # doing it first means a failure removing an unreadable ~/.pgpass can't
+        # skip it and leave a plaintext copy behind on a security-motivated reset.
         _cleanup_legacy_keyring_section()
         if removed_keyring:
             print(f"Deleted password for '{username}' from the system keyring")
+        removed_pgpass = _remove_pgpass_entry(username)
         if removed_pgpass:
             print(f"Removed WRDS entry for '{username}' from {_pgpass_path()}")
         # Only claim nothing was found when the keyring answer was definitive
@@ -584,6 +606,14 @@ def reset_credentials(full_reset: bool = False) -> None:
         # may survive, so a "nothing found" line here would contradict it.
         if removed_keyring is False and not removed_pgpass:
             print(f"No stored password found for '{username}'")
+
+    # Remove the username cache last: if a password removal above raised (e.g. an
+    # unreadable ~/.pgpass), the cache survives so a retry can still find the
+    # username and finish the reset instead of orphaning the stored password.
+    for user_file in (LAST_USER_FILE, _LEGACY_USER_FILE):
+        with contextlib.suppress(FileNotFoundError):
+            user_file.unlink()
+    print(f"Removed stored username '{username}'")
 
 
 if __name__ == "__main__":

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -25,7 +25,6 @@ The username cache moves from ``~/.wrds_user`` to a per-OS state directory.
 
 from __future__ import annotations
 
-import argparse
 import base64
 import binascii
 import configparser
@@ -614,19 +613,3 @@ def reset_credentials(full_reset: bool = False) -> None:
         with contextlib.suppress(FileNotFoundError):
             user_file.unlink()
     print(f"Removed stored username '{username}'")
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Manage stored WRDS credentials.")
-    parser.add_argument(
-        "--reset",
-        action="store_true",
-        help="Remove stored username and password (keyring and ~/.pgpass entry).",
-    )
-    args = parser.parse_args()
-
-    if args.reset:
-        reset_credentials(full_reset=True)
-    else:
-        creds = get_wrds_credentials()
-        print(f"Using credentials for '{creds.username}'")

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -209,8 +209,13 @@ def _is_wrds_line(fields: list[str], username: str) -> bool:
     )
 
 
-def _pgpass_has_entry(username: str) -> bool:
-    """True if libpq would find a usable WRDS password for ``username``.
+def _pgpass_has_entry(username: str, *, check_perms: bool = True) -> bool:
+    """True if a WRDS entry for ``username`` exists in the pgpass file.
+
+    With ``check_perms`` (the default), the file must also be usable by libpq —
+    a too-open file is treated as no entry. Pass ``check_perms=False`` to ask
+    only whether an entry *exists* (e.g. to avoid overwriting a user's current
+    line just because its permissions are loose).
 
     Returns False (rather than raising) if the file cannot be read — an
     unreadable ~/.pgpass is, for libpq's purposes, no usable entry.
@@ -219,7 +224,7 @@ def _pgpass_has_entry(username: str) -> bool:
     try:
         if not path.exists():
             return False
-        if _perms_too_open(path):
+        if check_perms and _perms_too_open(path):
             print(
                 f"Warning: {path} has permissions looser than 0600; libpq ignores it. "
                 f"Run: chmod 600 {path}",
@@ -371,7 +376,7 @@ def _migrate_legacy_keyring(username: str) -> None:
     # If ~/.pgpass already resolves for this user, that is their current
     # credential — never clobber it with the (possibly stale) legacy value.
     # Just drop the now-superseded legacy [WRDS] section.
-    if _pgpass_has_entry(username):
+    if _pgpass_has_entry(username, check_perms=False):
         _drop_legacy_keyring_section(cp, path)
         print(
             "Removed a superseded WRDS entry from the legacy plaintext keyring; "

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -86,15 +86,30 @@ def _persist_username(username: str) -> None:
     LAST_USER_FILE.write_text(username)
 
 
-def _atomic_write(path: Path, text: str, mode: int = 0o600) -> None:
-    """Write ``text`` to ``path`` atomically with restrictive permissions."""
+def _atomic_write(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` atomically, with 0600 permissions."""
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=str(path.parent))
     try:
         if hasattr(os, "fchmod"):
-            os.fchmod(fd, mode)
+            # Enforce 0600 explicitly rather than relying on mkstemp's default:
+            # this file may hold a plaintext password, so the mode must be
+            # guaranteed even if that default ever changes.
+            os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w") as fh:
             fh.write(text)
+        if path.is_symlink():
+            # os.replace swaps the symlink itself for the new regular file, so its
+            # original target is left untouched — and, for ~/.pgpass, may still
+            # hold the old WRDS entry (e.g. in a dotfiles copy). We don't write
+            # through the link (that would push a secret into a tracked tree), but
+            # we warn so the detachment isn't silent.
+            print(
+                f"Note: {path} is a symlink; replacing it with a regular file. Its "
+                "original target is now detached and may still contain the old entry.",
+                file=sys.stderr,
+                flush=True,
+            )
         os.replace(tmp, path)
     except BaseException:
         with contextlib.suppress(OSError):

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -543,6 +543,10 @@ def reset_credentials(full_reset: bool = False) -> None:
     if full_reset:
         removed_keyring = _keyring_delete(username)
         removed_pgpass = _remove_pgpass_entry(username)
+        # Also drop any legacy plaintext-keyring [WRDS] section: otherwise the
+        # next resolution would migrate the just-revoked password back into
+        # ~/.pgpass, undoing the reset.
+        _cleanup_legacy_keyring_section()
         if removed_keyring:
             print(f"Deleted password for '{username}' from the system keyring")
         if removed_pgpass:

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -96,7 +96,7 @@ def _atomic_write(path: Path, text: str) -> None:
             # this file may hold a plaintext password, so the mode must be
             # guaranteed even if that default ever changes.
             os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(text)
         if path.is_symlink():
             # os.replace swaps the symlink itself for the new regular file, so its
@@ -233,7 +233,8 @@ def _pgpass_scan(username: str, *, check_perms: bool = True) -> tuple[bool, bool
     manage it). A wildcard sitting above an exact line therefore yields
     ``(True, False)``. With ``check_perms`` (the default), a too-open file counts
     as no entry (libpq ignores it); pass ``check_perms=False`` to ask only whether
-    an entry exists. Returns ``(False, False)`` if the file is missing or unreadable.
+    an entry exists. Returns ``(False, False)`` if the file is missing, unreadable,
+    or not valid UTF-8 (jkp reads it as UTF-8 and warns in that last case).
     """
     path = _pgpass_path()
     try:
@@ -247,7 +248,22 @@ def _pgpass_scan(username: str, *, check_perms: bool = True) -> tuple[bool, bool
                 flush=True,
             )
             return False, False
-        lines = path.read_text().splitlines()
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        # jkp reads the file as UTF-8 — a deliberate choice, since libpq itself is
+        # byte-oriented and mandates no encoding. A file another tool wrote in a
+        # different encoding isn't "invalid"; jkp just can't read it here, so
+        # ignore it (with a warning) rather than crash the whole resolution.
+        # Use the literal env-var name here, not the ENV_PASSWORD constant: CodeQL's
+        # clear-text-logging check is name-based, so a "password"-named identifier
+        # flowing into this stderr sink is a false positive (cf. get_wrds_credentials).
+        print(
+            f"Warning: jkp reads {path} as UTF-8, but it is not valid UTF-8, so jkp "
+            "cannot use it. Set WRDS_PASSWORD or use the system keyring.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return False, False
     except OSError:
         return False, False
     matched = has_exact = False
@@ -282,6 +298,30 @@ def _pgpass_has_entry(username: str, *, check_perms: bool = True) -> bool:
     return _pgpass_scan(username, check_perms=check_perms)[0]
 
 
+def _read_pgpass_lines(path: Path) -> list[str]:
+    """Read an existing pgpass file's lines for a read-modify-write, raising an
+    actionable ``RuntimeError`` rather than a raw traceback when it can't be read.
+
+    jkp reads the file as UTF-8 — a deliberate choice, since libpq itself is
+    byte-oriented and mandates no ``.pgpass`` encoding. A file another tool wrote
+    in a different encoding isn't "invalid"; jkp simply can't edit it in place, so
+    say so and point at the alternatives instead of clobbering it.
+    """
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise RuntimeError(
+            f"jkp reads {path} as UTF-8, but it is not valid UTF-8 ({exc}); "
+            "re-save it as UTF-8, or use WRDS_PASSWORD or the system keyring."  # literal, not ENV_PASSWORD
+        ) from exc
+    except OSError as exc:
+        # e.g. a root-owned ~/.pgpass from an old sudo — surface an actionable
+        # message rather than a raw error after the user typed their password.
+        raise RuntimeError(
+            f"Cannot read existing {path} ({exc}); fix its permissions and retry."
+        ) from exc
+
+
 def _write_pgpass(username: str, password: str) -> Path:
     """Append or replace jkp's WRDS line, leaving every other entry untouched."""
     if "\n" in password or "\r" in password:
@@ -293,14 +333,7 @@ def _write_pgpass(username: str, password: str) -> Path:
     out: list[str] = []
     replaced = False
     if path.exists():
-        try:
-            existing = path.read_text().splitlines()
-        except OSError as exc:
-            # e.g. a root-owned ~/.pgpass from an old sudo — surface an actionable
-            # message rather than a raw error after the user typed their password.
-            raise RuntimeError(
-                f"Cannot read existing {path} ({exc}); fix its permissions and retry."
-            ) from exc
+        existing = _read_pgpass_lines(path)
         for raw in existing:
             if _is_wrds_line(_split_pgpass(raw.strip()), username):
                 if not replaced:
@@ -320,12 +353,7 @@ def _remove_pgpass_entry(username: str) -> bool:
     path = _pgpass_path()
     if not path.exists():
         return False
-    try:
-        lines = path.read_text().splitlines()
-    except OSError as exc:
-        raise RuntimeError(
-            f"Cannot read existing {path} ({exc}); fix its permissions and retry."
-        ) from exc
+    lines = _read_pgpass_lines(path)
     out: list[str] = []
     removed = False
     for raw in lines:

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -72,9 +72,6 @@ class Credentials:
     password: str | None  # None => authenticate via ~/.pgpass (omit password=)
 
 
-# --------------------------------------------------------------------------- #
-# Small helpers
-# --------------------------------------------------------------------------- #
 def _interactive() -> bool:
     return sys.stdin.isatty()
 
@@ -105,9 +102,6 @@ def _atomic_write(path: Path, text: str, mode: int = 0o600) -> None:
         raise
 
 
-# --------------------------------------------------------------------------- #
-# System keyring (encrypted OS store only; no file-backed fallback)
-# --------------------------------------------------------------------------- #
 def _keyring_get(username: str) -> str | None:
     try:
         return keyring.get_password(SERVICE_NAME, username)
@@ -158,9 +152,6 @@ def _keyring_delete(username: str) -> bool | None:
         return None
 
 
-# --------------------------------------------------------------------------- #
-# libpq password file (~/.pgpass / $PGPASSFILE)
-# --------------------------------------------------------------------------- #
 def _pgpass_path() -> Path:
     """The file libpq reads: $PGPASSFILE if set, else the per-OS default."""
     env = os.environ.get(ENV_PGPASSFILE)
@@ -304,9 +295,6 @@ def _remove_pgpass_entry(username: str) -> bool:
     return True
 
 
-# --------------------------------------------------------------------------- #
-# One-time migration off the legacy plaintext keyring
-# --------------------------------------------------------------------------- #
 def _escape_keyring_option(username: str) -> str:
     """Reproduce keyrings.alt's option-key escaping for a username.
 
@@ -436,9 +424,6 @@ def _migrate_legacy_keyring(username: str) -> None:
     )
 
 
-# --------------------------------------------------------------------------- #
-# Username / password resolution
-# --------------------------------------------------------------------------- #
 def _resolve_username(env_user: str | None = None) -> str:
     if env_user:
         return env_user.strip()

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -11,9 +11,10 @@ connection string omits ``password=`` and libpq reads the file itself
 stderr on every run so it is always clear which one was used.
 
 On a headless node with no system keyring daemon, provision credentials by
-running ``jkp connect`` on a login node (it writes ``~/.pgpass``), by exporting
-``WRDS_USERNAME``/``WRDS_PASSWORD``, or by creating ``~/.pgpass`` directly — it
-is the standard Postgres/WRDS mechanism and any tool can populate it.
+running ``jkp connect`` on a login node (it stores both the username and the
+``~/.pgpass`` line) or by exporting ``WRDS_USERNAME``/``WRDS_PASSWORD``. A
+hand-created ``~/.pgpass`` supplies only the password, so it must be paired with
+``WRDS_USERNAME`` — resolution never reads the username out of the file.
 
 Migration (one-time, automatic, non-interactive): a legacy plaintext-keyring
 entry (``~/.local/share/python_keyring/keyring_pass.cfg``, written by the removed

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -360,21 +360,30 @@ def _drop_legacy_keyring_section(cp: configparser.RawConfigParser, path: Path) -
             path.unlink()
 
 
+def _load_legacy_cfg() -> configparser.RawConfigParser | None:
+    """Load the legacy plaintext-keyring file if it exists and has a ``[WRDS]``
+    section; return None otherwise (missing, unreadable, unparseable, or no
+    section). Never raises."""
+    path = _LEGACY_KEYRING_FILE
+    if not path.exists():
+        return None
+    cp = configparser.RawConfigParser()
+    try:
+        cp.read(path, encoding="utf-8")
+    except (configparser.Error, UnicodeDecodeError, OSError):
+        return None
+    return cp if cp.has_section(SERVICE_NAME) else None
+
+
 def _cleanup_legacy_keyring_section() -> None:
     """Best-effort removal of a lingering ``[WRDS]`` section from the legacy
     plaintext keyring — used when the password now comes from another source (env
-    or system keyring) so the obsolete plaintext copy does not linger on disk.
-    Never raises."""
-    path = _LEGACY_KEYRING_FILE
-    if not path.exists():
+    or system keyring) so the obsolete plaintext copy does not linger. Never raises."""
+    cp = _load_legacy_cfg()
+    if cp is None:
         return
-    try:
-        cp = configparser.RawConfigParser()
-        cp.read(path, encoding="utf-8")
-        if cp.has_section(SERVICE_NAME):
-            _drop_legacy_keyring_section(cp, path)
-    except (configparser.Error, UnicodeDecodeError, OSError):
-        pass
+    with contextlib.suppress(OSError):
+        _drop_legacy_keyring_section(cp, _LEGACY_KEYRING_FILE)
 
 
 def _migrate_legacy_keyring(username: str) -> None:
@@ -388,19 +397,12 @@ def _migrate_legacy_keyring(username: str) -> None:
     An existing ~/.pgpass entry for the user is their current credential and is
     never overwritten; in that case we only drop the superseded legacy section.
     """
+    cp = _load_legacy_cfg()
+    if cp is None:
+        # No file, no [WRDS] section, or unparseable/unreadable: nothing to
+        # migrate — let normal resolution (env / ~/.pgpass / prompt) proceed.
+        return
     path = _LEGACY_KEYRING_FILE
-    if not path.exists():
-        return
-    cp = configparser.RawConfigParser()
-    try:
-        cp.read(path, encoding="utf-8")
-    except (configparser.Error, UnicodeDecodeError):
-        # A corrupt or non-UTF8 legacy file is not migratable; skip it and let
-        # normal resolution (env / ~/.pgpass / prompt) proceed. (An OSError on
-        # read propagates to the best-effort wrapper in get_wrds_credentials.)
-        return
-    if not cp.has_section(SERVICE_NAME):
-        return
 
     # If ~/.pgpass already resolves for this user, that is their current
     # credential — never clobber it with the (possibly stale) legacy value.

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -478,13 +478,16 @@ def get_wrds_credentials() -> Credentials:
     env_user = os.environ.get(ENV_USERNAME)
     env_pw = os.environ.get(ENV_PASSWORD)
     if env_user and env_pw:
-        _log_source(f"the {ENV_USERNAME}/{ENV_PASSWORD} environment variables")
+        # Literal env-var names in the log message (not the ENV_* constants) so no
+        # "password"-named identifier flows into a logging sink — the value is
+        # never logged, only the source label.
+        _log_source("the WRDS_USERNAME/WRDS_PASSWORD environment variables")
         return Credentials(env_user.strip(), env_pw)
 
     username = _resolve_username(env_user)
 
     if env_pw:
-        _log_source(f"the {ENV_PASSWORD} environment variable")
+        _log_source("the WRDS_PASSWORD environment variable")
         return Credentials(username, env_pw)
 
     keyring_pw = _keyring_get(username)

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -389,10 +389,23 @@ def _escape_keyring_option(username: str) -> str:
     )
 
 
-def _drop_legacy_keyring_section(cp: configparser.RawConfigParser, path: Path) -> None:
-    """Remove only jkp's ``[WRDS]`` section, preserving any other tools' sections;
-    delete the file if ours was the last section."""
-    cp.remove_section(SERVICE_NAME)
+def _drop_legacy_keyring_option(
+    cp: configparser.RawConfigParser, path: Path, username: str
+) -> bool:
+    """Remove only ``username``'s entry from jkp's ``[WRDS]`` section, preserving
+    any other usernames' entries in it. Drop the ``[WRDS]`` section — and delete
+    the file if that leaves no other tools' sections — only once that was its last
+    entry. Returns True if an entry was actually removed.
+
+    (The whole ``[WRDS]`` section can hold one option per WRDS username, so removing
+    the section wholesale would destroy other users' never-migrated passwords.)
+    """
+    option = _escape_keyring_option(username)
+    if not cp.has_option(SERVICE_NAME, option):
+        return False
+    cp.remove_option(SERVICE_NAME, option)
+    if not cp.options(SERVICE_NAME):
+        cp.remove_section(SERVICE_NAME)
     if cp.sections():
         buf = io.StringIO()
         cp.write(buf)
@@ -400,6 +413,7 @@ def _drop_legacy_keyring_section(cp: configparser.RawConfigParser, path: Path) -
     else:
         with contextlib.suppress(OSError):
             path.unlink()
+    return True
 
 
 def _load_legacy_cfg() -> configparser.RawConfigParser | None:
@@ -417,27 +431,30 @@ def _load_legacy_cfg() -> configparser.RawConfigParser | None:
     return cp if cp.has_section(SERVICE_NAME) else None
 
 
-def _cleanup_legacy_keyring_section() -> None:
-    """Best-effort removal of a lingering ``[WRDS]`` section from the legacy
-    plaintext keyring — used when the password now comes from another source (env
-    or system keyring) so the obsolete plaintext copy does not linger. Never raises."""
+def _cleanup_legacy_keyring_section(username: str) -> None:
+    """Best-effort removal of ``username``'s lingering entry from the legacy
+    plaintext keyring's ``[WRDS]`` section — used when the password now comes from
+    another source (env or system keyring) so the obsolete plaintext copy does not
+    linger. Other usernames' entries are preserved. Never raises."""
     cp = _load_legacy_cfg()
     if cp is None:
         return
     with contextlib.suppress(OSError):
-        _drop_legacy_keyring_section(cp, _LEGACY_KEYRING_FILE)
+        _drop_legacy_keyring_option(cp, _LEGACY_KEYRING_FILE, username)
 
 
 def _migrate_legacy_keyring(username: str) -> None:
     """Move jkp's legacy plaintext-keyring entry to ~/.pgpass, non-interactively.
 
     ``keyring_pass.cfg`` is the shared keyrings.alt store; its values are plain
-    ``base64(password)`` (PlaintextKeyring does no encryption). We read only the
-    ``[WRDS]`` section, write the equivalent ~/.pgpass line, and delete only that
-    section — never the file, which may hold other tools' credentials.
+    ``base64(password)`` (PlaintextKeyring does no encryption). We read only this
+    user's option in the ``[WRDS]`` section, write the equivalent ~/.pgpass line,
+    and delete only that option — never other usernames' entries or the file
+    itself, which may hold other tools' credentials.
 
     An existing ~/.pgpass entry for the user is their current credential and is
-    never overwritten; in that case we only drop the superseded legacy section.
+    never overwritten; in that case we only drop this user's superseded legacy
+    entry.
     """
     cp = _load_legacy_cfg()
     if cp is None:
@@ -448,15 +465,16 @@ def _migrate_legacy_keyring(username: str) -> None:
 
     # If ~/.pgpass already resolves for this user, that is their current
     # credential — never clobber it with the (possibly stale) legacy value.
-    # Just drop the now-superseded legacy [WRDS] section.
+    # Just drop this user's now-superseded legacy entry (only announce it if there
+    # actually was one — another user's entry may be all that remains).
     if _pgpass_has_entry(username, check_perms=False):
-        _drop_legacy_keyring_section(cp, path)
-        print(
-            "Removed a superseded WRDS entry from the legacy plaintext keyring; "
-            "kept your existing ~/.pgpass entry.",
-            file=sys.stderr,
-            flush=True,
-        )
+        if _drop_legacy_keyring_option(cp, path, username):
+            print(
+                "Removed a superseded WRDS entry from the legacy plaintext keyring; "
+                "kept your existing ~/.pgpass entry.",
+                file=sys.stderr,
+                flush=True,
+            )
         return
 
     # Only migrate jkp's own exact-key entry. Since jkp always stored the entry
@@ -480,9 +498,9 @@ def _migrate_legacy_keyring(username: str) -> None:
     except ValueError as exc:
         # The legacy password can't be stored in ~/.pgpass (e.g. it contains a
         # newline) — it's unusable, and libpq could never authenticate with it.
-        # Drop the dead section so we don't decode-and-fail on every future run,
-        # and let resolution surface a clean "no credentials" path instead.
-        _drop_legacy_keyring_section(cp, path)
+        # Drop this user's dead entry so we don't decode-and-fail on every future
+        # run, and let resolution surface a clean "no credentials" path instead.
+        _drop_legacy_keyring_option(cp, path, username)
         print(
             f"Discarded an unusable legacy WRDS credential ({exc}); "
             "run `jkp connect` to re-provision.",
@@ -490,7 +508,7 @@ def _migrate_legacy_keyring(username: str) -> None:
             flush=True,
         )
         return
-    _drop_legacy_keyring_section(cp, path)
+    _drop_legacy_keyring_option(cp, path, username)
     print(
         f"Migrated WRDS credential from the legacy plaintext keyring to {pgpass}.",
         file=sys.stderr,
@@ -593,7 +611,7 @@ def get_wrds_credentials() -> Credentials:
     keyring_pw = _keyring_get(username)
     if keyring_pw:
         # The keyring supersedes any legacy plaintext copy; clean it up.
-        _cleanup_legacy_keyring_section()
+        _cleanup_legacy_keyring_section(username)
         _log_source("the system keyring")
         return Credentials(username, keyring_pw)
 
@@ -661,7 +679,7 @@ def reset_credentials(full_reset: bool = False) -> None:
         # just-revoked password back into ~/.pgpass). Cleanup never raises, so
         # doing it first means a failure removing an unreadable ~/.pgpass can't
         # skip it and leave a plaintext copy behind on a security-motivated reset.
-        _cleanup_legacy_keyring_section()
+        _cleanup_legacy_keyring_section(username)
         if removed_keyring:
             print(f"Deleted password for '{username}' from the system keyring")
         removed_pgpass = _remove_pgpass_entry(username)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -50,6 +50,21 @@ class TestCliHelp:
         assert result.exit_code == 0
         assert "--reset" in _strip_ansi(result.output)
 
+    def test_connect_surfaces_actionable_error_cleanly(self):
+        """An actionable RuntimeError (e.g. an unreadable ~/.pgpass) must exit 1
+        with the message shown, not propagate as a traceback."""
+
+        def _boom(*a, **kw):
+            raise RuntimeError("Cannot read ~/.pgpass; fix its permissions and retry.")
+
+        with patch("jkp.data.wrds_credentials.reset_credentials", _boom):
+            result = runner.invoke(app, ["connect", "--reset"])
+
+        assert result.exit_code == 1
+        # handled as a clean exit, not a leaked RuntimeError traceback
+        assert not isinstance(result.exception, RuntimeError)
+        assert "Cannot read" in _strip_ansi(result.output)
+
 
 @pytest.mark.unit
 class TestVersionFlag:

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -117,6 +117,38 @@ def test_password_from_keyring(monkeypatch, _isolate_credential_state):
 
 
 @pytest.mark.unit
+def test_locked_keyring_warns_and_falls_through(monkeypatch, _isolate_credential_state, capsys):
+    """A present-but-locked keyring (KeyringError, not NoKeyringError) must warn
+    and fall through to ~/.pgpass rather than crash resolution."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.KeyringLocked))
+    _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:secret\n")
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None  # served from ~/.pgpass
+    assert "keyring is present but unusable" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_prompt_stores_to_pgpass_when_keyring_locked(monkeypatch, _isolate_credential_state):
+    """The *store* side of a locked keyring: if set_password raises a KeyringError
+    (not NoKeyringError), _prompt_and_store must fall through to ~/.pgpass rather
+    than crash — the write-side mirror of the locked-keyring read fallback."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr(mod.keyring, "set_password", _raises(mod.keyring.errors.KeyringLocked))
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
+
+    creds = mod._prompt_and_store("testuser")
+
+    assert creds.username == "testuser"
+    assert creds.password is None  # written to ~/.pgpass, not returned
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:" in mod._pgpass_path().read_text()
+
+
+@pytest.mark.unit
 def test_password_from_pgpass_returns_none_password(monkeypatch, _isolate_credential_state):
     """A matching ~/.pgpass entry → Credentials.password is None (libpq reads it)."""
     mod = _isolate_credential_state

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -978,6 +978,24 @@ def test_atomic_write_warns_when_replacing_symlink(_isolate_credential_state, ca
     assert "symlink" in capsys.readouterr().err
 
 
+@pytest.mark.unit
+def test_load_legacy_cfg(_isolate_credential_state):
+    """_load_legacy_cfg returns a parser only when the file exists and has a
+    [WRDS] section; None for missing / no-section / unparseable, never raising."""
+    mod = _isolate_credential_state
+    assert mod._load_legacy_cfg() is None  # missing file
+
+    mod._LEGACY_KEYRING_FILE.write_text("[other]\nx = y\n")
+    assert mod._load_legacy_cfg() is None  # no [WRDS] section
+
+    _write_real_keyring(mod, {"testuser": "pw"})
+    cp = mod._load_legacy_cfg()
+    assert cp is not None and cp.has_section("WRDS")
+
+    mod._LEGACY_KEYRING_FILE.write_bytes(b"[WRDS]\nx = \xff\xfe\n")
+    assert mod._load_legacy_cfg() is None  # non-UTF8 -> None, not a raise
+
+
 def _write_real_keyring(mod, entries):
     """Write a keyring_pass.cfg the way keyrings.alt does — values on tab-indented
     continuation lines with a leading newline, via configparser — so the parsing

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -41,9 +41,6 @@ def _isolate_credential_state(monkeypatch, tmp_path):
     return mod
 
 
-# --------------------------------------------------------------------------- #
-# Environment variables
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_env_vars_take_precedence(monkeypatch, _isolate_credential_state):
     """Both env vars set → use them without touching the keyring."""
@@ -74,9 +71,6 @@ def test_env_username_alone_used_with_keyring_password(monkeypatch, _isolate_cre
     assert creds.password == "kr-pw"
 
 
-# --------------------------------------------------------------------------- #
-# Username resolution
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_username_from_state_file(monkeypatch, _isolate_credential_state):
     mod = _isolate_credential_state
@@ -102,9 +96,6 @@ def test_legacy_username_file_migrates_to_state_dir(monkeypatch, _isolate_creden
     assert not mod._LEGACY_USER_FILE.exists(), "legacy username file should be removed"
 
 
-# --------------------------------------------------------------------------- #
-# Password sources
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_password_from_keyring(monkeypatch, _isolate_credential_state):
     mod = _isolate_credential_state
@@ -196,9 +187,6 @@ def test_no_credentials_non_interactive_raises_guidance(monkeypatch, _isolate_cr
     assert ".pgpass" in msg
 
 
-# --------------------------------------------------------------------------- #
-# .pgpass writing (append/replace, never clobber other entries)
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_write_pgpass_preserves_other_entries(_isolate_credential_state):
     mod = _isolate_credential_state
@@ -248,9 +236,6 @@ def test_pgpass_escapes_special_characters(_isolate_credential_state):
     assert mod._pgpass_has_entry("testuser") is True
 
 
-# --------------------------------------------------------------------------- #
-# Legacy plaintext-keyring migration
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_legacy_keyring_migrates_to_pgpass_and_removes_only_our_section(
     monkeypatch, _isolate_credential_state
@@ -299,9 +284,6 @@ def test_legacy_keyring_file_removed_when_only_our_section(monkeypatch, _isolate
     assert not mod._LEGACY_KEYRING_FILE.exists(), "empty keyring file should be removed"
 
 
-# --------------------------------------------------------------------------- #
-# reset_credentials
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_reset_removes_username_keyring_and_pgpass(monkeypatch, _isolate_credential_state, capsys):
     mod = _isolate_credential_state
@@ -378,9 +360,6 @@ def test_reset_warns_when_keyring_unreachable(monkeypatch, _isolate_credential_s
     assert "No stored password found" not in captured.out + captured.err
 
 
-# --------------------------------------------------------------------------- #
-# Migration — real on-disk format, escaped keys, fallback, I/O isolation
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_migration_handles_real_keyring_on_disk_format(monkeypatch, _isolate_credential_state):
     """keyrings.alt writes the value on a tab-indented continuation line with a
@@ -529,9 +508,6 @@ def test_escape_keyring_option_format(_isolate_credential_state, username, expec
     assert _isolate_credential_state._escape_keyring_option(username) == expected
 
 
-# --------------------------------------------------------------------------- #
-# .pgpass wildcard matching + preservation of foreign lines/comments/blanks
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "line",
@@ -590,9 +566,6 @@ def test_pgpass_escapes_special_username(_isolate_credential_state):
     assert mod._pgpass_has_entry("we:ird\\name") is True
 
 
-# --------------------------------------------------------------------------- #
-# Interactive prompt-and-store (keyring vs .pgpass fallback)
-# --------------------------------------------------------------------------- #
 @pytest.mark.unit
 def test_prompt_and_store_uses_keyring_when_available(monkeypatch, _isolate_credential_state):
     mod = _isolate_credential_state
@@ -752,9 +725,6 @@ def test_migration_defers_to_wildcard_pgpass_entry(monkeypatch, _isolate_credent
     assert not cp.has_section("WRDS")
 
 
-# --------------------------------------------------------------------------- #
-# helpers
-# --------------------------------------------------------------------------- #
 def _write_real_keyring(mod, entries):
     """Write a keyring_pass.cfg the way keyrings.alt does — values on tab-indented
     continuation lines with a leading newline, via configparser — so the parsing

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -1,52 +1,55 @@
 """Tests for WRDS credential resolution.
 
 See ``jkp connect --help`` for the canonical credential precedence order;
-these tests exercise it.
+these tests exercise it: WRDS_USERNAME/WRDS_PASSWORD env, then the system
+keyring, then a libpq password file (``$PGPASSFILE`` / ``~/.pgpass``), plus the
+one-time migration off the legacy plaintext keyring.
 """
 
 from __future__ import annotations
 
-import importlib
+import base64
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _clear_keyring_backend_cache():
-    """The backend swap is cached per-process, so reset it around every test to
-    keep cases independent (otherwise the first opt-in leaks into later tests)."""
+def _isolate_credential_state(monkeypatch, tmp_path):
+    """Point every credential path at a temp dir and clear the WRDS env vars, so
+    no test can read or write the developer's real keyring / ~/.pgpass / state."""
     import jkp.data.wrds_credentials as mod
 
-    mod._ensure_keyring_backend.cache_clear()
-    yield
-    mod._ensure_keyring_backend.cache_clear()
+    monkeypatch.delenv("WRDS_USERNAME", raising=False)
+    monkeypatch.delenv("WRDS_PASSWORD", raising=False)
+
+    pgpass = tmp_path / "pgpass"
+    monkeypatch.setenv("PGPASSFILE", str(pgpass))
+    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / "state" / "wrds_user")
+    monkeypatch.setattr(mod, "_LEGACY_USER_FILE", tmp_path / ".wrds_user")
+    monkeypatch.setattr(mod, "_LEGACY_KEYRING_FILE", tmp_path / "keyring_pass.cfg")
+
+    # Default: no keyring backend and non-interactive, unless a test overrides.
+    # Stubbing the keyring here (not just per-test) is what actually keeps tests
+    # off the developer's real keyring, as this fixture's docstring promises.
+    def _no_keyring(*_a, **_kw):
+        raise mod.keyring.errors.NoKeyringError("no keyring backend in tests")
+
+    monkeypatch.setattr(mod.keyring, "get_password", _no_keyring)
+    monkeypatch.setattr(mod.keyring, "set_password", _no_keyring)
+    monkeypatch.setattr(mod.keyring, "delete_password", _no_keyring)
+    monkeypatch.setattr(mod, "_interactive", lambda: False)
+    return mod
 
 
+# --------------------------------------------------------------------------- #
+# Environment variables
+# --------------------------------------------------------------------------- #
 @pytest.mark.unit
-def test_import_does_not_mutate_environ():
-    """Importing the module must not change PYTHON_KEYRING_BACKEND or any other
-    environment variable. The previous implementation mutated the environment at
-    import time, silently switching the user's keyring backend to plaintext."""
-    import os
-
-    before = dict(os.environ)
-    import jkp.data.wrds_credentials as mod  # noqa: F401
-
-    # Force a re-import to also exercise the import path.
-    importlib.reload(mod)
-    after = dict(os.environ)
-    assert before == after, "import must not mutate os.environ"
-
-
-@pytest.mark.unit
-def test_env_vars_take_precedence(monkeypatch):
-    """When WRDS_USERNAME and WRDS_PASSWORD are set, return those without
-    touching the keyring."""
+def test_env_vars_take_precedence(monkeypatch, _isolate_credential_state):
+    """Both env vars set → use them without touching the keyring."""
+    mod = _isolate_credential_state
     monkeypatch.setenv("WRDS_USERNAME", "ci-user")
     monkeypatch.setenv("WRDS_PASSWORD", "ci-secret")
-
-    # If keyring is touched, fail loudly.
-    import jkp.data.wrds_credentials as mod
 
     def _boom(*a, **kw):
         raise AssertionError("keyring must not be queried when env vars are set")
@@ -59,187 +62,652 @@ def test_env_vars_take_precedence(monkeypatch):
 
 
 @pytest.mark.unit
-def test_env_partial_falls_through_to_keyring(monkeypatch, tmp_path):
-    """If only one of the env vars is set, fall through to keyring resolution."""
-    monkeypatch.setenv("WRDS_USERNAME", "ci-user")
-    monkeypatch.delenv("WRDS_PASSWORD", raising=False)
+def test_env_username_alone_used_with_keyring_password(monkeypatch, _isolate_credential_state):
+    """WRDS_USERNAME alone is now honored as the username source (decoupled from
+    the password), with the password coming from the keyring."""
+    mod = _isolate_credential_state
+    monkeypatch.setenv("WRDS_USERNAME", "env-user")
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kr-pw")
 
-    import jkp.data.wrds_credentials as mod
-
-    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
-    (tmp_path / ".wrds_user").write_text("kept-user")
-
-    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kept-pw")
     creds = mod.get_wrds_credentials()
-    assert creds.username == "kept-user", "env-var partial set must not be used"
-    assert creds.password == "kept-pw"
+    assert creds.username == "env-user"
+    assert creds.password == "kr-pw"
+
+
+# --------------------------------------------------------------------------- #
+# Username resolution
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_username_from_state_file(monkeypatch, _isolate_credential_state):
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("saved-user")
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "pw")
+
+    creds = mod.get_wrds_credentials()
+    assert creds.username == "saved-user"
 
 
 @pytest.mark.unit
-def test_plaintext_opt_in_swaps_backend_and_warns(monkeypatch):
-    """Setting JKP_ALLOW_PLAINTEXT_KEYRING=1 should swap the keyring backend to
-    PlaintextKeyring and emit a warning when credential resolution runs."""
-    monkeypatch.setenv("JKP_ALLOW_PLAINTEXT_KEYRING", "1")
+def test_legacy_username_file_migrates_to_state_dir(monkeypatch, _isolate_credential_state):
+    """A legacy ~/.wrds_user is moved into the new per-OS state file."""
+    mod = _isolate_credential_state
+    mod._LEGACY_USER_FILE.write_text("legacy-user")
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "pw")
 
-    from keyrings.alt.file import PlaintextKeyring
+    creds = mod.get_wrds_credentials()
 
-    import jkp.data.wrds_credentials as mod
+    assert creds.username == "legacy-user"
+    assert mod.LAST_USER_FILE.read_text().strip() == "legacy-user"
+    assert not mod._LEGACY_USER_FILE.exists(), "legacy username file should be removed"
 
-    # Capture the backend swap instead of mutating the process-global keyring.
-    captured = []
-    monkeypatch.setattr(mod.keyring, "set_keyring", captured.append)
 
-    with pytest.warns(UserWarning, match="keyrings.alt.file.PlaintextKeyring"):
-        mod._ensure_keyring_backend()
+# --------------------------------------------------------------------------- #
+# Password sources
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_password_from_keyring(monkeypatch, _isolate_credential_state):
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("u")
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kr-secret")
 
-    assert len(captured) == 1, "the backend should be swapped exactly once"
-    assert isinstance(captured[0], PlaintextKeyring)
+    creds = mod.get_wrds_credentials()
+    assert creds.password == "kr-secret"
 
 
 @pytest.mark.unit
-def test_plaintext_no_optin_no_warning(monkeypatch, recwarn):
-    """Without the opt-in env var, no warning is emitted and the keyring backend
-    is not mutated."""
-    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+def test_password_from_pgpass_returns_none_password(monkeypatch, _isolate_credential_state):
+    """A matching ~/.pgpass entry → Credentials.password is None (libpq reads it)."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    # no keyring backend
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+    _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:secret\n")
 
-    import jkp.data.wrds_credentials as mod
-
-    set_keyring_calls = []
-    monkeypatch.setattr(mod.keyring, "set_keyring", lambda kr: set_keyring_calls.append(kr))
-    mod._ensure_keyring_backend()
-    assert not set_keyring_calls, "keyring backend should not be swapped without opt-in"
-    assert len(recwarn.list) == 0, "no warning should fire without opt-in"
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("value", ["true", "True", "yes", "on", "0", "2", ""])
-def test_plaintext_opt_in_requires_exact_1(monkeypatch, recwarn, value):
-    """Only the exact string "1" opts in. Anything else — including
-    truthy-looking values like "true"/"yes" and falsy ones like "0" — is treated
-    as not set: no backend swap, no warning. Guards the strict comparison against
-    being loosened into a fuzzy truthiness check later."""
-    monkeypatch.setenv("JKP_ALLOW_PLAINTEXT_KEYRING", value)
-
-    import jkp.data.wrds_credentials as mod
-
-    set_keyring_calls = []
-    monkeypatch.setattr(mod.keyring, "set_keyring", lambda kr: set_keyring_calls.append(kr))
-    mod._ensure_keyring_backend()
-    assert not set_keyring_calls, f"value {value!r} must not swap the keyring backend"
-    assert len(recwarn.list) == 0, f"value {value!r} must not emit a warning"
+    creds = mod.get_wrds_credentials()
+    assert creds.username == "testuser"
+    assert creds.password is None
 
 
 @pytest.mark.unit
-def test_backend_swap_is_cached(monkeypatch, recwarn):
-    """The opt-in swap happens at most once per process: repeated keyring access
-    must not re-run the swap or re-emit the warning."""
-    monkeypatch.setenv("JKP_ALLOW_PLAINTEXT_KEYRING", "1")
+def test_pgpass_ignored_when_permissions_too_open(monkeypatch, _isolate_credential_state):
+    """libpq ignores a group/world-readable .pgpass; so must our detection."""
+    import sys
 
-    import jkp.data.wrds_credentials as mod
+    if sys.platform.startswith("win"):
+        pytest.skip("permission check is Unix-only")
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+    path = _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:secret\n")
+    path.chmod(0o644)  # too open
 
-    captured = []
-    monkeypatch.setattr(mod.keyring, "set_keyring", captured.append)
-
-    mod._ensure_keyring_backend()
-    mod._ensure_keyring_backend()
-    with mod._keyring_backend():
-        pass
-
-    assert len(captured) == 1, "backend swap should happen once despite repeated calls"
-    warnings_emitted = [w for w in recwarn.list if issubclass(w.category, UserWarning)]
-    assert len(warnings_emitted) == 1, "the swap warning should fire once, not per call"
-
-
-@pytest.mark.unit
-def test_get_wrds_credentials_missing_backend_raises_guidance(monkeypatch, tmp_path):
-    """On a headless system with no keyring backend and no opt-in, the generic
-    NoKeyringError is re-raised with guidance pointing at the env-var and
-    plaintext-opt-in escape hatches."""
-    monkeypatch.delenv("WRDS_USERNAME", raising=False)
-    monkeypatch.delenv("WRDS_PASSWORD", raising=False)
-    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
-
-    import jkp.data.wrds_credentials as mod
-
-    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
-    (tmp_path / ".wrds_user").write_text("someuser")
-
-    def _no_backend(*a, **kw):
-        raise mod.keyring.errors.NoKeyringError("No recommended backend was available")
-
-    monkeypatch.setattr(mod.keyring, "get_password", _no_backend)
-
-    with pytest.raises(mod.keyring.errors.NoKeyringError) as excinfo:
+    assert mod._pgpass_has_entry("testuser") is False
+    with pytest.raises(RuntimeError, match="No WRDS password found"):
         mod.get_wrds_credentials()
 
+
+@pytest.mark.unit
+def test_no_credentials_non_interactive_raises_guidance(monkeypatch, _isolate_credential_state):
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("u")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        mod.get_wrds_credentials()
     msg = str(excinfo.value)
     assert "WRDS_USERNAME" in msg
-    assert "WRDS_PASSWORD" in msg
-    assert "JKP_ALLOW_PLAINTEXT_KEYRING" in msg
+    assert ".pgpass" in msg
+
+
+# --------------------------------------------------------------------------- #
+# .pgpass writing (append/replace, never clobber other entries)
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_write_pgpass_preserves_other_entries(_isolate_credential_state):
+    mod = _isolate_credential_state
+    _write_pgpass(mod, "otherhost:5432:otherdb:someone:otherpw\n")
+
+    mod._write_pgpass("testuser", "s3cret")
+
+    contents = mod._pgpass_path().read_text()
+    assert "otherhost:5432:otherdb:someone:otherpw" in contents
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:s3cret" in contents
 
 
 @pytest.mark.unit
-def test_reset_credentials_missing_backend_raises_guidance(monkeypatch, tmp_path):
-    """`jkp connect --reset` on a headless system must surface the same guidance
-    rather than the bare NoKeyringError from keyring.delete_password."""
-    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+def test_write_pgpass_replaces_our_line_in_place(_isolate_credential_state):
+    mod = _isolate_credential_state
+    mod._write_pgpass("testuser", "old")
+    mod._write_pgpass("testuser", "new")
 
-    import jkp.data.wrds_credentials as mod
-
-    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
-    (tmp_path / ".wrds_user").write_text("someuser")
-
-    def _no_backend(*a, **kw):
-        raise mod.keyring.errors.NoKeyringError("No recommended backend was available")
-
-    monkeypatch.setattr(mod.keyring, "delete_password", _no_backend)
-
-    with pytest.raises(mod.keyring.errors.NoKeyringError) as excinfo:
-        mod.reset_credentials(full_reset=True)
-
-    msg = str(excinfo.value)
-    assert "JKP_ALLOW_PLAINTEXT_KEYRING" in msg
+    lines = [
+        ln
+        for ln in mod._pgpass_path().read_text().splitlines()
+        if "wrds-pgdata" in ln and ":testuser:" in ln
+    ]
+    assert lines == ["wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:new"]
 
 
 @pytest.mark.unit
-def test_reset_credentials_deletes_existing_entry(monkeypatch, tmp_path, capsys):
-    """A successful delete reports the deletion and removes the username file."""
-    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+def test_write_pgpass_is_mode_600(_isolate_credential_state):
+    import sys
 
-    import jkp.data.wrds_credentials as mod
+    if sys.platform.startswith("win"):
+        pytest.skip("permission check is Unix-only")
+    mod = _isolate_credential_state
+    path = mod._write_pgpass("testuser", "s3cret")
+    assert (path.stat().st_mode & 0o777) == 0o600
 
-    user_file = tmp_path / ".wrds_user"
-    monkeypatch.setattr(mod, "LAST_USER_FILE", user_file)
-    user_file.write_text("someuser")
+
+@pytest.mark.unit
+def test_pgpass_escapes_special_characters(_isolate_credential_state):
+    """A password containing ':' round-trips: it is escaped on write and libpq's
+    matcher still finds the entry (the has-entry check unescapes)."""
+    mod = _isolate_credential_state
+    mod._write_pgpass("testuser", "pa:ss\\word")
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:pa\\:ss\\\\word" in (
+        mod._pgpass_path().read_text()
+    )
+    assert mod._pgpass_has_entry("testuser") is True
+
+
+# --------------------------------------------------------------------------- #
+# Legacy plaintext-keyring migration
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_legacy_keyring_migrates_to_pgpass_and_removes_only_our_section(
+    monkeypatch, _isolate_credential_state
+):
+    """The migration seeds ~/.pgpass from the plaintext keyring's [WRDS] entry
+    (plain base64, no keyrings-alt) and deletes ONLY that section — a second
+    tool's section must survive."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+
+    b64 = base64.encodebytes(b"legacy-secret").decode()
+    other = base64.encodebytes(b"other-tool").decode()
+    mod._LEGACY_KEYRING_FILE.write_text(
+        f"[WRDS]\ntestuser = {b64}\n[some-other-service]\nbob = {other}\n"
+    )
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.username == "testuser"
+    assert creds.password is None  # now served from ~/.pgpass
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:legacy-secret" in (
+        mod._pgpass_path().read_text()
+    )
+
+    import configparser
+
+    cp = configparser.RawConfigParser()
+    cp.read(mod._LEGACY_KEYRING_FILE, encoding="utf-8")
+    assert not cp.has_section("WRDS"), "our section must be removed"
+    assert cp.has_section("some-other-service"), "other tools' section must survive"
+
+
+@pytest.mark.unit
+def test_legacy_keyring_file_removed_when_only_our_section(monkeypatch, _isolate_credential_state):
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    b64 = base64.encodebytes(b"legacy-secret").decode()
+    mod._LEGACY_KEYRING_FILE.write_text(f"[WRDS]\ntestuser = {b64}\n")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    mod.get_wrds_credentials()
+
+    assert not mod._LEGACY_KEYRING_FILE.exists(), "empty keyring file should be removed"
+
+
+# --------------------------------------------------------------------------- #
+# reset_credentials
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_reset_removes_username_keyring_and_pgpass(monkeypatch, _isolate_credential_state, capsys):
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    mod._write_pgpass("testuser", "s3cret")
+    _write_pgpass_append(mod, "otherhost:5432:db:bob:pw\n")
 
     deleted = []
     monkeypatch.setattr(mod.keyring, "delete_password", lambda *a, **kw: deleted.append(a))
 
     mod.reset_credentials(full_reset=True)
 
-    assert deleted, "delete_password should have been called"
     out = capsys.readouterr().out
-    assert "Deleted password for 'someuser'" in out
-    assert not user_file.exists(), "username file should be removed"
+    assert "Removed stored username 'testuser'" in out
+    assert not mod.LAST_USER_FILE.exists()
+    assert deleted, "keyring delete should have been attempted"
+    # our pgpass line gone, the other tool's line preserved
+    contents = mod._pgpass_path().read_text()
+    assert ":testuser:" not in contents
+    assert "otherhost:5432:db:bob:pw" in contents
 
 
 @pytest.mark.unit
-def test_reset_credentials_missing_entry_is_handled(monkeypatch, tmp_path, capsys):
-    """A genuine 'no entry to delete' (PasswordDeleteError) is still handled
-    gracefully and must not be swallowed by the NoKeyringError translation."""
-    monkeypatch.delenv("JKP_ALLOW_PLAINTEXT_KEYRING", raising=False)
+def test_reset_no_username_is_handled(_isolate_credential_state, capsys):
+    mod = _isolate_credential_state
+    mod.reset_credentials(full_reset=True)  # must not raise
+    assert "nothing to reset" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Migration — real on-disk format, escaped keys, fallback, I/O isolation
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_migration_handles_real_keyring_on_disk_format(monkeypatch, _isolate_credential_state):
+    """keyrings.alt writes the value on a tab-indented continuation line with a
+    leading newline; the migration must decode that real format, not just a
+    single-line convenience form."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    _write_real_keyring(mod, {"testuser": "real-secret"})
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:real-secret" in (
+        mod._pgpass_path().read_text()
+    )
+
+
+@pytest.mark.unit
+def test_migration_matches_escaped_username_key(monkeypatch, _isolate_credential_state):
+    """A username with a dot is stored by keyrings.alt under an escaped key
+    (``test.user`` -> ``test_2euser``). With two stored users the single-entry
+    fallback can't rescue a bad match, so the escaped-key lookup must work."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("test.user")
+    # Keys hard-coded (not via the module's own escaper) so the test is an
+    # independent check of the escaping, not a tautology.
+    _write_real_keyring(mod, {"test_2euser": "dotted-secret", "otheruser": "other-pw"})
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:test.user:dotted-secret" in (
+        mod._pgpass_path().read_text()
+    )
+
+
+@pytest.mark.unit
+def test_migration_single_entry_fallback(monkeypatch, _isolate_credential_state):
+    """When the resolved username doesn't match the stored key but exactly one
+    WRDS entry exists, migrate it under the resolved username."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("resolved-user")
+    _write_real_keyring(mod, {"testuser": "the-secret"})  # key != resolved username
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:resolved-user:the-secret" in (
+        mod._pgpass_path().read_text()
+    )
+
+
+@pytest.mark.unit
+def test_migration_io_failure_does_not_abort_resolution(
+    monkeypatch, _isolate_credential_state, capsys
+):
+    """A migration I/O error must warn and fall through, not abort resolution
+    when a usable ~/.pgpass fallback exists."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:fallback\n")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    def _boom(_username):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mod, "_migrate_legacy_keyring", _boom)
+
+    creds = mod.get_wrds_credentials()  # must not raise
+
+    assert creds.password is None  # served from the fallback pgpass
+    assert "could not migrate" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_migration_corrupt_non_utf8_keyring_falls_through(monkeypatch, _isolate_credential_state):
+    """A non-UTF8/corrupt legacy keyring_pass.cfg must be skipped (not abort
+    resolution) so a usable ~/.pgpass fallback still serves credentials."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    mod._LEGACY_KEYRING_FILE.write_bytes(b"[WRDS]\ntestuser = \xff\xfe not utf8\n")
+    _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:fallback\n")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    creds = mod.get_wrds_credentials()  # must not raise
+
+    assert creds.password is None
+    assert "testuser:fallback" in mod._pgpass_path().read_text()
+
+
+@pytest.mark.unit
+def test_migration_preserves_existing_pgpass_entry(monkeypatch, _isolate_credential_state):
+    """If ~/.pgpass already has a WRDS entry (the user's current credential), the
+    migration must NOT overwrite it with the stale legacy-keyring value — it only
+    drops the superseded legacy [WRDS] section."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:CURRENT_PW\n")
+    _write_real_keyring(mod, {"testuser": "STALE_PW"})
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None
+    contents = mod._pgpass_path().read_text()
+    assert "testuser:CURRENT_PW" in contents, "current pgpass password must be preserved"
+    assert "STALE_PW" not in contents, "stale legacy password must not overwrite it"
+
+    import configparser
+
+    cp = configparser.RawConfigParser()
+    cp.read(mod._LEGACY_KEYRING_FILE)
+    assert not cp.has_section("WRDS"), "superseded legacy section should still be cleaned up"
+
+
+@pytest.mark.unit
+def test_write_pgpass_rejects_newline_password(_isolate_credential_state):
+    """A newline in the password would inject a spurious .pgpass line; reject it."""
+    mod = _isolate_credential_state
+    with pytest.raises(ValueError, match="newline"):
+        mod._write_pgpass("testuser", "line1\nwildcard:injected")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("username", "expected"),
+    [
+        ("testuser", "testuser"),
+        ("test.user", "test_2euser"),
+        ("a-b", "a_2db"),
+        ("a\tb", "a_09b"),  # control byte -> zero-padded hex
+        ("josé", "jos_c3_a9"),  # non-ASCII -> UTF-8 bytes
+    ],
+)
+def test_escape_keyring_option_format(_isolate_credential_state, username, expected):
+    """Exact reproduction of keyrings.alt's option-key escaping (_%02x per byte)."""
+    assert _isolate_credential_state._escape_keyring_option(username) == expected
+
+
+# --------------------------------------------------------------------------- #
+# .pgpass wildcard matching + preservation of foreign lines/comments/blanks
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "line",
+    [
+        "*:*:*:testuser:secret",
+        "wrds-pgdata.wharton.upenn.edu:9737:wrds:*:secret",
+        "*:*:*:*:secret",
+    ],
+)
+def test_pgpass_wildcard_entry_matches(_isolate_credential_state, line):
+    mod = _isolate_credential_state
+    _write_pgpass(mod, line + "\n")
+    assert mod._pgpass_has_entry("testuser") is True
+
+
+@pytest.mark.unit
+def test_write_pgpass_preserves_comments_blanks_and_wildcards(_isolate_credential_state):
+    mod = _isolate_credential_state
+    _write_pgpass(
+        mod,
+        "# my pgpass\n\notherhost:5432:db:bob:pw\n*:*:*:wild:wpw\n",
+    )
+
+    mod._write_pgpass("testuser", "s3cret")
+
+    lines = mod._pgpass_path().read_text().splitlines()
+    assert "# my pgpass" in lines
+    assert "" in lines, "blank line should be preserved"
+    assert "otherhost:5432:db:bob:pw" in lines
+    assert "*:*:*:wild:wpw" in lines
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:s3cret" in lines
+
+
+@pytest.mark.unit
+def test_remove_pgpass_entry_preserves_comments_and_others(_isolate_credential_state):
+    mod = _isolate_credential_state
+    _write_pgpass(mod, "# keep me\notherhost:5432:db:bob:pw\n")
+    mod._write_pgpass("testuser", "s3cret")
+
+    assert mod._remove_pgpass_entry("testuser") is True
+
+    contents = mod._pgpass_path().read_text()
+    assert "# keep me" in contents
+    assert "otherhost:5432:db:bob:pw" in contents
+    assert ":testuser:" not in contents
+
+
+@pytest.mark.unit
+def test_pgpass_escapes_special_username(_isolate_credential_state):
+    """A username containing ':' / '\\' is escaped on write and still matched."""
+    mod = _isolate_credential_state
+    mod._write_pgpass("we:ird\\name", "pw")
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:we\\:ird\\\\name:pw" in (
+        mod._pgpass_path().read_text()
+    )
+    assert mod._pgpass_has_entry("we:ird\\name") is True
+
+
+# --------------------------------------------------------------------------- #
+# Interactive prompt-and-store (keyring vs .pgpass fallback)
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_prompt_and_store_uses_keyring_when_available(monkeypatch, _isolate_credential_state):
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("u")
+    monkeypatch.setattr(mod, "_interactive", lambda: True)
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: None)
+    stored = {}
+    monkeypatch.setattr(mod.keyring, "set_password", lambda s, u, p: stored.update({u: p}))
+    monkeypatch.setattr(mod.getpass, "getpass", lambda *a, **kw: "typed-pw")
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password == "typed-pw"
+    assert stored == {"u": "typed-pw"}
+    assert not mod._pgpass_path().exists(), "keyring path must not write ~/.pgpass"
+
+
+@pytest.mark.unit
+def test_prompt_and_store_falls_back_to_pgpass_without_keyring(
+    monkeypatch, _isolate_credential_state
+):
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("u")
+    monkeypatch.setattr(mod, "_interactive", lambda: True)
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+    monkeypatch.setattr(mod.keyring, "set_password", _raises(mod.keyring.errors.NoKeyringError))
+    monkeypatch.setattr(mod.getpass, "getpass", lambda *a, **kw: "typed-pw")
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None  # libpq reads it from ~/.pgpass
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:u:typed-pw" in (mod._pgpass_path().read_text())
+
+
+@pytest.mark.unit
+def test_empty_env_vars_treated_as_unset(monkeypatch, _isolate_credential_state):
+    """Empty-string WRDS_USERNAME/WRDS_PASSWORD must be treated as unset, not as
+    a blank username/password."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("fileuser")
+    monkeypatch.setenv("WRDS_USERNAME", "")
+    monkeypatch.setenv("WRDS_PASSWORD", "")
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kr-pw")
+
+    creds = mod.get_wrds_credentials()
+    assert creds.username == "fileuser"
+    assert creds.password == "kr-pw"
+
+
+@pytest.mark.unit
+def test_password_from_env_with_username_from_file(monkeypatch, _isolate_credential_state):
+    """WRDS_PASSWORD alone (username from the state file) is honored without
+    touching the keyring."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("fileuser")
+    monkeypatch.setenv("WRDS_PASSWORD", "envpw")
+
+    def _boom(*a, **kw):
+        raise AssertionError("keyring must not be queried when WRDS_PASSWORD is set")
+
+    monkeypatch.setattr(mod.keyring, "get_password", _boom)
+
+    creds = mod.get_wrds_credentials()
+    assert creds.username == "fileuser"
+    assert creds.password == "envpw"
+
+
+@pytest.mark.unit
+def test_keyring_password_cleans_up_lingering_legacy_section(
+    monkeypatch, _isolate_credential_state
+):
+    """When the system keyring supplies the password, a lingering legacy [WRDS]
+    section is cleaned up — but other tools' sections are preserved."""
+    import base64
+    import configparser
+
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    cp = configparser.RawConfigParser()
+    cp.add_section("WRDS")
+    cp.set("WRDS", "testuser", "\n" + base64.encodebytes(b"old-plaintext").decode())
+    cp.add_section("other")
+    cp.set("other", "bob", "\n" + base64.encodebytes(b"x").decode())
+    with mod._LEGACY_KEYRING_FILE.open("w") as fh:
+        cp.write(fh)
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kr-pw")
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password == "kr-pw"  # keyring wins
+    check = configparser.RawConfigParser()
+    check.read(mod._LEGACY_KEYRING_FILE)
+    assert not check.has_section("WRDS"), "superseded legacy section should be cleaned up"
+    assert check.has_section("other"), "other tools' section must survive"
+
+
+@pytest.mark.unit
+def test_legacy_keyring_path_uses_keyring_convention():
+    """The legacy file was written by keyrings.alt, which uses keyring's
+    data_root() (not platformdirs) — matters on macOS/Windows where the two
+    diverge. Guards against a silent revert to a platformdirs-derived path."""
+    from keyring.util.platform_ import data_root
 
     import jkp.data.wrds_credentials as mod
 
-    monkeypatch.setattr(mod, "LAST_USER_FILE", tmp_path / ".wrds_user")
-    (tmp_path / ".wrds_user").write_text("someuser")
+    assert mod._keyring_data_root is data_root
 
-    def _no_entry(*a, **kw):
-        raise mod.keyring.errors.PasswordDeleteError("not found")
 
-    monkeypatch.setattr(mod.keyring, "delete_password", _no_entry)
+@pytest.mark.unit
+def test_migration_newline_legacy_password_discarded_and_idempotent(
+    monkeypatch, _isolate_credential_state
+):
+    """A legacy password that ~/.pgpass cannot store (contains a newline) is
+    discarded and its dead section dropped — so resolution doesn't loop forever
+    decoding-then-failing, and a second run is a clean no-op."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    _write_real_keyring(mod, {"testuser": "line1\nline2"})
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
 
-    mod.reset_credentials(full_reset=True)  # must not raise
+    with pytest.raises(RuntimeError, match="No WRDS password found"):
+        mod.get_wrds_credentials()
 
-    out = capsys.readouterr().out
-    assert "No keyring entry found" in out
+    assert not mod._LEGACY_KEYRING_FILE.exists(), "dead section should be dropped"
+    # idempotent: nothing left to re-process
+    with pytest.raises(RuntimeError, match="No WRDS password found"):
+        mod.get_wrds_credentials()
+
+
+@pytest.mark.unit
+def test_migration_defers_to_wildcard_pgpass_entry(monkeypatch, _isolate_credential_state):
+    """A catch-all ~/.pgpass entry already covers WRDS (libpq wildcard semantics),
+    so migration preserves the user's file and drops the superseded legacy section
+    rather than overwriting. Documents this intentional trade-off."""
+    import configparser
+
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    _write_pgpass(mod, "*:*:*:*:existing-pw\n")
+    _write_real_keyring(mod, {"testuser": "legacy-pw"})
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None  # libpq serves it from the wildcard entry
+    assert mod._pgpass_path().read_text().strip() == "*:*:*:*:existing-pw"
+    assert "legacy-pw" not in mod._pgpass_path().read_text()
+    cp = configparser.RawConfigParser()
+    cp.read(mod._LEGACY_KEYRING_FILE)
+    assert not cp.has_section("WRDS")
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _write_real_keyring(mod, entries):
+    """Write a keyring_pass.cfg the way keyrings.alt does — values on tab-indented
+    continuation lines with a leading newline, via configparser — so the parsing
+    test reflects what actually lands on users' disks. ``entries`` maps the
+    (already keyrings.alt-escaped) option key to the plaintext password."""
+    import configparser
+
+    cp = configparser.RawConfigParser()
+    cp.add_section(mod.SERVICE_NAME)
+    for key, password in entries.items():
+        cp.set(mod.SERVICE_NAME, key, "\n" + base64.encodebytes(password.encode()).decode())
+    with mod._LEGACY_KEYRING_FILE.open("w") as fh:
+        cp.write(fh)
+
+
+def _raises(exc):
+    def _fn(*a, **kw):
+        raise exc("no backend")
+
+    return _fn
+
+
+def _write_pgpass(mod, content):
+    path = mod._pgpass_path()
+    path.write_text(content)
+    if not __import__("sys").platform.startswith("win"):
+        path.chmod(0o600)
+    return path
+
+
+def _write_pgpass_append(mod, content):
+    path = mod._pgpass_path()
+    with path.open("a") as fh:
+        fh.write(content)

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -440,6 +440,88 @@ def test_reset_warns_when_keyring_unreachable(monkeypatch, _isolate_credential_s
 
 
 @pytest.mark.unit
+def test_reset_clears_legacy_even_when_pgpass_removal_fails(monkeypatch, _isolate_credential_state):
+    """A failure removing the ~/.pgpass line must not skip the legacy-section
+    cleanup: reset revokes what it can (keyring + legacy plaintext copy) before
+    surfacing the error, so no plaintext copy is left behind on a security reset."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    mod._LEGACY_KEYRING_FILE.write_text("[WRDS]\ntestuser = eA==\n")
+
+    def _boom(*a, **kw):
+        raise RuntimeError("Cannot read ~/.pgpass; fix its permissions and retry.")
+
+    monkeypatch.setattr(mod, "_remove_pgpass_entry", _boom)
+
+    with pytest.raises(RuntimeError, match="[Cc]annot read"):
+        mod.reset_credentials(full_reset=True)
+    # the legacy plaintext [WRDS] section was cleared before the pgpass failure
+    # (its file held only that section, so cleanup removes the file entirely)
+    assert not mod._LEGACY_KEYRING_FILE.exists()
+
+
+@pytest.mark.unit
+def test_reset_keeps_username_cache_when_pgpass_removal_fails(
+    monkeypatch, _isolate_credential_state
+):
+    """If removing the ~/.pgpass line fails, the username cache must survive so a
+    retry can find the username and finish the reset rather than orphaning the
+    stored password (the cache is deleted last, after the password removals)."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+
+    def _boom(*a, **kw):
+        raise RuntimeError("Cannot read ~/.pgpass; fix its permissions and retry.")
+
+    monkeypatch.setattr(mod, "_remove_pgpass_entry", _boom)
+
+    with pytest.raises(RuntimeError, match="[Cc]annot read"):
+        mod.reset_credentials(full_reset=True)
+    assert mod.LAST_USER_FILE.read_text() == "testuser"  # cache intact for the retry
+
+
+@pytest.mark.unit
+def test_reset_empty_username_cache_falls_through_to_legacy(_isolate_credential_state, capsys):
+    """An empty/whitespace username cache must be treated as missing — reset uses
+    the legacy ~/.wrds_user rather than resetting user '' and consuming the legacy
+    file unread."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("   ")  # empty/whitespace cache
+    mod._LEGACY_USER_FILE.write_text("legacy-user")
+
+    mod.reset_credentials(full_reset=False)
+
+    out = capsys.readouterr().out
+    assert "legacy-user" in out  # legacy used as the username, not skipped or user ''
+    assert not mod.LAST_USER_FILE.exists() and not mod._LEGACY_USER_FILE.exists()
+
+
+@pytest.mark.unit
+def test_migration_pgpass_write_error_is_caught(monkeypatch, _isolate_credential_state, capsys):
+    """If migrating the legacy keyring to ~/.pgpass fails with a RuntimeError from
+    _write_pgpass (e.g. an unreadable pgpass), resolution must warn and continue,
+    not crash — pins the RuntimeError arm of the migration wrapper."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    _write_real_keyring(mod, {"testuser": "legacy-pw"})  # a migratable legacy entry
+
+    def _boom(*a, **kw):
+        raise RuntimeError("Cannot read existing ~/.pgpass; fix its permissions and retry.")
+
+    monkeypatch.setattr(mod, "_write_pgpass", _boom)
+
+    # migration fails inside get_wrds_credentials; the wrapper must catch it, warn,
+    # and let resolution continue to the no-credentials path rather than crashing.
+    with pytest.raises(RuntimeError, match="No WRDS password"):
+        mod.get_wrds_credentials()
+    assert "could not migrate" in capsys.readouterr().err
+
+
+@pytest.mark.unit
 def test_migration_handles_real_keyring_on_disk_format(monkeypatch, _isolate_credential_state):
     """keyrings.alt writes the value on a tab-indented continuation line with a
     leading newline; the migration must decode that real format, not just a
@@ -600,6 +682,45 @@ def test_write_pgpass_rejects_newline_password(_isolate_credential_state):
     mod = _isolate_credential_state
     with pytest.raises(ValueError, match="newline"):
         mod._write_pgpass("testuser", "line1\nwildcard:injected")
+
+
+@pytest.mark.unit
+def test_write_pgpass_unreadable_file_gives_actionable_error(_isolate_credential_state):
+    """If ~/.pgpass exists but can't be read (e.g. root-owned from an old sudo),
+    _write_pgpass raises an actionable error instead of a raw PermissionError
+    after the user has already typed their password."""
+    import os
+    import sys
+
+    if sys.platform.startswith("win") or os.geteuid() == 0:
+        pytest.skip("permission semantics require a non-root POSIX user")
+    mod = _isolate_credential_state
+    path = _write_pgpass(mod, "otherhost:5432:db:bob:pw\n")
+    path.chmod(0o000)
+    try:
+        with pytest.raises(RuntimeError, match="[Cc]annot read"):
+            mod._write_pgpass("testuser", "newpw")
+    finally:
+        path.chmod(0o600)  # restore so tmp cleanup can remove it
+
+
+@pytest.mark.unit
+def test_remove_pgpass_unreadable_file_gives_actionable_error(_isolate_credential_state):
+    """`jkp connect --reset` against an unreadable ~/.pgpass must also raise an
+    actionable error, not a raw PermissionError — the same guard as the write path."""
+    import os
+    import sys
+
+    if sys.platform.startswith("win") or os.geteuid() == 0:
+        pytest.skip("permission semantics require a non-root POSIX user")
+    mod = _isolate_credential_state
+    path = _write_pgpass(mod, "otherhost:5432:db:bob:pw\n")
+    path.chmod(0o000)
+    try:
+        with pytest.raises(RuntimeError, match="[Cc]annot read"):
+            mod._remove_pgpass_entry("testuser")
+    finally:
+        path.chmod(0o600)  # restore so tmp cleanup can remove it
 
 
 @pytest.mark.unit

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -300,6 +300,34 @@ def test_reset_no_username_is_handled(_isolate_credential_state, capsys):
     assert "nothing to reset" in capsys.readouterr().out
 
 
+@pytest.mark.unit
+def test_reset_clears_legacy_keyring_section(monkeypatch, _isolate_credential_state):
+    """full_reset must remove a lingering legacy [WRDS] section, so the next
+    resolution cannot migrate the just-revoked password back into ~/.pgpass —
+    while preserving any other tool's section."""
+    import base64
+    import configparser
+
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    cp = configparser.RawConfigParser()
+    cp.add_section("WRDS")
+    cp.set("WRDS", "testuser", "\n" + base64.encodebytes(b"revoked").decode())
+    cp.add_section("other")
+    cp.set("other", "bob", "\n" + base64.encodebytes(b"x").decode())
+    with mod._LEGACY_KEYRING_FILE.open("w") as fh:
+        cp.write(fh)
+    monkeypatch.setattr(mod.keyring, "delete_password", lambda *a, **kw: None)
+
+    mod.reset_credentials(full_reset=True)
+
+    check = configparser.RawConfigParser()
+    check.read(mod._LEGACY_KEYRING_FILE)
+    assert not check.has_section("WRDS"), "revoked legacy section must be removed"
+    assert check.has_section("other"), "other tools' section must survive"
+
+
 # --------------------------------------------------------------------------- #
 # Migration — real on-disk format, escaped keys, fallback, I/O isolation
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -705,6 +705,43 @@ def test_remove_pgpass_unreadable_file_gives_actionable_error(_isolate_credentia
 
 
 @pytest.mark.unit
+def test_pgpass_not_utf8_is_ignored_with_warning(_isolate_credential_state, capsys):
+    """A non-UTF-8 ~/.pgpass (jkp reads it as UTF-8, but libpq is byte-oriented so
+    such a file is possible) is skipped with a warning during resolution, not a
+    crash."""
+    mod = _isolate_credential_state
+    path = mod._pgpass_path()
+    path.write_bytes(b"wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:p\xe9ss\n")
+    if not sys.platform.startswith("win"):
+        path.chmod(0o600)  # pass the perms gate so the read (not perms) is exercised
+
+    assert mod._pgpass_scan("testuser") == (False, False)
+    assert "not valid UTF-8" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_write_pgpass_not_utf8_gives_actionable_error(_isolate_credential_state):
+    """`jkp connect` against a non-UTF-8 ~/.pgpass raises an actionable error
+    rather than clobbering a file it can't read."""
+    mod = _isolate_credential_state
+    mod._pgpass_path().write_bytes(b"otherhost:5432:db:bob:p\xe9ss\n")
+
+    with pytest.raises(RuntimeError, match="not valid UTF-8"):
+        mod._write_pgpass("testuser", "newpw")
+
+
+@pytest.mark.unit
+def test_remove_pgpass_not_utf8_gives_actionable_error(_isolate_credential_state):
+    """`jkp connect --reset` against a non-UTF-8 ~/.pgpass likewise raises an
+    actionable error, not a raw UnicodeDecodeError."""
+    mod = _isolate_credential_state
+    mod._pgpass_path().write_bytes(b"otherhost:5432:db:bob:p\xe9ss\n")
+
+    with pytest.raises(RuntimeError, match="not valid UTF-8"):
+        mod._remove_pgpass_entry("testuser")
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("username", "expected"),
     [

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -640,6 +640,45 @@ def test_migration_preserves_existing_pgpass_entry(monkeypatch, _isolate_credent
 
 
 @pytest.mark.unit
+def test_migration_preserves_other_users_legacy_entries(_isolate_credential_state):
+    """The legacy [WRDS] section can hold one option per WRDS username; migrating
+    one user must remove only that user's option, never destroy another user's
+    never-migrated password."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("usera")
+    _write_real_keyring(mod, {"usera": "pw-a", "userb": "pw-b"})
+
+    creds = mod.get_wrds_credentials()  # migrates usera to ~/.pgpass
+
+    assert creds.username == "usera"
+    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:usera:pw-a" in mod._pgpass_path().read_text()
+    cp = configparser.RawConfigParser()
+    cp.read(mod._LEGACY_KEYRING_FILE)
+    assert not cp.has_option("WRDS", "usera"), "migrated user's entry removed"
+    assert cp.has_option("WRDS", "userb"), "other user's legacy entry must survive"
+
+
+@pytest.mark.unit
+def test_migration_precheck_does_not_touch_other_users(_isolate_credential_state, capsys):
+    """When ~/.pgpass already serves usera and the legacy section holds only userb,
+    the pre-check must not delete userb's entry, nor falsely announce that something
+    was superseded (usera's pgpass entry supersedes nothing in the legacy store)."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("usera")
+    _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:usera:pw-a\n")
+    _write_real_keyring(mod, {"userb": "pw-b"})  # legacy holds only the other user
+
+    mod.get_wrds_credentials()  # resolves usera via pgpass; the migration pre-check runs
+
+    cp = configparser.RawConfigParser()
+    cp.read(mod._LEGACY_KEYRING_FILE)
+    assert cp.has_option("WRDS", "userb"), "another user's entry must not be destroyed"
+    assert "superseded" not in capsys.readouterr().err  # nothing was actually superseded
+
+
+@pytest.mark.unit
 def test_migration_does_not_overwrite_loose_perm_pgpass(_isolate_credential_state):
     """Even a 0644 ~/.pgpass holds the user's *current* WRDS line; migration must
     not overwrite it with the legacy value just because libpq would ignore the

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -9,6 +9,9 @@ one-time migration off the legacy plaintext keyring.
 from __future__ import annotations
 
 import base64
+import configparser
+import os
+import sys
 
 import pytest
 
@@ -236,8 +239,6 @@ def test_password_from_pgpass_returns_none_password(monkeypatch, _isolate_creden
 @pytest.mark.unit
 def test_pgpass_ignored_when_permissions_too_open(monkeypatch, _isolate_credential_state):
     """libpq ignores a group/world-readable .pgpass; so must our detection."""
-    import sys
-
     if sys.platform.startswith("win"):
         pytest.skip("permission check is Unix-only")
     mod = _isolate_credential_state
@@ -294,8 +295,6 @@ def test_write_pgpass_replaces_our_line_in_place(_isolate_credential_state):
 
 @pytest.mark.unit
 def test_write_pgpass_is_mode_600(_isolate_credential_state):
-    import sys
-
     if sys.platform.startswith("win"):
         pytest.skip("permission check is Unix-only")
     mod = _isolate_credential_state
@@ -340,8 +339,6 @@ def test_legacy_keyring_migrates_to_pgpass_and_removes_only_our_section(
     assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:legacy-secret" in (
         mod._pgpass_path().read_text()
     )
-
-    import configparser
 
     cp = configparser.RawConfigParser()
     cp.read(mod._LEGACY_KEYRING_FILE, encoding="utf-8")
@@ -398,9 +395,6 @@ def test_reset_clears_legacy_keyring_section(monkeypatch, _isolate_credential_st
     """full_reset must remove a lingering legacy [WRDS] section, so the next
     resolution cannot migrate the just-revoked password back into ~/.pgpass —
     while preserving any other tool's section."""
-    import base64
-    import configparser
-
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
     mod.LAST_USER_FILE.write_text("testuser")
@@ -567,8 +561,6 @@ def test_migration_ignores_entry_under_mismatched_key(monkeypatch, _isolate_cred
     is NOT migrated — only jkp's own exact-key entry is (which is everything jkp
     ever wrote). The mismatched section is left untouched, not migrated under the
     wrong username."""
-    import configparser
-
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
     mod.LAST_USER_FILE.write_text("resolved-user")
@@ -642,8 +634,6 @@ def test_migration_preserves_existing_pgpass_entry(monkeypatch, _isolate_credent
     assert "testuser:CURRENT_PW" in contents, "current pgpass password must be preserved"
     assert "STALE_PW" not in contents, "stale legacy password must not overwrite it"
 
-    import configparser
-
     cp = configparser.RawConfigParser()
     cp.read(mod._LEGACY_KEYRING_FILE)
     assert not cp.has_section("WRDS"), "superseded legacy section should still be cleaned up"
@@ -654,9 +644,6 @@ def test_migration_does_not_overwrite_loose_perm_pgpass(_isolate_credential_stat
     """Even a 0644 ~/.pgpass holds the user's *current* WRDS line; migration must
     not overwrite it with the legacy value just because libpq would ignore the
     loose-permission file."""
-    import configparser
-    import sys
-
     if sys.platform.startswith("win"):
         pytest.skip("permission check is Unix-only")
     mod = _isolate_credential_state
@@ -689,9 +676,6 @@ def test_write_pgpass_unreadable_file_gives_actionable_error(_isolate_credential
     """If ~/.pgpass exists but can't be read (e.g. root-owned from an old sudo),
     _write_pgpass raises an actionable error instead of a raw PermissionError
     after the user has already typed their password."""
-    import os
-    import sys
-
     if sys.platform.startswith("win") or os.geteuid() == 0:
         pytest.skip("permission semantics require a non-root POSIX user")
     mod = _isolate_credential_state
@@ -708,9 +692,6 @@ def test_write_pgpass_unreadable_file_gives_actionable_error(_isolate_credential
 def test_remove_pgpass_unreadable_file_gives_actionable_error(_isolate_credential_state):
     """`jkp connect --reset` against an unreadable ~/.pgpass must also raise an
     actionable error, not a raw PermissionError — the same guard as the write path."""
-    import os
-    import sys
-
     if sys.platform.startswith("win") or os.geteuid() == 0:
         pytest.skip("permission semantics require a non-root POSIX user")
     mod = _isolate_credential_state
@@ -874,9 +855,6 @@ def test_keyring_password_cleans_up_lingering_legacy_section(
 ):
     """When the system keyring supplies the password, a lingering legacy [WRDS]
     section is cleaned up — but other tools' sections are preserved."""
-    import base64
-    import configparser
-
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
     mod.LAST_USER_FILE.write_text("testuser")
@@ -937,8 +915,6 @@ def test_migration_defers_to_wildcard_pgpass_entry(monkeypatch, _isolate_credent
     """A catch-all ~/.pgpass entry already covers WRDS (libpq wildcard semantics),
     so migration preserves the user's file and drops the superseded legacy section
     rather than overwriting. Documents this intentional trade-off."""
-    import configparser
-
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
     mod.LAST_USER_FILE.write_text("testuser")
@@ -1001,8 +977,6 @@ def _write_real_keyring(mod, entries):
     continuation lines with a leading newline, via configparser — so the parsing
     test reflects what actually lands on users' disks. ``entries`` maps the
     (already keyrings.alt-escaped) option key to the plaintext password."""
-    import configparser
-
     cp = configparser.RawConfigParser()
     cp.add_section(mod.SERVICE_NAME)
     for key, password in entries.items():
@@ -1021,7 +995,7 @@ def _raises(exc):
 def _write_pgpass(mod, content):
     path = mod._pgpass_path()
     path.write_text(content)
-    if not __import__("sys").platform.startswith("win"):
+    if not sys.platform.startswith("win"):
         path.chmod(0o600)
     return path
 

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -480,21 +480,25 @@ def test_migration_matches_escaped_username_key(monkeypatch, _isolate_credential
 
 
 @pytest.mark.unit
-def test_migration_single_entry_fallback(monkeypatch, _isolate_credential_state):
-    """When the resolved username doesn't match the stored key but exactly one
-    WRDS entry exists, migrate it under the resolved username."""
+def test_migration_ignores_entry_under_mismatched_key(monkeypatch, _isolate_credential_state):
+    """A legacy entry stored under a key that doesn't match the resolved username
+    is NOT migrated — only jkp's own exact-key entry is (which is everything jkp
+    ever wrote). The mismatched section is left untouched, not migrated under the
+    wrong username."""
+    import configparser
+
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
     mod.LAST_USER_FILE.write_text("resolved-user")
     _write_real_keyring(mod, {"testuser": "the-secret"})  # key != resolved username
     monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
 
-    creds = mod.get_wrds_credentials()
+    mod._migrate_legacy_keyring("resolved-user")
 
-    assert creds.password is None
-    assert "wrds-pgdata.wharton.upenn.edu:9737:wrds:resolved-user:the-secret" in (
-        mod._pgpass_path().read_text()
-    )
+    assert not mod._pgpass_has_entry("resolved-user", check_perms=False), "must not migrate"
+    cp = configparser.RawConfigParser()
+    cp.read(mod._LEGACY_KEYRING_FILE)
+    assert cp.has_section("WRDS"), "mismatched section is left untouched"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -972,6 +972,73 @@ def test_load_legacy_cfg(_isolate_credential_state):
     assert mod._load_legacy_cfg() is None  # non-UTF8 -> None, not a raise
 
 
+@pytest.mark.unit
+def test_wildcard_only_pgpass_warns(monkeypatch, _isolate_credential_state, capsys):
+    """When WRDS is served only by a catch-all wildcard .pgpass line (no exact
+    entry), warn — jkp can't set/change such an entry via `jkp connect`."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+    _write_pgpass(mod, "*:*:*:*:wildpw\n")
+
+    creds = mod.get_wrds_credentials()
+
+    assert creds.password is None  # served via the wildcard
+    assert "catch-all" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_exact_pgpass_entry_does_not_warn(monkeypatch, _isolate_credential_state, capsys):
+    """An exact WRDS entry serves without the wildcard warning."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+    _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:pw\n")
+
+    mod.get_wrds_credentials()
+
+    assert "catch-all" not in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_wildcard_above_exact_still_warns(monkeypatch, _isolate_credential_state, capsys):
+    """libpq is first-match: a wildcard line *above* jkp's exact entry is what
+    actually serves WRDS, so `jkp connect` still can't manage it — warn even
+    though an exact line also exists lower down."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+    _write_pgpass(
+        mod,
+        "*:*:*:*:wildpw\nwrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:pw\n",
+    )
+
+    mod.get_wrds_credentials()
+
+    assert "catch-all" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_exact_above_wildcard_does_not_warn(monkeypatch, _isolate_credential_state, capsys):
+    """When jkp's exact entry comes first, it is the effective credential, so no
+    wildcard warning fires even though a catch-all line follows it."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", _raises(mod.keyring.errors.NoKeyringError))
+    _write_pgpass(
+        mod,
+        "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:pw\n*:*:*:*:wildpw\n",
+    )
+
+    mod.get_wrds_credentials()
+
+    assert "catch-all" not in capsys.readouterr().err
+
+
 def _write_real_keyring(mod, entries):
     """Write a keyring_pass.cfg the way keyrings.alt does — values on tab-indented
     continuation lines with a leading newline, via configparser — so the parsing

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -97,6 +97,85 @@ def test_legacy_username_file_migrates_to_state_dir(monkeypatch, _isolate_creden
 
 
 @pytest.mark.unit
+def test_empty_cached_username_treated_as_missing(_isolate_credential_state):
+    """An empty state file (e.g. from a past mistake) must not be returned as the
+    username — it is treated as missing so resolution doesn't silently use ''."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("")  # empty cache
+
+    with pytest.raises(RuntimeError, match="No WRDS username"):
+        mod._resolve_username()  # non-interactive (fixture) -> raises, not ''
+
+
+@pytest.mark.unit
+def test_empty_legacy_username_file_treated_as_missing(_isolate_credential_state):
+    """An empty ~/.wrds_user must not migrate into the state file as '' — the
+    legacy path needs the same empty guard as the cache path."""
+    mod = _isolate_credential_state
+    mod._LEGACY_USER_FILE.write_text("   \n")  # whitespace only
+
+    with pytest.raises(RuntimeError, match="No WRDS username"):
+        mod._resolve_username()  # non-interactive (fixture) -> raises, not ''
+    assert not mod.LAST_USER_FILE.exists(), "empty legacy username must not be cached"
+
+
+@pytest.mark.unit
+def test_empty_prompt_input_is_rejected_and_not_cached(monkeypatch, _isolate_credential_state):
+    """Hitting Enter at the username prompt must be rejected, not cached as ''."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr(mod, "_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: "")
+
+    with pytest.raises(RuntimeError, match="[Ee]mpty username"):
+        mod._resolve_username()
+    assert not mod.LAST_USER_FILE.exists(), "empty username must not be cached"
+
+
+@pytest.mark.unit
+def test_whitespace_env_username_treated_as_missing(monkeypatch, _isolate_credential_state):
+    """WRDS_USERNAME='   ' must be stripped before the truthiness check, not
+    accepted as username='' — so the env fast-path is skipped and, with no state
+    file and no terminal, resolution raises rather than proceeding with user=''."""
+    mod = _isolate_credential_state
+    monkeypatch.setenv("WRDS_USERNAME", "   ")
+    monkeypatch.setenv("WRDS_PASSWORD", "pw")
+
+    with pytest.raises(RuntimeError, match="No WRDS username"):
+        mod.get_wrds_credentials()
+
+
+@pytest.mark.unit
+def test_empty_prompt_password_is_rejected(monkeypatch, _isolate_credential_state):
+    """Hitting Enter at the password prompt must be rejected, not stored as a junk
+    empty ~/.pgpass line that later 'resolves' while auth silently fails."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "")
+
+    with pytest.raises(RuntimeError, match="[Ee]mpty password"):
+        mod._prompt_and_store("testuser")
+    assert not mod._pgpass_path().exists() or "testuser" not in mod._pgpass_path().read_text()
+
+
+@pytest.mark.unit
+def test_prompt_and_store_persists_username_for_reset(monkeypatch, _isolate_credential_state):
+    """A credential provisioned for an env-provided WRDS_USERNAME (which the
+    resolver does not persist) must still cache the username, so `jkp connect
+    --reset` can revoke it rather than leaving an orphaned ~/.pgpass line."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
+
+    mod._prompt_and_store("env-user")  # no keyring in tests -> written to ~/.pgpass
+
+    assert mod.LAST_USER_FILE.read_text().strip() == "env-user"  # cached for reset
+    pgpass = mod._pgpass_path()
+    assert "env-user" in pgpass.read_text()
+    # ...and reset can now find + remove it
+    mod.reset_credentials(full_reset=True)
+    assert not pgpass.exists() or "env-user" not in pgpass.read_text()
+
+
+@pytest.mark.unit
 def test_password_from_keyring(monkeypatch, _isolate_credential_state):
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -956,6 +956,28 @@ def test_migration_defers_to_wildcard_pgpass_entry(monkeypatch, _isolate_credent
     assert not cp.has_section("WRDS")
 
 
+@pytest.mark.unit
+def test_atomic_write_warns_when_replacing_symlink(_isolate_credential_state, capsys, tmp_path):
+    """Writing through a symlinked path replaces the link with a regular file and
+    leaves the original target untouched — warn so the detachment (and any secret
+    left in the target, e.g. a dotfiles copy) isn't silent."""
+    mod = _isolate_credential_state
+    target = tmp_path / "real_pgpass"
+    target.write_text("orig\n")
+    link = tmp_path / "link_pgpass"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):  # e.g. Windows without privilege
+        pytest.skip("symlinks not supported in this environment")
+
+    mod._atomic_write(link, "new\n")
+
+    assert not link.is_symlink()  # the link was replaced by a regular file
+    assert link.read_text() == "new\n"
+    assert target.read_text() == "orig\n"  # the original target is untouched
+    assert "symlink" in capsys.readouterr().err
+
+
 def _write_real_keyring(mod, entries):
     """Write a keyring_pass.cfg the way keyrings.alt does — values on tab-indented
     continuation lines with a leading newline, via configparser — so the parsing

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -360,6 +360,24 @@ def test_reset_clears_legacy_keyring_section(monkeypatch, _isolate_credential_st
     assert check.has_section("other"), "other tools' section must survive"
 
 
+@pytest.mark.unit
+def test_reset_warns_when_keyring_unreachable(monkeypatch, _isolate_credential_state, capsys):
+    """A locked/unreachable keyring during --reset must warn that an entry may
+    survive, rather than silently reporting a clean success."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "delete_password", _raises(mod.keyring.errors.KeyringLocked))
+
+    mod.reset_credentials(full_reset=True)
+
+    captured = capsys.readouterr()
+    assert "a stored entry may still exist" in captured.err
+    # ...and the run must not also claim nothing was found (that would contradict
+    # the warning): the keyring answer here is "unknown", not "definitively empty".
+    assert "No stored password found" not in captured.out + captured.err
+
+
 # --------------------------------------------------------------------------- #
 # Migration — real on-disk format, escaped keys, fallback, I/O isolation
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -564,6 +564,33 @@ def test_migration_preserves_existing_pgpass_entry(monkeypatch, _isolate_credent
 
 
 @pytest.mark.unit
+def test_migration_does_not_overwrite_loose_perm_pgpass(_isolate_credential_state):
+    """Even a 0644 ~/.pgpass holds the user's *current* WRDS line; migration must
+    not overwrite it with the legacy value just because libpq would ignore the
+    loose-permission file."""
+    import configparser
+    import sys
+
+    if sys.platform.startswith("win"):
+        pytest.skip("permission check is Unix-only")
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    path = _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:CURRENT_PW\n")
+    path.chmod(0o644)  # loose perms: libpq would ignore it, but it's still the user's entry
+    _write_real_keyring(mod, {"testuser": "STALE_PW"})
+
+    mod._migrate_legacy_keyring("testuser")
+
+    contents = mod._pgpass_path().read_text()
+    assert "CURRENT_PW" in contents, "the user's current entry must be preserved"
+    assert "STALE_PW" not in contents, "legacy value must not overwrite it"
+    cp = configparser.RawConfigParser()
+    cp.read(mod._LEGACY_KEYRING_FILE)
+    assert not cp.has_section("WRDS"), "superseded legacy section should be dropped"
+
+
+@pytest.mark.unit
 def test_write_pgpass_rejects_newline_password(_isolate_credential_state):
     """A newline in the password would inject a spurious .pgpass line; reject it."""
     mod = _isolate_credential_state

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -57,9 +57,29 @@ class TestGenWrdsConnectionInfo:
         assert "host=wrds-pgdata.wharton.upenn.edu" in result
         assert "port=9737" in result
         assert "dbname=wrds" in result
-        assert "user=testuser" in result
-        assert "password=testpass" in result
+        assert "user='testuser'" in result
+        assert "password='testpass'" in result
         assert "sslmode=require" in result
+
+    def test_password_with_special_characters_is_quoted_and_escaped(self):
+        """A password containing spaces/quotes/backslashes must be single-quoted
+        with libpq escaping so it can't break the conninfo."""
+        from jkp.data.aux_functions import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("testuser", "p ss'w\\rd")
+
+        # spaces stay inside the quotes; ' and \ are backslash-escaped
+        assert "password='p ss\\'w\\\\rd'" in result
+        assert "sslmode=require" in result
+
+    def test_username_with_special_characters_is_quoted_and_escaped(self):
+        """A username with a space or quote must be single-quoted and escaped too,
+        or it breaks libpq's conninfo parsing just as an unquoted password would."""
+        from jkp.data.aux_functions import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("od d'user", None)
+
+        assert "user='od d\\'user'" in result
 
     def test_password_omitted_when_none(self):
         """With password=None the password= field is omitted so libpq reads
@@ -68,9 +88,114 @@ class TestGenWrdsConnectionInfo:
 
         result = gen_wrds_connection_info("testuser", None)
 
-        assert "user=testuser" in result
+        assert "user='testuser'" in result
         assert "password=" not in result
         assert "sslmode=require" in result
+
+    def test_sql_literal_escapes_conninfo_for_embedding(self):
+        """_sql_literal must escape the conninfo so it embeds in single-quoted
+        ATTACH/postgres_scan SQL without a quoted password terminating the literal.
+        Proven at the parse layer — no postgres extension or network — so it runs
+        unconditionally in CI, unlike the ATTACH integration check below."""
+        duckdb = pytest.importorskip("duckdb")
+        from jkp.data.aux_functions import _sql_literal, gen_wrds_connection_info
+
+        conninfo = gen_wrds_connection_info("testuser", "p ss'w\\d")
+        con = duckdb.connect()
+
+        # Escaped: the whole conninfo parses as one string literal and round-trips.
+        assert con.execute(f"SELECT '{_sql_literal(conninfo)}'").fetchone()[0] == conninfo
+        # Unescaped: the raw quote terminates the literal early -> ParserException.
+        with pytest.raises(Exception) as excinfo:
+            con.execute(f"SELECT '{conninfo}'")
+        assert "Parser" in type(excinfo.value).__name__
+
+    def test_conninfo_embeds_in_sql_without_parse_error(self):
+        """Integration check (needs the DuckDB postgres extension): a real ATTACH
+        with the escaped conninfo must fail at the *connection* stage, not with a
+        ParserException — proving the SQL literal held together AND libpq accepted
+        the quoted conninfo. Also pins the password's echo format for the masking
+        in _attach_wrds."""
+        duckdb = pytest.importorskip("duckdb")
+        from jkp.data.aux_functions import _sql_literal, gen_wrds_connection_info
+
+        con = duckdb.connect()
+        try:
+            con.execute("INSTALL postgres; LOAD postgres")
+        except Exception:  # pragma: no cover - environment without the extension
+            pytest.skip("duckdb postgres extension unavailable")
+
+        # A password with a space, a single quote, and a backslash — the exact
+        # class the libpq quoting targets. Point at a dead local endpoint so the
+        # ATTACH fails to *connect* rather than hanging on a real socket.
+        conninfo = (
+            gen_wrds_connection_info("testuser", "p ss'w\\d")
+            .replace("host=wrds-pgdata.wharton.upenn.edu", "host=127.0.0.1")
+            .replace("port=9737", "port=9")
+            .replace("sslmode=require", "sslmode=disable")
+            # cap any hang if something ever happens to listen on :9
+            + " connect_timeout=2"
+        )
+        # Guard the neutering: if the WRDS host/port constants ever change, the
+        # .replace() calls above would silently no-op and this test would dial the
+        # real WRDS endpoint. Assert the substitutions actually took effect.
+        assert "host=127.0.0.1" in conninfo and "port=9 " in conninfo
+        assert "wrds-pgdata.wharton.upenn.edu" not in conninfo
+
+        from jkp.data.aux_functions import _password_in_error
+
+        with pytest.raises(Exception) as excinfo:
+            con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
+        err = str(excinfo.value)
+        # A ParserException would mean the SQL literal was broken by the password's
+        # quote (the SQL-escaping half of the fix).
+        assert "Parser" not in type(excinfo.value).__name__, err
+        # Reaching the connection stage proves libpq accepted the quoted conninfo
+        # (the libpq-escaping half): a regression from \' to ''-style escaping would
+        # fail here as a conninfo-syntax error even though the parse test still passes.
+        assert "connect" in err.lower(), err
+        # And DuckDB really echoes the password in the libpq-escaped form the masking
+        # matches — pinned against a real error, not a synthesized one, so a DuckDB
+        # echo-format change can't silently regress _attach_wrds's redaction.
+        assert _password_in_error(err, "p ss'w\\d")
+
+    def test_password_masking_matches_libpq_escaped_form(self):
+        """DuckDB echoes the connection string with the password in libpq-escaped
+        form, so the masking must match that form — a raw ``password in text``
+        check misses every special-character password."""
+        from jkp.data.aux_functions import (
+            _password_in_error,
+            _pg_escape_value,
+            _redact_password,
+        )
+
+        pw = "ab'cd\\e"
+        err = f"IO Error: Unable to connect at password='{_pg_escape_value(pw)}' sslmode=disable"
+
+        assert pw not in err  # the raw password does not appear verbatim
+        assert _password_in_error(err, pw)
+        redacted = _redact_password(err, pw)
+        assert "***" in redacted
+        assert _pg_escape_value(pw) not in redacted
+
+    def test_password_masking_matches_sql_doubled_form(self):
+        """A parser error echoes the *raw statement text*, where the password is
+        SQL-escaped over the libpq-escaped form. Masking must match that composed
+        form too — neither the raw nor the plain libpq-escaped form appears."""
+        from jkp.data.aux_functions import (
+            _password_in_error,
+            _pg_escape_value,
+            _redact_password,
+            _sql_literal,
+        )
+
+        pw = "ab'cd\\e"
+        composed = _sql_literal(_pg_escape_value(pw))
+        err = f"Parser Error: syntax error near ...{composed}... in statement"
+
+        assert pw not in err and _pg_escape_value(pw) not in err  # only the composed form
+        assert _password_in_error(err, pw)
+        assert composed not in _redact_password(err, pw)
 
 
 class TestDownloadRawDataTablesBranching:
@@ -369,6 +494,30 @@ class TestParallelDownload:
         assert "hunter2secret" not in err  # credential redacted
         assert "***" in err  # ... replaced in place
         assert "connection failed" in err and "while reading" in err  # ... diagnostic preserved
+
+    @patch("jkp.data.aux_functions.download_wrds_table_attached")
+    def test_special_char_password_not_leaked_in_aggregated_error(
+        self, mock_dl, mock_duckdb_multi, test_paths
+    ):
+        """A password with a quote/backslash appears in DuckDB errors in its
+        libpq-escaped form, so redaction must scrub that form too — a raw
+        ``str(e).replace(password, ...)`` would miss it and leak the secret."""
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        def fail_with_secret(con, alias, table, filename, **kwargs):
+            # the libpq-escaped form is what a real DuckDB error would contain
+            raise ValueError(r"connection failed for password='ab\'cd' while reading")
+
+        mock_dl.side_effect = fail_with_secret
+
+        with pytest.raises(RuntimeError) as exc_info:
+            download_raw_data_tables(test_paths, "user", "ab'cd", max_workers=2)
+
+        err = str(exc_info.value)
+        assert "ab'cd" not in err  # raw form absent
+        assert r"ab\'cd" not in err  # libpq-escaped form absent (the form that appeared)
+        assert "***" in err
+        assert "connection failed" in err and "while reading" in err
 
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     @patch("jkp.data.aux_functions._attach_wrds")
@@ -751,6 +900,20 @@ class TestAttachWrds:
             _attach_wrds(con, "host=x password=hunter2", "hunter2")
         assert "hunter2" not in str(exc_info.value)
         assert "credentials" in str(exc_info.value).lower()
+
+    def test_redacts_special_char_password_on_attach_error(self):
+        """The escaped form of a special-character password is what appears in the
+        ATTACH error, so detection must match it — a raw ``password in str(e)``
+        would miss it and re-raise the secret."""
+        from jkp.data.aux_functions import _attach_wrds
+
+        con = MagicMock()
+        con.execute.side_effect = RuntimeError(r"ATTACH failed: password='ab\'cd' dbname=wrds")
+        with pytest.raises(RuntimeError) as exc_info:
+            _attach_wrds(con, r"host=x password='ab\'cd'", "ab'cd")
+        msg = str(exc_info.value)
+        assert "ab'cd" not in msg and r"ab\'cd" not in msg  # neither form leaks
+        assert "credentials" in msg.lower()
 
     def test_passes_through_non_password_error(self):
         from jkp.data.aux_functions import _attach_wrds

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -61,6 +61,17 @@ class TestGenWrdsConnectionInfo:
         assert "password=testpass" in result
         assert "sslmode=require" in result
 
+    def test_password_omitted_when_none(self):
+        """With password=None the password= field is omitted so libpq reads
+        ~/.pgpass / $PGPASSFILE."""
+        from jkp.data.aux_functions import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("testuser", None)
+
+        assert "user=testuser" in result
+        assert "password=" not in result
+        assert "sslmode=require" in result
+
 
 class TestDownloadRawDataTablesBranching:
     """Tests for download_raw_data_tables() branching logic.

--- a/uv.lock
+++ b/uv.lock
@@ -1133,14 +1133,13 @@ dependencies = [
     { name = "fastexcel" },
     { name = "ibis-framework", extra = ["duckdb", "postgres"] },
     { name = "keyring" },
-    { name = "keyrings-alt" },
     { name = "numba" },
     { name = "numpy" },
+    { name = "platformdirs" },
     { name = "polars" },
     { name = "polars-ds" },
     { name = "polars-ols" },
     { name = "pyarrow" },
-    { name = "pycryptodomex" },
     { name = "sqlalchemy" },
     { name = "tqdm" },
     { name = "typer" },
@@ -1170,14 +1169,13 @@ requires-dist = [
     { name = "fastexcel", specifier = ">=0.16.0" },
     { name = "ibis-framework", extras = ["duckdb", "postgres"], specifier = ">=12.0" },
     { name = "keyring", specifier = ">=25.6.0" },
-    { name = "keyrings-alt", specifier = ">=5.0.2" },
     { name = "numba", specifier = ">=0.61" },
     { name = "numpy", specifier = ">=1.26.4" },
+    { name = "platformdirs", specifier = ">=4.9.6" },
     { name = "polars", specifier = ">=1.40" },
     { name = "polars-ds", specifier = ">=0.11.2" },
     { name = "polars-ols", specifier = ">=0.3.5" },
     { name = "pyarrow", specifier = ">=16.1.0" },
-    { name = "pycryptodomex", specifier = ">=3.23.0" },
     { name = "sqlalchemy", specifier = ">=1.4.49" },
     { name = "tqdm", specifier = ">=4.66.5" },
     { name = "typer", specifier = ">=0.15.0" },
@@ -1474,19 +1472,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
-]
-
-[[package]]
-name = "keyrings-alt"
-version = "5.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/7b/e3bf53326e0753bee11813337b1391179582ba5c6851b13e0d9502d15a50/keyrings_alt-5.0.2.tar.gz", hash = "sha256:8f097ebe9dc8b185106502b8cdb066c926d2180e13b4689fd4771a3eab7d69fb", size = 29229, upload-time = "2024-08-14T01:09:28.12Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/0d/9c59313ab43d0858a9a665e80763bd830dc78d5f379afc3815e123c486c2/keyrings.alt-5.0.2-py3-none-any.whl", hash = "sha256:6be74693192f3f37bbb752bfac9b86e6177076b17d2ac12a390f1d6abff8ac7c", size = 17930, upload-time = "2024-08-14T01:09:26.785Z" },
 ]
 
 [[package]]
@@ -2465,36 +2450,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pycryptodomex"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/00/10edb04777069a42490a38c137099d4b17ba6e36a4e6e28bdc7470e9e853/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7b37e08e3871efe2187bc1fd9320cc81d87caf19816c648f24443483005ff886", size = 2498764, upload-time = "2025-05-17T17:22:21.453Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/3f/2872a9c2d3a27eac094f9ceaa5a8a483b774ae69018040ea3240d5b11154/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:91979028227543010d7b2ba2471cf1d1e398b3f183cb105ac584df0c36dac28d", size = 1643012, upload-time = "2025-05-17T17:22:23.702Z" },
-    { url = "https://files.pythonhosted.org/packages/70/af/774c2e2b4f6570fbf6a4972161adbb183aeeaa1863bde31e8706f123bf92/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8962204c47464d5c1c4038abeadd4514a133b28748bcd9fa5b6d62e3cec6fa", size = 2187643, upload-time = "2025-05-17T17:22:26.37Z" },
-    { url = "https://files.pythonhosted.org/packages/de/a3/71065b24cb889d537954cedc3ae5466af00a2cabcff8e29b73be047e9a19/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33986a0066860f7fcf7c7bd2bc804fa90e434183645595ae7b33d01f3c91ed8", size = 2273762, upload-time = "2025-05-17T17:22:28.313Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/0b/ff6f43b7fbef4d302c8b981fe58467b8871902cdc3eb28896b52421422cc/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7947ab8d589e3178da3d7cdeabe14f841b391e17046954f2fbcd941705762b5", size = 2313012, upload-time = "2025-05-17T17:22:30.57Z" },
-    { url = "https://files.pythonhosted.org/packages/02/de/9d4772c0506ab6da10b41159493657105d3f8bb5c53615d19452afc6b315/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c25e30a20e1b426e1f0fa00131c516f16e474204eee1139d1603e132acffc314", size = 2186856, upload-time = "2025-05-17T17:22:32.819Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ad/8b30efcd6341707a234e5eba5493700a17852ca1ac7a75daa7945fcf6427/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:da4fa650cef02db88c2b98acc5434461e027dce0ae8c22dd5a69013eaf510006", size = 2347523, upload-time = "2025-05-17T17:22:35.386Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/02/16868e9f655b7670dbb0ac4f2844145cbc42251f916fc35c414ad2359849/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:58b851b9effd0d072d4ca2e4542bf2a4abcf13c82a29fd2c93ce27ee2a2e9462", size = 2272825, upload-time = "2025-05-17T17:22:37.632Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/18/4ca89ac737230b52ac8ffaca42f9c6f1fd07c81a6cd821e91af79db60632/pycryptodomex-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:a9d446e844f08299236780f2efa9898c818fe7e02f17263866b8550c7d5fb328", size = 1772078, upload-time = "2025-05-17T17:22:40Z" },
-    { url = "https://files.pythonhosted.org/packages/73/34/13e01c322db027682e00986873eca803f11c56ade9ba5bbf3225841ea2d4/pycryptodomex-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bc65bdd9fc8de7a35a74cab1c898cab391a4add33a8fe740bda00f5976ca4708", size = 1803656, upload-time = "2025-05-17T17:22:42.139Z" },
-    { url = "https://files.pythonhosted.org/packages/54/68/9504c8796b1805d58f4425002bcca20f12880e6fa4dc2fc9a668705c7a08/pycryptodomex-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c885da45e70139464f082018ac527fdaad26f1657a99ee13eecdce0f0ca24ab4", size = 1707172, upload-time = "2025-05-17T17:22:44.704Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
-    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
-    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
-    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
-    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Rework WRDS credential handling to use libpq's `~/.pgpass` / `$PGPASSFILE` as the headless credential store, and remove the file-backed plaintext keyring (the `JKP_ALLOW_PLAINTEXT_KEYRING` opt-in and the `keyrings-alt` dependency).

- **Decoupled resolution.** Username: `WRDS_USERNAME` → saved state file → prompt. Password: `WRDS_PASSWORD` → system keyring → `~/.pgpass` / `$PGPASSFILE`.
- **libpq handles the secret on headless nodes.** When the password comes from a pgpass file, jkp omits `password=` from the connection string and lets libpq read the file; the resolved source is printed to stderr.
- **`jkp connect` stays the single interface.** It stores in the system keyring on desktops, or writes `~/.pgpass` (mode 600) on a headless login node — `$HOME` is shared, so batch jobs read it with no further setup.
- **Automatic, non-interactive migration.** An existing plaintext-keyring entry is moved to `~/.pgpass` (removing only jkp's own `[WRDS]` section, preserving any other tool's), and the username cache moves from `~/.wrds_user` to a per-OS state directory.

Closes #232

## Change Type

- [x] Infrastructure change (CI, config, dependencies)

Dependency delta: drop `keyrings-alt` and `pycryptodomex`, add `platformdirs`.

## Methodological Impact

None.

## Data Impact

None — credential handling only. No change to downloaded data, characteristics, or factor returns.

## Breaking Changes

**Yes — `JKP_ALLOW_PLAINTEXT_KEYRING` and the file-backed plaintext keyring are removed.** Existing headless setups are migrated automatically on the next run: jkp reads its entry from the legacy `keyring_pass.cfg`, writes `~/.pgpass`, and removes only its own section. No user action is required; provisioning going forward is `~/.pgpass` (via `jkp connect` on a login node) or `WRDS_USERNAME`/`WRDS_PASSWORD`.

This is a pre-release (pre-PyPI) breaking change, so no released dataset is affected. Release notes should mention the removed env var and the automatic migration.

## Tests

- Rewrote `tests/unit/test_wrds_credentials.py` for the new model: env/keyring/`.pgpass` precedence and the full credential-source interaction matrix; both migrations; surgical section removal that preserves other tools' entries; `.pgpass` escaping, wildcard matching, and 0600-permission handling; the on-disk keyring format; and the interactive prompt paths.
- Added a `password=None` case for `gen_wrds_connection_info` in `tests/unit/test_wrds_download.py`.
- Full unit suite passes (838).

## Checklist

- [x] I have run the tests locally (`pytest`)
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [x] I have verified the pipeline runs successfully after my changes
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

## Additional Notes

- Validated end-to-end on an HPC cluster: the migration ran against real credential files on a login node, and a full pipeline run on a compute node authenticated to live WRDS via the migrated `~/.pgpass` and downloaded all raw tables.
- Cross-platform: the `.pgpass` and legacy-keyring paths are derived from libpq's and keyring's own per-OS conventions (`keyring.util.platform_.data_root()` for the legacy file). macOS/Windows path behavior is reasoned from those libraries' source; CI executes on Linux only.
- `slurm/submit_job_som_hpc.slurm` and `README.md` are updated to document the login-node `~/.pgpass` workflow.
