### PR TITLE
fix: add --comment so Claude Code Review posts inline PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

Fixes #248. The `Claude Code Review` workflow (triggered by the `claude-review` label) runs the review successfully but never posts feedback to the PR. The `code-review` skill's default mode reviews and prints findings without posting; this PR appends `--comment` to the workflow's `prompt:` so the skill posts its findings as inline PR comments (authored by `claude[bot]` via the Claude GitHub App token).

Evidence from the PR #245 run (29229967564): the run completed with `is_error: false`, but the comment-posting step ended with `No buffered inline comments` — the skill never entered comment mode, so nothing was buffered to post. Token permissions were ruled out: the sibling `claude.yml` workflow posts fine with an identical read-only `permissions` block.

## Change Type

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [x] Infrastructure change (CI, config, dependencies)
- [ ] Documentation only
- [ ] Performance-impacting change

## Methodological Impact

None

## Data Impact

None

## Breaking Changes

None

## Tests

No test coverage applies — this is a one-line CI workflow configuration change.

**Verification must happen post-merge.** Testing on this PR itself does not work: `claude-code-action` refuses to run when the workflow file on the PR branch differs from the copy on the default branch (anti-tampering check during the OIDC → app-token exchange). Labeling this PR confirmed that — run [29388740286](https://github.com/bkelly-lab/jkp-data/actions/runs/29388740286) skipped with `Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.`

Post-merge verification plan: add the `claude-review` label to any open PR (one that does not modify the workflow file) and confirm review feedback from `claude[bot]` appears.

**Why `--comment` is the fix** (plugin source, pinned to current `main`):

- The `/code-review` command's own instructions, [step 7](https://github.com/anthropics/claude-code/blob/db8834ba1d72e9a26fba30ac85f3bc4316bb0689/plugins/code-review/commands/code-review.md#L62-L67):
  > If `--comment` argument was NOT provided, stop here. **Do not post any GitHub comments.**
  > If `--comment` argument IS provided and NO issues were found, post a summary comment using `gh pr comment` and stop.
  > If `--comment` argument IS provided and issues were found, continue to step 8 [→ step 9 posts inline comments].
- The [plugin README](https://github.com/anthropics/claude-code/blob/db8834ba1d72e9a26fba30ac85f3bc4316bb0689/plugins/code-review/README.md): `--comment`: Post the review as a comment on the pull request (**default: outputs to terminal only**).

This exactly matches the observed PR #245 behavior: the review ran, stopped at step 7, and the action's post step found `No buffered inline comments`. The command's `allowed-tools` frontmatter already allowlists the posting tools (`Bash(gh pr comment:*)`, `mcp__github_inline_comment__create_inline_comment`), so the 6 permission denials on that run were unrelated exploratory calls, not blocked posting attempts.

## Checklist

- [ ] I have run the tests locally (`pytest`) — N/A: YAML-only workflow change, no Python code touched
- [ ] I have run the linter locally (`ruff check src/jkp/data/ tests/`) — N/A: no Python code touched
- [ ] I have verified the pipeline runs successfully after my changes — N/A: does not affect the pipeline
- [ ] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

## Additional Notes

If the review still posts nothing after merging and labeling a PR, the fallback diagnostic from #248 applies: inspect the new run's `permission_denials_count` and the `post-buffered-inline-comments` step output. (This is now less likely given the plugin-source evidence above — the posting tools are already in the command's allowlist.)
