### PR TITLE
fix: mask the WRDS password on the default postgres_scan download path

### DIFF
--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -702,6 +702,16 @@ def gen_wrds_connection_info(user, password: str | None = None) -> str:
 
     When ``password`` is ``None`` the ``password=`` field is omitted, so libpq
     authenticates from ``$PGPASSFILE`` / ``~/.pgpass`` instead.
+
+    Password-masking note: DuckDB's *statement* echo (``LINE 1: ...``) is a caret-centered window
+    with front elision (``...``), not a head-anchored cut, so field ordering does NOT make it safe --
+    a left cut whose window starts inside the password leaves only a tail fragment, and ``password=``
+    coming last actually maximizes that tail exposure. This isn't defended here by ordering; it's
+    defended downstream: connection-stage errors echo the full conninfo untruncated (detection fires
+    and masks), and the guards use fragment-tolerant detection that fails closed on a truncated echo
+    (see :func:`_password_leak_in_error`, which also notes the one gap -- a truncated echo that
+    retains fewer than 8 consecutive form characters). A truncated statement echo is also unreachable
+    through the current call sites, whose SQL templates are fixed and conninfo is ``_sql_literal``d.
     """
     parts = [
         f"host={WRDS_HOST}",
@@ -725,9 +735,10 @@ def gen_wrds_connection_info(user, password: str | None = None) -> str:
 def _password_forms(password: str) -> tuple[str, str, str]:
     """The forms the password can take on its way into an error message: raw, the
     libpq-escaped conninfo form (echoed by a connection IOException), and the
-    SQL-escaped-then-libpq-escaped form (echoed from the raw statement text by a
-    parser error). Ordered most-escaped first so redaction replaces the longest
-    match before its shorter substrings."""
+    libpq-escaped form with SQL-escaping applied on top (echoed from the raw statement
+    text by a parser error -- ``_sql_literal(_pg_escape_value(pw))``, libpq first then SQL).
+    Ordered most-escaped first so redaction replaces the longest match before its shorter
+    substrings."""
     escaped = _pg_escape_value(password)
     return (_sql_literal(escaped), escaped, password)
 
@@ -735,23 +746,207 @@ def _password_forms(password: str) -> tuple[str, str, str]:
 def _password_in_error(text: str, password: str) -> bool:
     """True if the password appears in ``text`` in any of the forms it can take in
     an error message (see :func:`_password_forms`)."""
+    if not password:  # an empty password has no forms to find; "" is a substring of everything
+        return False
     return any(form in text for form in _password_forms(password))
 
 
 def _redact_password(text: str, password: str) -> str:
     """Replace the password with ``***`` in every form it can take in an error
     message (see :func:`_password_forms`)."""
+    if not password:  # guard against "" interleaving *** between every character
+        return text
     for form in _password_forms(password):
         text = text.replace(form, "***")
     return text
 
 
-def get_columns(conn, conninfo, lib, table):
-    cols = conn.execute(f"""
-        SELECT *
-        FROM postgres_scan('{_sql_literal(conninfo)}', '{lib}', '{table}')
-        LIMIT 0
-    """).description
+# A run of this many consecutive password-form characters in an error is treated as a leak. DuckDB's
+# ``LINE 1: ...`` statement excerpt is a caret-centered window with front elision that can slice a
+# password mid-string, leaving only a fragment that no complete-form check would catch (see
+# :func:`gen_wrds_connection_info`). Long enough that a coincidental match against real error text is
+# implausible for a real (high-entropy) WRDS password; a password made of common words could still
+# false-positive, which only over-masks (never leaks). It also bounds what fragment detection can
+# reach: an echo retaining fewer than this many consecutive form chars fails open -- see the
+# limitation in :func:`_password_leak_in_error`.
+_MIN_LEAK_FRAGMENT = 8
+
+
+def _password_leak_in_error(text: str, password: str) -> bool:
+    """True if the password appears in ``text`` in full *or* as a truncated fragment.
+
+    Connection-stage failures echo the full conninfo (a complete :func:`_password_forms` form
+    appears), but a statement-echo error can slice a form, leaving a prefix/suffix. Detection catches
+    both by scanning ``_MIN_LEAK_FRAGMENT``-char windows of ``text`` (bounded by the error length,
+    not the password length).
+
+    Known limitation -- short surviving runs: fragment matching needs a run of ``_MIN_LEAK_FRAGMENT``
+    consecutive form characters, so ANY echo that retains fewer than that (<= 7) consecutive form
+    chars fails open (re-raised raw), regardless of the password's length. A short password (every
+    form < 8 chars) hits this on *any* truncation and so is the guaranteed case; a longer password
+    hits it only when the cut happens to leave a <= 7-char run. This is not fixable by lowering the
+    window: any window short enough to catch a <= 7-char run (<= 6, <= 4, ...) false-positives on
+    ordinary error text, which would over-mask real diagnostics. It is a narrow gap -- the
+    truncated-echo path is unreachable through the current fixed, ``_sql_literal``-escaped call
+    sites -- so it is disclosed rather than papered over."""
+    if not password:
+        return False
+    forms = _password_forms(password)
+    if any(form in text for form in forms):  # fast path: a complete form is present
+        return True
+    if len(text) < _MIN_LEAK_FRAGMENT:
+        return False
+    for i in range(len(text) - _MIN_LEAK_FRAGMENT + 1):
+        window = text[i : i + _MIN_LEAK_FRAGMENT]
+        if any(window in form for form in forms):
+            return True
+    return False
+
+
+_GuardT = TypeVar("_GuardT")
+
+
+def _guard_password_errors(
+    password: str | None, transform: Callable[[str], str], fn: Callable[[], _GuardT]
+) -> _GuardT:
+    """Shared core for the password-leak guards below. Runs ``fn()`` and returns its result.
+
+    DuckDB's postgres extension embeds the full conninfo (including the password) in the error text
+    of a failed ``postgres_scan('...')`` / ``ATTACH '...'``. If ``fn`` raises an error whose text
+    carries the password (in any of the forms it can take -- see :func:`_password_forms`), re-raise
+    ``RuntimeError(transform(text))``. Errors that don't carry the password (e.g. a missing table)
+    propagate unchanged.
+
+    Channels through which the raw (password-bearing) error text could re-surface are closed:
+
+    1. The exception *chain*: the replacement is raised *outside* the ``except`` block, so the
+       original exception is not attached as ``__context__``/``__cause__`` and can't be recovered by
+       anything that walks the chain (Sentry-style capture). A context-manager form can't do this:
+       raising the replacement from ``__exit__`` runs while the body's exception is still the one
+       being handled, so Python sets it as the new exception's ``__context__`` (verified
+       empirically). The guard must therefore wrap the call itself and raise after the ``except``.
+    2. This frame's *locals*: the raise-site frame is the one ``pytest --showlocals`` (and
+       Sentry-style local capture) renders, and it is the only frame that holds the raw error
+       string, so its locals are dropped in ``finally`` before the traceback escapes. (Stdlib
+       ``logging`` with ``exc_info`` does *not* render locals, so it was never at risk.)
+    3. Exotic exits: if ``transform`` itself raises anything (a ``MemoryError``, or a
+       ``KeyboardInterrupt`` landing inside it), the raw text sits on its frame -- that
+       sub-traceback is dropped. If a ``KeyboardInterrupt`` lands in the microsecond detection
+       window instead, the raw exception would ride out as its ``__context__`` (severed) and on the
+       detection/guard frames (dropped by nulling the interrupt's traceback). Both leave the raw
+       text unreachable via the escaping exception's chain or frame locals.
+
+    Not in scope: caller frames still hold ``password``/``conninfo`` in their own locals; that
+    exposure is inherent to those call sites and can't be closed from here. Only the raw error text
+    -- unique to this frame -- is scrubbed.
+    """
+    text: str | None = None
+    try:
+        return fn()
+    except Exception as e:
+        try:
+            detail = str(e)  # inside the guarded region: a raising __str__ can't chain the raw
+            leaked = bool(password) and _password_leak_in_error(detail, password)
+        except BaseException as interrupt:  # e.g. Ctrl-C mid-detection, or a raising __str__
+            interrupt.__context__ = None  # don't chain the raw exception onto the interrupt
+            interrupt.__traceback__ = None  # drop the detection frame (holds the raw text)
+            raise
+        if not leaked:
+            raise
+        text = detail
+        del detail
+    try:
+        message = transform(text)
+    except BaseException as exc:  # MemoryError, or a Ctrl-C landing inside transform
+        exc.__traceback__ = None  # drop that sub-traceback (transform's frame holds the raw text)
+        raise
+    finally:
+        del text
+    try:
+        raise RuntimeError(message)
+    finally:
+        del password, transform, fn, message
+
+
+# Generic, password-free message. A connection failure echoes the full conninfo regardless of its
+# cause (bad password, DNS failure, TLS problem), so the hint names all the likely culprits rather
+# than misattributing every failure to credentials.
+_WRDS_QUERY_FAILED_MSG = (
+    "WRDS query failed. Check credentials, MFA approval, or network connectivity."
+)
+
+
+def _mask_password_errors(
+    password: str | None,
+    fn: Callable[[], _GuardT],
+    *,
+    message: str = _WRDS_QUERY_FAILED_MSG,
+) -> _GuardT:
+    """Run ``fn``, replacing a password-bearing failure with a generic ``message``.
+
+    Use for connection-establishing operations (ATTACH, the first ``postgres_scan`` probe), where a
+    failure most likely means bad credentials and a friendly hint is more useful than the raw error.
+    """
+    return _guard_password_errors(password, lambda _text: message, fn)
+
+
+def _redact_password_errors(
+    password: str | None, fn: Callable[[], _GuardT], *, context: str | None = None
+) -> _GuardT:
+    """Run ``fn``, re-raising a password-bearing failure with only the secret scrubbed.
+
+    Use where a genuine diagnostic (e.g. a mid-download socket drop) is more useful than a credential
+    hint. Two of the three call sites are post-ATTACH -- the histogram query and the persistent
+    per-table download -- where the connection (and thus the password) already succeeded, so a later
+    failure is almost certainly a diagnostic. The default ``postgres_scan`` COPY also uses redact,
+    as a deliberate deviation: it opens a fresh connection per statement, so a bad password *can*
+    first surface there (see its call-site comment), but the preceding ``get_columns`` probe already
+    established the credentials, so a COPY failure is far more likely a real mid-transfer error --
+    worth keeping over a misattributed credential message. Either way the fail-closed check below
+    guarantees no secret survives. Keeps the real error text minus the password (cf.
+    :func:`_redact_password`), matching the parallel worker's policy. ``context`` (e.g. a table name)
+    is prefixed onto the scrubbed message so a failure in a per-item loop keeps its identity.
+
+    Fail-closed: :func:`_redact_password` replaces whole forms only, so redact then *re-check the
+    result* with the fragment-aware detector. If anything still matches -- the error was
+    fragment-only (no whole form to scrub), or it mixed a complete echo (scrubbed) with a sliced
+    ``LINE 1: ...`` excerpt (a fragment, not scrubbed) -- fall back to the generic mask message
+    rather than surface a partially-redacted error.
+    """
+
+    def _transform(text: str) -> str:
+        body = _redact_password(text, password or "")
+        if password and _password_leak_in_error(body, password):
+            body = _WRDS_QUERY_FAILED_MSG  # a fragment survived redaction: fail closed
+        return f"{context}: {body}" if context else body
+
+    return _guard_password_errors(password, _transform, fn)
+
+
+def get_columns(
+    conn: duckdb.DuckDBPyConnection,
+    conninfo: str,
+    lib: str,
+    table: str,
+    *,
+    password: str | None,
+) -> list[str]:
+    """Column names of a WRDS table read via ``postgres_scan``.
+
+    ``password`` is keyword-only and required (pass ``None`` only for the ``~/.pgpass`` path, which
+    has no secret in the conninfo) so a caller can't silently omit it and re-open the leak: on a
+    wrong/expired password DuckDB echoes the conninfo, so the probe is guarded.
+    """
+    cols = _mask_password_errors(
+        password,
+        lambda: (
+            conn.execute(f"""
+            SELECT *
+            FROM postgres_scan('{_sql_literal(conninfo)}', '{lib}', '{table}')
+            LIMIT 0
+        """).description
+        ),
+    )
     return [c[0] for c in cols]
 
 
@@ -832,23 +1027,37 @@ def download_wrds_table(
     filename: str,
     date_column: str | None = None,
     end_date: date | None = None,
+    *,
+    password: str | None,
 ) -> None:
+    """Download a WRDS table to ``filename`` via ``postgres_scan`` (optionally date-filtered).
+
+    ``password`` is keyword-only and required (pass ``None`` only for the ``~/.pgpass`` path) for
+    the same reason as :func:`get_columns`: it feeds the password-leak guards around the probe and
+    the COPY, so a caller can't silently omit it and re-open the leak.
+    """
     lib, table = table_name.split(".")
-    cols = get_columns(duckdb_conn, conninfo, lib, table)
+    cols = get_columns(duckdb_conn, conninfo, lib, table, password=password)
     projection = build_projection(cols)
 
     where_clause = ""
     if date_column and end_date:
         where_clause = f"WHERE {date_column} <= '{end_date}'"
 
-    duckdb_conn.execute(f"""
-        COPY (
-          SELECT {projection}
-          FROM postgres_scan('{_sql_literal(conninfo)}', '{lib}', '{table}')
-          {where_clause}
-        )
-        TO '{filename}' (FORMAT PARQUET);
-    """)
+    # postgres_scan opens a fresh connection per statement, so a wrong/expired password (or MFA
+    # denial) can first surface here at the COPY, not only at the get_columns probe. Redact rather
+    # than mask so a genuine mid-transfer diagnostic (e.g. a socket drop) survives with its detail.
+    _redact_password_errors(
+        password,
+        lambda: duckdb_conn.execute(f"""
+            COPY (
+              SELECT {projection}
+              FROM postgres_scan('{_sql_literal(conninfo)}', '{lib}', '{table}')
+              {where_clause}
+            )
+            TO '{filename}' (FORMAT PARQUET);
+        """),
+    )
 
 
 # The raw-data download is the one place in this pipeline that runs an explicit Python thread pool.
@@ -911,14 +1120,14 @@ def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str | 
     ATTACH error text, so on failure suppress the original exception and raise a generic,
     password-free error. Errors that don't contain the password propagate unchanged.
     """
-    try:
-        con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
-    except Exception as e:
-        if password and _password_in_error(str(e), password):
-            raise RuntimeError(
-                "Failed to attach WRDS connection. Check credentials and MFA approval."
-            ) from None
-        raise
+    _mask_password_errors(
+        password,
+        lambda: con.execute(
+            f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)"
+        ),
+        message="Failed to attach WRDS connection. Check credentials, MFA approval, or network "
+        "connectivity.",
+    )
 
 
 def _install_postgres_extension() -> None:
@@ -1034,7 +1243,13 @@ def _compute_histograms(
             con.execute("LOAD postgres;")  # extension installed once up front by the caller
             _attach_wrds(con, conninfo, password)
             try:
-                return table, _year_histogram(con, "wrds", lib, tbl, date_columns[table], end_date)
+                # Post-ATTACH: the password already authenticated, so redact (keep the diagnostic)
+                # rather than mask a genuine query/connection error as a credential problem.
+                hist = _redact_password_errors(
+                    password,
+                    lambda: _year_histogram(con, "wrds", lib, tbl, date_columns[table], end_date),
+                )
+                return table, hist
             finally:
                 with contextlib.suppress(Exception):
                     con.execute("DETACH wrds")
@@ -1439,19 +1654,32 @@ def download_raw_data_tables(
 
     if persistent_connection:
         # Use ATTACH for a single persistent connection (reduces MFA on NAT-rotated networks).
+        # ATTACH succeeded, so the password is valid, but a later per-table query can still echo the
+        # conninfo (e.g. if WRDS drops the socket mid-download and the reconnect fails) -- redact so
+        # that working password can't reach the terminal or Slurm log. Guard each table
+        # individually (with its name as context) so a mid-run failure keeps its identity instead
+        # of surfacing as a bare, table-less error, mirroring the parallel worker's per-task prefix.
         _attach_wrds(con, conninfo, password)
         try:
             for table in table_names:
-                download_wrds_table_attached(
-                    con,
-                    "wrds",
-                    table,
-                    filenames[table],
-                    date_column=date_columns.get(table),
-                    end_date=end_date,
+                _redact_password_errors(
+                    password,
+                    lambda t=table: download_wrds_table_attached(
+                        con,
+                        "wrds",
+                        t,
+                        filenames[t],
+                        date_column=date_columns.get(t),
+                        end_date=end_date,
+                    ),
+                    context=table,
                 )
         finally:
-            con.execute("DETACH wrds")
+            # A DETACH on a connection dropped mid-download would itself raise and displace the
+            # redacted error (which then survives only as __context__), burying the diagnostic.
+            # Suppress it, matching _compute_histograms and the parallel worker.
+            with contextlib.suppress(Exception):
+                con.execute("DETACH wrds")
     else:
         # Use postgres_scan() which creates a new connection per query (default)
         for table in table_names:
@@ -1462,6 +1690,7 @@ def download_raw_data_tables(
                 filenames[table],
                 date_column=date_columns.get(table),
                 end_date=end_date,
+                password=password,
             )
 
     con.close()

--- a/tests/unit/test_download_and_config.py
+++ b/tests/unit/test_download_and_config.py
@@ -254,6 +254,7 @@ class TestDownloadWrdsTable:
             filename="out.parquet",
             date_column=date_column,
             end_date=end_date,
+            password=None,
         )
         return mock_conn.execute.call_args[0][0]
 

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -197,6 +197,66 @@ class TestGenWrdsConnectionInfo:
         assert _password_in_error(err, pw)
         assert composed not in _redact_password(err, pw)
 
+    def test_empty_password_is_a_noop(self):
+        """An empty password has no forms to find/replace. Without an early-out, "" is a substring
+        of everything: _password_in_error would report a match and _redact_password would interleave
+        *** between every character. Guard against that footgun (it's truthiness-gated in the guards,
+        but the helpers must be safe on their own)."""
+        from jkp.data.aux_functions import (
+            _password_in_error,
+            _password_leak_in_error,
+            _redact_password,
+        )
+
+        text = "IO Error: connection reset by peer"
+        assert _password_in_error(text, "") is False
+        assert _password_leak_in_error(text, "") is False
+        assert _redact_password(text, "") == text
+
+    def test_password_leak_detects_truncated_fragment(self):
+        """A truncated statement echo (DuckDB's caret-centered ``LINE 1: ...`` window) can slice a
+        password, leaving only a tail fragment with no complete form. _password_in_error misses that
+        (whole forms only); _password_leak_in_error must catch a >= 8-char fragment so the guard
+        doesn't fail open."""
+        from jkp.data.aux_functions import _password_in_error, _password_leak_in_error
+
+        password = "SEKRIT-abcdefghijklmnop"  # noqa: S105
+        # Front-elided echo: the head (incl. `password='`) is cut; a 12-char tail survives.
+        truncated = (
+            "Parser Error: syntax error\n\nLINE 1: ...efghijklmnop', 'comp', 'funda')) TO 'x'"
+        )
+        assert password not in truncated  # no complete form present...
+        assert _password_in_error(truncated, password) is False  # ...so the whole-form check misses
+        assert (
+            _password_leak_in_error(truncated, password) is True
+        )  # ...but the fragment check hits
+
+    def test_password_leak_ignores_short_coincidental_runs(self):
+        """Fragment matching needs a run of >= 8 password chars, so a short coincidental overlap
+        (here 'reset' happens to be inside the password) does not trigger a false leak."""
+        from jkp.data.aux_functions import _password_leak_in_error
+
+        password = "reset-Xq"  # noqa: S105  # 'reset' overlaps common error text, but only 5 chars
+        assert _password_leak_in_error("IO Error: connection reset by peer", password) is False
+
+    def test_truncation_below_fragment_length_is_a_documented_gap(self):
+        """Documented limitation, not a bug: detection needs a run of _MIN_LEAK_FRAGMENT consecutive
+        form chars, so ANY echo retaining <= 7 of them fails open -- regardless of password length. A
+        short password is the guaranteed case (any truncation); a long password hits it only when the
+        cut leaves a <= 7-char run. Intentional -- any window short enough to catch a <= 7-char run
+        would false-positive on ordinary error text (see _password_leak_in_error). Pinned so the
+        boundary is a conscious choice: if you make this pass, you have changed the detection
+        contract."""
+        from jkp.data.aux_functions import _password_leak_in_error
+
+        short = "hunter2"  # noqa: S105  # 7 chars: every truncation leaves <= 6
+        assert _password_leak_in_error("... password=hunter2 ...", short) is True  # full: caught
+        assert _password_leak_in_error("LINE 1: ...unter2', 'comp')", short) is False  # tail: not
+
+        # A LONG password truncated to a 7-char surviving run also fails open -- not a length issue.
+        long = "SEKRIT-abcdefghijklmnop"  # noqa: S105
+        assert _password_leak_in_error("LINE 1: ...klmnop', 'comp')", long) is False  # 6-char tail
+
 
 class TestDownloadRawDataTablesBranching:
     """Tests for download_raw_data_tables() branching logic.
@@ -286,6 +346,92 @@ class TestDownloadRawDataTablesBranching:
 
         download_raw_data_tables(test_paths, "user", "pass", persistent_connection=True)
         mock_conn.close.assert_called_once()
+
+    def test_sequential_postgres_scan_masks_password_end_to_end(self, mock_duckdb, test_paths):
+        """Default-flag download: a wrong password surfaced by the first postgres_scan probe must
+        not leak through the orchestrator (issue #250). Exercises the real get_columns/
+        download_wrds_table and pins the ``password=`` plumbing at the sequential call site.
+
+        The broad ``pytest.raises(Exception)`` only proves *something* raised; the ``credentials``
+        assertion below is what makes this strict (that the leak was masked). Do not drop it."""
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        _mock, mock_conn = mock_duckdb
+        password = "topsecret"  # noqa: S105
+
+        def execute(sql, *args):
+            if "LIMIT 0" in sql:  # get_columns probe -> first postgres_scan, wrong password
+                raise RuntimeError(f"IO Error: Connection failed: password={password} dbname=wrds")
+            return MagicMock(description=[("col1",), ("col2",)])
+
+        mock_conn.execute.side_effect = execute  # side_effect overrides the fixture's return_value
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011
+            download_raw_data_tables(test_paths, "user", password, end_date=dt.date(2025, 12, 31))
+        assert password not in str(exc_info.value)
+        assert "credentials" in str(exc_info.value).lower()
+
+    def test_persistent_connection_redacts_password_end_to_end(self, mock_duckdb, test_paths):
+        """Persistent-connection path: ATTACH succeeds (valid password), but a later per-table
+        query that echoes the conninfo must not leak that working password (issue #250 sibling).
+
+        As above, the ``connection reset`` assertion (redaction kept the real diagnostic) is what
+        makes the broad ``pytest.raises`` strict -- do not drop it."""
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        _mock, mock_conn = mock_duckdb
+        password = "topsecret"  # noqa: S105
+
+        def execute(sql, *args):
+            # ATTACH / LOAD / the LIMIT 0 probe succeed; the COPY drops the socket mid-download.
+            if "COPY" in sql:
+                raise RuntimeError(f"IO Error: password={password} dbname=wrds connection reset")
+            return MagicMock(description=[("col1",), ("col2",)])
+
+        mock_conn.execute.side_effect = execute  # side_effect overrides the fixture's return_value
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011
+            download_raw_data_tables(
+                test_paths,
+                "user",
+                password,
+                end_date=dt.date(2025, 12, 31),
+                persistent_connection=True,
+            )
+        msg = str(exc_info.value)
+        assert password not in msg
+        assert "connection reset" in msg  # redaction keeps the real diagnostic
+        # Per-table guard tags the failing table so a mid-run failure keeps its identity. The first
+        # table in the canonical list is comp.exrt_dly, so its COPY is the one that fails here.
+        assert msg.startswith("comp.exrt_dly: ")
+
+    def test_persistent_detach_failure_does_not_bury_redacted_error(self, mock_duckdb, test_paths):
+        """The mid-download socket-drop scenario: the COPY fails (redacted, password-free) AND the
+        DETACH in the finally then fails on the dead connection. The DETACH must be suppressed, or it
+        would displace the redacted per-table diagnostic (which then survives only as __context__)."""
+        from jkp.data.aux_functions import download_raw_data_tables
+
+        _mock, mock_conn = mock_duckdb
+        password = "topsecret"  # noqa: S105
+
+        def execute(sql, *args):
+            if "COPY" in sql:
+                raise RuntimeError(f"IO Error: password={password} dbname=wrds connection reset")
+            if "DETACH" in sql:
+                raise RuntimeError("Cannot DETACH: connection already closed")
+            return MagicMock(description=[("col1",), ("col2",)])
+
+        mock_conn.execute.side_effect = execute
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011
+            download_raw_data_tables(
+                test_paths,
+                "user",
+                password,
+                end_date=dt.date(2025, 12, 31),
+                persistent_connection=True,
+            )
+        msg = str(exc_info.value)
+        assert "connection reset" in msg  # the redacted COPY diagnostic survived...
+        assert "DETACH" not in msg  # ...and the DETACH failure did not displace it
+        assert password not in msg
 
 
 class TestGetColumnsAttached:
@@ -889,19 +1035,24 @@ class TestDateRangeSplitting:
 
 
 class TestAttachWrds:
-    """The shared WRDS ATTACH helper (password redaction)."""
+    """The shared WRDS ATTACH helper (password masking -- _attach_wrds uses _mask_password_errors,
+    so a leak surfaces the generic credential message, not a redacted error)."""
 
-    def test_redacts_password_on_attach_error(self):
+    def test_masks_password_on_attach_error(self):
         from jkp.data.aux_functions import _attach_wrds
 
         con = MagicMock()
         con.execute.side_effect = RuntimeError("ATTACH failed: host=x password=hunter2 dbname=wrds")
         with pytest.raises(RuntimeError) as exc_info:
             _attach_wrds(con, "host=x password=hunter2", "hunter2")
-        assert "hunter2" not in str(exc_info.value)
-        assert "credentials" in str(exc_info.value).lower()
+        msg = str(exc_info.value)
+        assert "hunter2" not in msg
+        assert "credentials" in msg.lower()
+        # Pin the ATTACH-specific message so a dropped `message=` (falling back to the generic
+        # get_columns text) is caught, not silently accepted.
+        assert "attach" in msg.lower()
 
-    def test_redacts_special_char_password_on_attach_error(self):
+    def test_masks_special_char_password_on_attach_error(self):
         """The escaped form of a special-character password is what appears in the
         ATTACH error, so detection must match it — a raw ``password in str(e)``
         would miss it and re-raise the secret."""
@@ -923,6 +1074,319 @@ class TestAttachWrds:
         # A non-credential error (no password in it) propagates unchanged.
         with pytest.raises(RuntimeError, match="too many connections"):
             _attach_wrds(con, "host=x password=hunter2", "hunter2")
+
+
+class TestPostgresScanPasswordMasking:
+    """The default sequential postgres_scan() download path must not leak the password.
+
+    Unlike the ATTACH path (see TestAttachWrds), get_columns()/download_wrds_table() embed the
+    full conninfo in ``postgres_scan('...')`` SQL, so a wrong/expired password makes DuckDB echo
+    the conninfo — and thus the password — in the IOException it raises.
+    """
+
+    def test_get_columns_masks_password_on_error(self):
+        """get_columns()'s probe must scrub the password from a postgres_scan failure (#250).
+
+        The probe establishes the connection, so a failure most likely means bad credentials —
+        hence the generic credential-check message (mask), not a redacted raw error."""
+        from jkp.data.aux_functions import get_columns
+
+        password = "topsecret"  # noqa: S105
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError(
+            f"IO Error: Connection failed: host=x password={password} dbname=wrds"
+        )
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011
+            get_columns(conn, f"host=x password={password}", "comp", "funda", password=password)
+        assert password not in str(exc_info.value)
+        assert "credentials" in str(exc_info.value).lower()
+
+    def test_get_columns_requires_password_keyword(self):
+        """password is keyword-only and required, so a caller can't silently omit it and re-open
+        the leak (the fail-open regression shape). Omitting it is a TypeError, not a quiet no-op."""
+        from jkp.data.aux_functions import get_columns
+
+        with pytest.raises(TypeError):
+            get_columns(MagicMock(), "host=x", "comp", "funda")  # type: ignore[call-arg]
+
+    def test_download_wrds_table_requires_password_keyword(self):
+        """Same fail-open guard on download_wrds_table: omitting password is a TypeError, so a
+        reintroduced ``password=None`` default (which would disable masking) can't slip through."""
+        from jkp.data.aux_functions import download_wrds_table
+
+        with pytest.raises(TypeError):
+            download_wrds_table("host=x", MagicMock(), "comp.funda", "out.parquet")  # type: ignore[call-arg]
+
+    def test_download_wrds_table_redacts_password_on_copy_error(self):
+        """download_wrds_table()'s COPY runs after the probe already opened the connection, so a
+        failure there is a genuine diagnostic: redact the secret but keep the rest (#250)."""
+        from jkp.data.aux_functions import download_wrds_table
+
+        password = "topsecret"  # noqa: S105
+
+        def execute(sql, *args):
+            # get_columns' LIMIT 0 probe succeeds; the COPY fails echoing the conninfo.
+            if "COPY" in sql:
+                raise RuntimeError(f"IO Error: host=x password={password} dbname=wrds table full")
+            return MagicMock(description=[("col_a",), ("col_b",)])
+
+        conn = MagicMock()
+        conn.execute.side_effect = execute
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011
+            download_wrds_table(
+                f"host=x password={password}",
+                conn,
+                "comp.funda",
+                "out.parquet",
+                password=password,
+            )
+        msg = str(exc_info.value)
+        assert password not in msg
+        assert "table full" in msg  # redaction preserves the diagnostic
+
+    def test_masked_error_does_not_leak_via_exception_chain(self):
+        """The password must be gone from the whole chain, not just str(e): a context-manager guard
+        scrubs the message but leaves the original on __context__, which Sentry-style chain-walking
+        recovers. The guard wraps the call and raises outside the except, so the chain is clean."""
+        from jkp.data.aux_functions import get_columns
+
+        password = "topsecret"  # noqa: S105
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError(f"IO Error: password={password} dbname=wrds")
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011
+            get_columns(conn, f"host=x password={password}", "comp", "funda", password=password)
+
+        node: BaseException | None = exc_info.value
+        while node is not None:
+            assert password not in str(node)
+            node = node.__context__ or node.__cause__
+
+    def test_guard_frame_does_not_retain_raw_error_in_locals(self):
+        """The raise-site frame (_guard_password_errors) is what ``pytest --showlocals`` /
+        Sentry-style local capture render, and it is the only frame that holds the raw
+        password-bearing error text. It must drop that from its locals. A unique marker present
+        *only* in the raw error (not in the password or conninfo, so caller-frame locals can't
+        account for it) must not survive in that frame's locals."""
+        import traceback
+
+        from jkp.data.aux_functions import get_columns
+
+        password = "topsecret"  # noqa: S105
+        marker = "RAWERR_MARKER_9x8y7z"  # appears only inside the raw DuckDB error string
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError(
+            f"IO Error: password={password} dbname=wrds {marker}"
+        )
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011
+            get_columns(conn, f"host=x password={password}", "comp", "funda", password=password)
+
+        assert marker not in str(exc_info.value)
+        guard_frames = [
+            frame
+            for frame, _lineno in traceback.walk_tb(exc_info.value.__traceback__)
+            if frame.f_code.co_name == "_guard_password_errors"
+        ]
+        assert guard_frames, "guard frame not found in traceback"
+        for frame in guard_frames:
+            assert marker not in repr(frame.f_locals)
+
+    @staticmethod
+    def _raw_reachable(exc: BaseException, sentinel: str) -> bool:
+        """True if ``sentinel`` is reachable from ``exc`` via its chain (``str``) or ANY traceback
+        frame's locals. ``sentinel`` must be a string that exists ONLY inside the raw error text --
+        never as a standalone test local -- so a hit means the raw error survived on some frame.
+        (An earlier version filtered by frame name and so skipped the transform/callback frames
+        where these leaks actually live, letting mutants pass; search every frame instead.)"""
+        node: BaseException | None = exc
+        while node is not None:
+            if sentinel in str(node):
+                return True
+            tb = node.__traceback__
+            while tb is not None:
+                if sentinel in repr(tb.tb_frame.f_locals):
+                    return True
+                tb = tb.tb_next
+            node = node.__context__ or node.__cause__
+        return False
+
+    def test_transform_failure_does_not_leak_raw_text(self):
+        """Exotic exit: if the transform itself raises (realistically MemoryError), the raw text is
+        on the transform's frame. That sub-traceback must be dropped so it can't be walked out.
+
+        The sentinel is an inline literal that appears only inside the raised error's text (never as
+        a standalone local), so _raw_reachable's all-frames search can't false-hit a test local -- a
+        hit means the transform frame's ``_text`` survived (which reverting exc.__traceback__=None
+        would cause)."""
+        from jkp.data.aux_functions import _guard_password_errors
+
+        password = "topsecret"  # noqa: S105
+
+        def boom():
+            raise RuntimeError(f"IO Error: password={password} dbname=wrds RAWSENTINEL_XFORM_MEM")
+
+        def bad_transform(_text):
+            raise MemoryError("out of memory")
+
+        with pytest.raises(MemoryError) as exc_info:
+            _guard_password_errors(password, bad_transform, boom)
+        # Compute on its own line, NOT inline in the assert: pytest's assertion rewriter binds the
+        # literal argument to a temp local in this frame, and this frame is in the traceback being
+        # walked, so an inline sentinel would false-hit.
+        reachable = self._raw_reachable(exc_info.value, "RAWSENTINEL_XFORM_MEM")
+        assert not reachable
+
+    def test_interrupt_during_detection_does_not_leak(self):
+        """Exotic exit: a Ctrl-C landing in the detection window must not carry the raw exception
+        out on the KeyboardInterrupt's chain, nor on the detection/guard frames."""
+        from jkp.data.aux_functions import _guard_password_errors
+
+        password = "topsecret"  # noqa: S105
+
+        def boom():
+            raise RuntimeError(f"IO Error: password={password} dbname=wrds RAWSENTINEL_DETECT")
+
+        def interrupt_detection(_text, _password):
+            raise KeyboardInterrupt
+
+        with (
+            patch("jkp.data.aux_functions._password_leak_in_error", interrupt_detection),
+            pytest.raises(KeyboardInterrupt) as exc_info,
+        ):
+            _guard_password_errors(password, lambda t: t, boom)
+        assert exc_info.value.__context__ is None  # chain severed
+        reachable = self._raw_reachable(exc_info.value, "RAWSENTINEL_DETECT")  # own line: see above
+        assert not reachable
+
+    def test_interrupt_during_transform_does_not_leak(self):
+        """Sibling of the above: a Ctrl-C landing *inside* transform (not the detection window) is a
+        BaseException, so the transform escape hatch must catch BaseException -- not just Exception
+        -- or the raw text rides out on transform's frame."""
+        from jkp.data.aux_functions import _guard_password_errors
+
+        password = "topsecret"  # noqa: S105
+
+        def boom():
+            raise RuntimeError(f"IO Error: password={password} dbname=wrds RAWSENTINEL_XFORM_KI")
+
+        def interrupt_transform(_text):
+            raise KeyboardInterrupt
+
+        with pytest.raises(KeyboardInterrupt) as exc_info:
+            _guard_password_errors(password, interrupt_transform, boom)
+        reachable = self._raw_reachable(
+            exc_info.value, "RAWSENTINEL_XFORM_KI"
+        )  # own line: see above
+        assert not reachable
+
+    def test_redact_errors_prefixes_context(self):
+        """_redact_password_errors(..., context=table) tags the scrubbed message with the failing
+        item's identity, so a per-table loop failure isn't a bare, table-less error."""
+        from jkp.data.aux_functions import _redact_password_errors
+
+        password = "topsecret"  # noqa: S105
+
+        def boom():
+            raise RuntimeError(f"IO Error: password={password} dbname=wrds reset")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _redact_password_errors(password, boom, context="crsp.dsf_v2")
+        msg = str(exc_info.value)
+        assert msg.startswith("crsp.dsf_v2: ")
+        assert password not in msg
+        assert "reset" in msg  # diagnostic preserved
+
+    def test_redact_fails_closed_on_truncated_fragment(self):
+        """When only a truncated fragment matched (no complete form), _redact_password can't scrub
+        it, so the redact path must fail closed to the generic message -- not surface the raw error
+        with the password tail intact (issue #250, the truncated-echo fail-open)."""
+        from jkp.data.aux_functions import _password_in_error, _redact_password_errors
+
+        password = "SEKRIT-abcdefghijklmnop"  # noqa: S105
+        tail = "efghijklmnop', 'comp', 'funda')) TO 'x'"  # >=8-char fragment, no complete form
+
+        def boom():
+            raise RuntimeError(f"Parser Error: syntax error\n\nLINE 1: ...{tail}")
+
+        assert not _password_in_error(f"...{tail}", password)  # precondition: fragment only
+        with pytest.raises(RuntimeError) as exc_info:
+            _redact_password_errors(password, boom, context="crsp.dsf_v2")
+        msg = str(exc_info.value)
+        assert "efghijklmnop" not in msg  # the raw fragment must not survive
+        assert "credentials" in msg.lower()  # failed closed to the generic message
+        assert msg.startswith("crsp.dsf_v2: ")  # context still preserved
+
+    def test_redact_fails_closed_on_mixed_full_and_fragment_echo(self):
+        """The dangerous case: one error carries BOTH a complete conninfo echo AND an independent
+        truncated fragment (DuckDB can emit a header echo plus a sliced LINE 1: excerpt). Redacting
+        whole forms leaves the fragment; the re-check on the redacted body must catch it and fail
+        closed, or the fragment ships inside 'redacted' output."""
+        from jkp.data.aux_functions import _redact_password_errors
+
+        password = "SEKRIT-abcdefghijklmnop"  # noqa: S105
+
+        def boom():
+            # complete form (scrubbable) AND a sliced tail fragment (not scrubbable) in one message
+            raise RuntimeError(
+                f"IO Error: ... password='{password}' ... connection dropped\n\n"
+                "LINE 1: ...efghijklmnop', 'crsp', 'msf_v2') TO 'out.parquet'"
+            )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _redact_password_errors(password, boom, context="crsp.msf_v2")
+        msg = str(exc_info.value)
+        assert "efghijklmnop" not in msg  # the sliced fragment must not survive the redaction
+        assert password not in msg
+        assert "credentials" in msg.lower()  # failed closed rather than ship a partial redaction
+
+    def test_get_columns_passes_through_non_password_error(self):
+        """A failure that doesn't carry the password propagates unchanged."""
+        from jkp.data.aux_functions import get_columns
+
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("Catalog Error: table does not exist")
+        with pytest.raises(RuntimeError, match="does not exist"):
+            get_columns(conn, "host=x password=hunter2", "comp", "nope", password="hunter2")
+
+    def test_get_columns_none_password_propagates_raw_error(self):
+        """The ~/.pgpass path passes password=None (no secret in the conninfo), so masking is a
+        no-op and the original error propagates unchanged."""
+        from jkp.data.aux_functions import get_columns
+
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("IO Error: connection reset by peer")
+        with pytest.raises(RuntimeError, match="connection reset by peer"):
+            get_columns(conn, "host=x sslmode=require", "comp", "funda", password=None)
+
+    def test_compute_histograms_query_failure_is_redacted(self):
+        """A histogram query (post-ATTACH) failure must not leak the password, but must keep the
+        real diagnostic (redaction, not the credential-check message) since the password is valid."""
+        from jkp.data.aux_functions import _compute_histograms
+
+        password = "topsecret"  # noqa: S105
+
+        def execute(sql, *args):
+            # ATTACH succeeds; the per-year COUNT(*) query fails echoing the conninfo.
+            if "EXTRACT(YEAR" in sql:
+                raise RuntimeError(f"IO Error: host=x password={password} dbname=wrds reset")
+            return MagicMock()
+
+        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
+            con = MagicMock()
+            con.__enter__.return_value = con
+            con.execute.side_effect = execute
+            mock_duckdb.connect.return_value = con
+            with pytest.raises(Exception) as exc_info:  # noqa: PT011
+                _compute_histograms(
+                    f"host=x password={password}",
+                    ["crsp.dsf_v2"],
+                    {"crsp.dsf_v2": "dlycaldt"},
+                    dt.date(2025, 12, 31),
+                    4,
+                    password,
+                )
+        msg = str(exc_info.value)
+        assert password not in msg
+        assert "reset" in msg  # redaction preserves the diagnostic
 
 
 class TestMapInterruptible:


### PR DESCRIPTION
## Summary

Fixes #250. `get_columns` and `download_wrds_table` ran `postgres_scan('{conninfo}', ...)` with the full libpq conninfo (including the password) embedded in the SQL, but had no password-masking wrapper. On a wrong or expired WRDS password, DuckDB's `IOException` echoes the conninfo, so the password landed in the terminal and in Slurm logs. This is the `postgres_scan` branch that `jkp build` runs by default (single worker, no `--persistent-connection`), so it is the most common path. The sibling paths (`_attach_wrds`, the parallel worker) were already masked; this closes the remaining gap.

The fix adds a shared password-leak guard used at every conninfo-bearing call site:

- **`_guard_password_errors`** wraps the risky call. On an error whose text carries the password it re-raises a password-free `RuntimeError`; other errors propagate unchanged. It raises *outside* the `except` block (so the original isn't chained on via `__context__`), drops the raw error text from the raise-site frame's locals, and closes two exotic exits (a `MemoryError`/`KeyboardInterrupt` inside the transform, and a `Ctrl-C` in the detection window).
- **`_mask_password_errors`** (generic credential/network message) for connection-establishing calls — the first `postgres_scan` probe and `_attach_wrds`.
- **`_redact_password_errors`** (keeps the real diagnostic minus the secret) for post-connection failures — the COPY, the persistent per-table loop, and the histogram query.
- **Fragment-tolerant detection**: DuckDB's caret-centered `LINE 1: ...` statement excerpt can slice a password mid-string, leaving a tail that no whole-form check would catch. Detection now matches truncated fragments, and the redact path **fails closed** to the generic message when only a fragment matched (it can't be reliably scrubbed).
- `password` is now **keyword-only and required** on `get_columns`/`download_wrds_table`, so a caller can't silently omit it and re-open the leak. `None` (the `~/.pgpass` path, where the conninfo has no secret) is still valid and disables masking.

Validated against real WRDS on an HPC login node and against real DuckDB 1.5.2: the leak reproduces, the guards detect/scrub the real error format across all failure modes, the happy path is unaffected, and the `.pgpass` path (password never in the conninfo) is confirmed to carry no secret.

## Change Type

- [x] Infrastructure change (CI, config, dependencies)

## Methodological Impact

None.

## Data Impact

None. No change to any values, columns, or methodology written to `data/processed/`.

## Breaking Changes

None to released datasets. Internal API: `get_columns` and `download_wrds_table` now take a keyword-only, required `password` argument (both are internal helpers with no external callers).

## Tests

Added a security-focused suite (`TestPostgresScanPasswordMasking` plus additions to `TestAttachWrds`, `TestGenWrdsConnectionInfo`, and `TestDownloadRawDataTablesBranching`): synthesized-leak masking/redaction, the required-keyword `TypeError`, exception-chain and frame-locals scrubbing, the transform-failure and Ctrl-C exotic exits, fragment detection + fail-closed redaction on a truncated echo, the per-table context prefix, and orchestrator-level end-to-end masking for both the sequential and persistent paths. The original synthesized-leak test fails before the fix and passes after. Full unit suite: 912 passed; ruff clean; pyright unchanged.

## Checklist

- [x] I have run the tests locally (`pytest`)
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [x] I have verified the pipeline runs successfully after my changes
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

## Additional Notes

Pre-existing behavior, not a regression — deferred out of #245 to keep that PR scoped to credential storage. No `CHANGELOG_DATA.md` entry (no data-output change).
