### PR TITLE
fix: make `jkp connect` actually verify the WRDS connection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ The pipeline has two entry points that run sequentially:
 - `src/jkp/data/aux_functions.py` — Core library: all characteristic calculations, data transformations, and I/O utilities
 - `src/jkp/data/portfolio.py` — Standalone factor portfolio construction script
 - `src/jkp/data/wrds_credentials.py` — WRDS credential resolution (env vars, system keyring, and the libpq `~/.pgpass` file)
+- `src/jkp/data/wrds_connection.py` — WRDS connection construction and verification (`gen_wrds_connection_info`, `verify_wrds_connection`), with password redaction on failure paths
 
 ### Data flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,8 @@ jkp-data/
 │           ├── main.py          # Pipeline orchestration
 │           ├── portfolio.py     # Factor portfolio construction
 │           ├── config.py        # Pipeline configuration
-│           └── wrds_credentials.py # WRDS credential management
+│           ├── wrds_credentials.py # WRDS credential management
+│           └── wrds_connection.py  # WRDS connection setup and verification
 ├── tests/                   # Test suite
 │   ├── conftest.py          # Shared fixtures
 │   └── unit/                # Unit tests

--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
      ```
      Kindly follow the prompts.
 
-     Note: If you need to change your password or credentials, run `jkp connect --reset` and then `jkp connect`
+     `jkp connect` opens a real WRDS connection, so a successful run confirms
+     that your credentials, connectivity, and MFA all work. A password typed at
+     the prompt is verified before it is stored, so a typo is never saved: just
+     run `jkp connect` again and re-enter it.
+
+     Note: if you have changed your password at WRDS, run `jkp connect --reset`
+     and then `jkp connect`.
 
    - **Credential precedence.** When the pipeline needs WRDS credentials, it
      resolves them from the `WRDS_USERNAME`/`WRDS_PASSWORD` environment

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -34,7 +34,13 @@ from .compustat_correction import (
 from .config import COLLECT_CHUNK_SIZE, CORRECTION_SPILL_COMPRESSION, END_DATE, MAIN_FILTERS
 from .output_writer import write_dataframe
 from .paths import DataPaths
-from .wrds_credentials import WRDS_DB, WRDS_HOST, WRDS_PORT
+from .wrds_connection import (
+    _attach_wrds,
+    _install_postgres_extension,
+    _redact_password,
+    _sql_literal,
+    gen_wrds_connection_info,
+)
 
 
 def fl_none():
@@ -675,77 +681,6 @@ def gen_crsp_sf(paths: DataPaths, freq):
     return result
 
 
-def _pg_escape_value(value: str) -> str:
-    """libpq-escape a conninfo value (user or password) for a single-quoted field.
-
-    libpq accepts single-quoted values with backslash-escaped ``\\`` and ``'``,
-    so quoting lets a value hold spaces or special characters without breaking the
-    conninfo. For the password this is also the form that appears in any error text
-    echoing the connection string, so the credential-masking checks reuse it rather
-    than matching the raw password.
-    """
-    return value.replace("\\", "\\\\").replace("'", "\\'")
-
-
-def _sql_literal(value: str) -> str:
-    """Escape a string for embedding inside a single-quoted DuckDB SQL literal.
-
-    The conninfo is interpolated into ``ATTACH '...'`` / ``postgres_scan('...')``
-    SQL, so any single quote it contains (e.g. around a libpq-quoted password)
-    must be doubled or it terminates the SQL string literal.
-    """
-    return value.replace("'", "''")
-
-
-def gen_wrds_connection_info(user, password: str | None = None) -> str:
-    """Build a libpq conninfo for WRDS.
-
-    When ``password`` is ``None`` the ``password=`` field is omitted, so libpq
-    authenticates from ``$PGPASSFILE`` / ``~/.pgpass`` instead.
-    """
-    parts = [
-        f"host={WRDS_HOST}",
-        f"port={WRDS_PORT}",
-        f"dbname={WRDS_DB}",
-        # Quote the username too: a space or quote in it would otherwise break
-        # libpq's conninfo parsing exactly as an unquoted password would.
-        f"user='{_pg_escape_value(user)}'",
-    ]
-    if password is not None:
-        # Single-quote and escape so a password containing spaces or special
-        # characters can't break the conninfo (or split the value, which would
-        # defeat the password-masking check in _attach_wrds). The conninfo is
-        # itself embedded in a single-quoted SQL literal at each use site, so
-        # callers must additionally pass it through _sql_literal.
-        parts.append(f"password='{_pg_escape_value(password)}'")
-    parts.append("sslmode=require")
-    return " ".join(parts)
-
-
-def _password_forms(password: str) -> tuple[str, str, str]:
-    """The forms the password can take on its way into an error message: raw, the
-    libpq-escaped conninfo form (echoed by a connection IOException), and the
-    SQL-escaped-then-libpq-escaped form (echoed from the raw statement text by a
-    parser error). Ordered most-escaped first so redaction replaces the longest
-    match before its shorter substrings."""
-    escaped = _pg_escape_value(password)
-    return (_sql_literal(escaped), escaped, password)
-
-
-def _password_in_error(text: str, password: str) -> bool:
-    """True if the password appears in ``text`` in any of the forms it can take in
-    an error message (see :func:`_password_forms`)."""
-    return any(form in text for form in _password_forms(password))
-
-
-def _redact_password(text: str, password: str) -> str:
-    """Replace the password with ``***`` in every form it can take in an error
-    message (see :func:`_password_forms`)."""
-    for form in _password_forms(password):
-        text = text.replace(form, "***")
-    return text
-
-
 def get_columns(conn, conninfo, lib, table):
     cols = conn.execute(f"""
         SELECT *
@@ -902,35 +837,6 @@ def _chunk_path(filename: str, i: int) -> str:
     """Per-chunk parquet path, e.g. .../crsp_dsf_v2.parquet -> .../crsp_dsf_v2.part00.parquet."""
     p = Path(filename)
     return str(p.with_name(f"{p.stem}.part{i:02d}{p.suffix}"))
-
-
-def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str | None) -> None:
-    """ATTACH the WRDS Postgres database read-only on an existing DuckDB connection.
-
-    DuckDB's postgres extension embeds the full connection string (including the password) in
-    ATTACH error text, so on failure suppress the original exception and raise a generic,
-    password-free error. Errors that don't contain the password propagate unchanged.
-    """
-    try:
-        con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
-    except Exception as e:
-        if password and _password_in_error(str(e), password):
-            raise RuntimeError(
-                "Failed to attach WRDS connection. Check credentials and MFA approval."
-            ) from None
-        raise
-
-
-def _install_postgres_extension() -> None:
-    """Install the DuckDB postgres extension once, up front (idempotent).
-
-    Doing it in the main thread means the parallel workers only ``LOAD`` it (a per-connection,
-    no-download operation), which avoids a concurrent-INSTALL race across the pool writing the same
-    extension file, and surfaces a fetch failure as one clean error here rather than N worker
-    tracebacks.
-    """
-    with duckdb.connect(":memory:") as con:
-        con.execute("INSTALL postgres;")
 
 
 _MapT = TypeVar("_MapT")

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -120,7 +120,9 @@ def connect(
 
     Opens a real WRDS connection (attaches the database read-only and runs a
     trivial query), so a successful run confirms credentials, connectivity,
-    and MFA all actually work. This triggers a WRDS Duo MFA push on every run.
+    and MFA all actually work. This may trigger a WRDS Duo MFA push: WRDS trusts a
+    username/IP pair for 30 days after a successful approval, so expect one on the
+    first run from a new IP and again once that window expires.
 
     Credential precedence (highest first):
 
@@ -147,10 +149,15 @@ def connect(
             typer.echo("Credentials reset.")
             return
 
-        creds = get_wrds_credentials()
-
+        # Imported before resolving credentials, not after: this is the process's
+        # first `duckdb` import, and a broken native wheel (GLIBC mismatch on an HPC
+        # node) raises ImportError, which is not in the except tuple below and so
+        # escapes to Typer's pretty-exception handler. That handler prints frame
+        # locals on typer < 0.23.0, and pyproject allows typer>=0.15.0 — so no
+        # plaintext password may be bound in this frame when the import runs.
         from .wrds_connection import verify_wrds_connection
 
+        creds = get_wrds_credentials()
         verify_wrds_connection(creds.username, creds.password)
         typer.echo(f"Connected as: {creds.username}")
     except (RuntimeError, ValueError, OSError) as exc:
@@ -161,6 +168,14 @@ def connect(
         # Their messages are password-free; surface the message and exit non-zero rather
         # than dumping a traceback.
         typer.echo(str(exc), err=True)
+        # A mistyped password is stored before it is ever verified, so the next run
+        # finds it, never re-prompts, and fails identically forever. --reset is the
+        # only way out, and it belongs here rather than in the wrds_connection
+        # messages, which pipeline workers share and for which it is not the fix.
+        typer.echo(
+            "If a stored password is wrong, run `jkp connect --reset` and re-enter credentials.",
+            err=True,
+        )
         raise typer.Exit(1) from exc
 
 

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -153,11 +153,13 @@ def connect(
 
         verify_wrds_connection(creds.username, creds.password)
         typer.echo(f"Connected as: {creds.username}")
-    except RuntimeError as exc:
-        # Credential resolution and connection verification raise RuntimeError
-        # for anticipated, actionable conditions (no/empty username, an
-        # unreadable ~/.pgpass, a failed WRDS attach). Surface the message and
-        # exit non-zero rather than dumping a traceback.
+    except (RuntimeError, ValueError, OSError) as exc:
+        # Anticipated, actionable failures from credential resolution and connection
+        # verification: RuntimeError (no/empty username, unreadable ~/.pgpass, a failed
+        # WRDS attach), ValueError (e.g. a password containing a newline), and OSError
+        # (e.g. an unwritable state dir when persisting the username / writing ~/.pgpass).
+        # Their messages are password-free; surface the message and exit non-zero rather
+        # than dumping a traceback.
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
 

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -120,7 +120,9 @@ def connect(
 
     Opens a real WRDS connection (attaches the database read-only and runs a
     trivial query), so a successful run confirms credentials, connectivity,
-    and MFA all actually work. This may trigger a WRDS Duo MFA push: WRDS trusts a
+    and MFA all actually work. A password entered at the prompt is verified
+    before it is stored, so a typo is never persisted and simply re-prompts on
+    the next run. This may trigger a WRDS Duo MFA push: WRDS trusts a
     username/IP pair for 30 days after a successful approval, so expect one on the
     first run from a new IP and again once that window expires.
 
@@ -157,8 +159,13 @@ def connect(
         # plaintext password may be bound in this frame when the import runs.
         from .wrds_connection import verify_wrds_connection
 
-        creds = get_wrds_credentials()
-        verify_wrds_connection(creds.username, creds.password)
+        # Injected rather than called on the result: on the freshly-prompted path the
+        # check has to run between the prompt and the store, which is inside
+        # get_wrds_credentials. It verifies every resolution path exactly once, so
+        # verifying again here would open a second connection (and risk a second Duo
+        # push). Passing the function also keeps the plaintext password out of this
+        # frame on the prompt path.
+        creds = get_wrds_credentials(verify=verify_wrds_connection)
         typer.echo(f"Connected as: {creds.username}")
     except (RuntimeError, ValueError, OSError) as exc:
         # Anticipated, actionable failures from credential resolution and connection
@@ -168,10 +175,12 @@ def connect(
         # Their messages are password-free; surface the message and exit non-zero rather
         # than dumping a traceback.
         typer.echo(str(exc), err=True)
-        # A mistyped password is stored before it is ever verified, so the next run
-        # finds it, never re-prompts, and fails identically forever. --reset is the
-        # only way out, and it belongs here rather than in the wrds_connection
-        # messages, which pipeline workers share and for which it is not the fix.
+        # Still worth pointing at: a password typed at the prompt is now verified
+        # before it is stored, but one that arrived from an env var, an entry
+        # predating this check, or a hand-edited ~/.pgpass can still be wrong, and
+        # resolution never re-prompts while a stored value exists. Kept at the CLI
+        # layer because the wrds_connection messages are shared with pipeline worker
+        # paths, where --reset is not the right advice.
         typer.echo(
             "If a stored password is wrong, run `jkp connect --reset` and re-enter credentials.",
             err=True,

--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -116,7 +116,11 @@ def connect(
         help="Reset stored WRDS credentials.",
     ),
 ) -> None:
-    """Test or configure the WRDS connection.
+    """Verify the WRDS connection, or configure/reset stored credentials.
+
+    Opens a real WRDS connection (attaches the database read-only and runs a
+    trivial query), so a successful run confirms credentials, connectivity,
+    and MFA all actually work. This triggers a WRDS Duo MFA push on every run.
 
     Credential precedence (highest first):
 
@@ -144,11 +148,16 @@ def connect(
             return
 
         creds = get_wrds_credentials()
+
+        from .wrds_connection import verify_wrds_connection
+
+        verify_wrds_connection(creds.username, creds.password)
         typer.echo(f"Connected as: {creds.username}")
     except RuntimeError as exc:
-        # Credential resolution raises RuntimeError for anticipated, actionable
-        # conditions (no/empty username, an unreadable ~/.pgpass). Surface the
-        # message and exit non-zero rather than dumping a traceback.
+        # Credential resolution and connection verification raise RuntimeError
+        # for anticipated, actionable conditions (no/empty username, an
+        # unreadable ~/.pgpass, a failed WRDS attach). Surface the message and
+        # exit non-zero rather than dumping a traceback.
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
 

--- a/src/jkp/data/wrds_connection.py
+++ b/src/jkp/data/wrds_connection.py
@@ -39,7 +39,7 @@ def _sql_literal(value: str) -> str:
 
 
 def gen_wrds_connection_info(
-    user, password: str | None = None, *, connect_timeout: int | None = None
+    user: str, password: str | None = None, *, connect_timeout: int | None = None
 ) -> str:
     """Build a libpq conninfo for WRDS.
 
@@ -97,17 +97,22 @@ def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str | 
     """ATTACH the WRDS Postgres database read-only on an existing DuckDB connection.
 
     DuckDB's postgres extension embeds the full connection string (including the password) in
-    ATTACH error text, so on failure suppress the original exception and raise a generic,
+    ATTACH error text, so on failure drop the original exception and raise a generic,
     password-free error. Errors that don't contain the password propagate unchanged.
     """
+    leaked = False
     try:
         con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
     except Exception as e:
-        if password and _password_in_error(str(e), password):
-            raise RuntimeError(
-                "Failed to attach WRDS connection. Check credentials and MFA approval."
-            ) from None
-        raise
+        if not (password and _password_in_error(str(e), password)):
+            raise
+        leaked = True
+    if leaked:
+        # Raised after the except block exits rather than with `from None` inside it. The
+        # interpreter clears the handled exception on exit, so __context__ is None here;
+        # `from None` only hides the chain from printed tracebacks, leaving the DuckDB
+        # error (whose text embeds the password) reachable on the exception object.
+        raise RuntimeError("Failed to attach WRDS connection. Check credentials and MFA approval.")
 
 
 def _install_postgres_extension() -> None:
@@ -135,6 +140,7 @@ def verify_wrds_connection(
     it must leave the user time to approve the Duo MFA push, so it defaults to 25s.
     """
     conninfo = gen_wrds_connection_info(username, password, connect_timeout=connect_timeout)
+    failed = False
     try:
         # Inside the try: INSTALL can itself fail (e.g. no network to DuckDB's
         # extension repo, plausible on the headless HPC nodes this targets), and
@@ -149,13 +155,15 @@ def verify_wrds_connection(
         # the failure text embeds the password; pass it through unchanged.
         raise
     except Exception:
-        # Any other failure (a failed INSTALL/LOAD, or the ~/.pgpass auth path where
-        # password is None and _attach_wrds re-raises the raw DuckDB exception, or a
-        # query error). Surface one actionable, password-free message so callers that
-        # only handle RuntimeError (e.g. `jkp connect`) exit cleanly instead of a
-        # traceback. Use `from None`, not `from e`: the raw DuckDB error can embed the
-        # conninfo/password, and chaining it as __cause__ would carry the secret on the
-        # exception object even though this message is clean.
+        # Any other failure (a failed INSTALL/LOAD, the ~/.pgpass auth path where password
+        # is None and _attach_wrds re-raises the raw DuckDB exception, or the probe query
+        # failing). Recorded here and raised below.
+        failed = True
+    if failed:
+        # Raised outside the handler for the same reason as in _attach_wrds: the raw DuckDB
+        # error can embed the conninfo and password, and `from None` would leave it on
+        # __context__. One actionable, password-free message also lets callers that only
+        # handle RuntimeError (e.g. `jkp connect`) exit cleanly instead of dumping a traceback.
         raise RuntimeError(
             "Failed to connect to WRDS. Check your network, credentials, and MFA approval."
-        ) from None
+        )

--- a/src/jkp/data/wrds_connection.py
+++ b/src/jkp/data/wrds_connection.py
@@ -123,7 +123,7 @@ def _install_postgres_extension() -> None:
 
 
 def verify_wrds_connection(
-    username: str, password: str | None, *, connect_timeout: int = 10
+    username: str, password: str | None, *, connect_timeout: int = 25
 ) -> None:
     """Open a real WRDS connection and confirm it is queryable.
 
@@ -131,8 +131,8 @@ def verify_wrds_connection(
     it. The ATTACH authenticates eagerly (opening the libpq connection triggers the
     WRDS Duo MFA push), so a successful return means credentials, connectivity, and
     MFA all succeeded. Raises :class:`RuntimeError` with a password-free message on
-    any failure. ``connect_timeout`` bounds how long libpq waits on an unreachable
-    host before failing.
+    any failure. ``connect_timeout`` bounds how long libpq waits before failing —
+    it must leave the user time to approve the Duo MFA push, so it defaults to 25s.
     """
     conninfo = gen_wrds_connection_info(username, password, connect_timeout=connect_timeout)
     _install_postgres_extension()

--- a/src/jkp/data/wrds_connection.py
+++ b/src/jkp/data/wrds_connection.py
@@ -1,0 +1,142 @@
+"""WRDS connection primitives.
+
+Builds the libpq conninfo for the WRDS Postgres endpoint, attaches it read-only
+on a DuckDB connection, and verifies connectivity. Kept separate from the heavy
+``aux_functions`` pipeline module so the CLI's ``jkp connect`` command can check
+a connection without importing the whole pipeline.
+
+Password handling: the password only ever appears inside the conninfo and the
+DuckDB ATTACH statement. DuckDB's postgres extension echoes the full connection
+string (password included) in ATTACH error text, so the masking helpers here
+detect and redact every escaped form the password can take in an error message.
+"""
+
+import duckdb
+
+from .wrds_credentials import WRDS_DB, WRDS_HOST, WRDS_PORT
+
+
+def _pg_escape_value(value: str) -> str:
+    """libpq-escape a conninfo value (user or password) for a single-quoted field.
+
+    libpq accepts single-quoted values with backslash-escaped ``\\`` and ``'``,
+    so quoting lets a value hold spaces or special characters without breaking the
+    conninfo. For the password this is also the form that appears in any error text
+    echoing the connection string, so the credential-masking checks reuse it rather
+    than matching the raw password.
+    """
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _sql_literal(value: str) -> str:
+    """Escape a string for embedding inside a single-quoted DuckDB SQL literal.
+
+    The conninfo is interpolated into ``ATTACH '...'`` / ``postgres_scan('...')``
+    SQL, so any single quote it contains (e.g. around a libpq-quoted password)
+    must be doubled or it terminates the SQL string literal.
+    """
+    return value.replace("'", "''")
+
+
+def gen_wrds_connection_info(
+    user, password: str | None = None, *, connect_timeout: int | None = None
+) -> str:
+    """Build a libpq conninfo for WRDS.
+
+    When ``password`` is ``None`` the ``password=`` field is omitted, so libpq
+    authenticates from ``$PGPASSFILE`` / ``~/.pgpass`` instead. When
+    ``connect_timeout`` is set, libpq gives up after that many seconds rather than
+    hanging on an unreachable host.
+    """
+    parts = [
+        f"host={WRDS_HOST}",
+        f"port={WRDS_PORT}",
+        f"dbname={WRDS_DB}",
+        # Quote the username too: a space or quote in it would otherwise break
+        # libpq's conninfo parsing exactly as an unquoted password would.
+        f"user='{_pg_escape_value(user)}'",
+    ]
+    if password is not None:
+        # Single-quote and escape so a password containing spaces or special
+        # characters can't break the conninfo (or split the value, which would
+        # defeat the password-masking check in _attach_wrds). The conninfo is
+        # itself embedded in a single-quoted SQL literal at each use site, so
+        # callers must additionally pass it through _sql_literal.
+        parts.append(f"password='{_pg_escape_value(password)}'")
+    parts.append("sslmode=require")
+    if connect_timeout is not None:
+        parts.append(f"connect_timeout={connect_timeout}")
+    return " ".join(parts)
+
+
+def _password_forms(password: str) -> tuple[str, str, str]:
+    """The forms the password can take on its way into an error message: raw, the
+    libpq-escaped conninfo form (echoed by a connection IOException), and the
+    SQL-escaped-then-libpq-escaped form (echoed from the raw statement text by a
+    parser error). Ordered most-escaped first so redaction replaces the longest
+    match before its shorter substrings."""
+    escaped = _pg_escape_value(password)
+    return (_sql_literal(escaped), escaped, password)
+
+
+def _password_in_error(text: str, password: str) -> bool:
+    """True if the password appears in ``text`` in any of the forms it can take in
+    an error message (see :func:`_password_forms`)."""
+    return any(form in text for form in _password_forms(password))
+
+
+def _redact_password(text: str, password: str) -> str:
+    """Replace the password with ``***`` in every form it can take in an error
+    message (see :func:`_password_forms`)."""
+    for form in _password_forms(password):
+        text = text.replace(form, "***")
+    return text
+
+
+def _attach_wrds(con: duckdb.DuckDBPyConnection, conninfo: str, password: str | None) -> None:
+    """ATTACH the WRDS Postgres database read-only on an existing DuckDB connection.
+
+    DuckDB's postgres extension embeds the full connection string (including the password) in
+    ATTACH error text, so on failure suppress the original exception and raise a generic,
+    password-free error. Errors that don't contain the password propagate unchanged.
+    """
+    try:
+        con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
+    except Exception as e:
+        if password and _password_in_error(str(e), password):
+            raise RuntimeError(
+                "Failed to attach WRDS connection. Check credentials and MFA approval."
+            ) from None
+        raise
+
+
+def _install_postgres_extension() -> None:
+    """Install the DuckDB postgres extension once, up front (idempotent).
+
+    Doing it in the main thread means the parallel workers only ``LOAD`` it (a per-connection,
+    no-download operation), which avoids a concurrent-INSTALL race across the pool writing the same
+    extension file, and surfaces a fetch failure as one clean error here rather than N worker
+    tracebacks.
+    """
+    with duckdb.connect(":memory:") as con:
+        con.execute("INSTALL postgres;")
+
+
+def verify_wrds_connection(
+    username: str, password: str | None, *, connect_timeout: int = 10
+) -> None:
+    """Open a real WRDS connection and confirm it is queryable.
+
+    Attaches the WRDS Postgres database read-only and runs a trivial query against
+    it. The ATTACH authenticates eagerly (opening the libpq connection triggers the
+    WRDS Duo MFA push), so a successful return means credentials, connectivity, and
+    MFA all succeeded. Raises :class:`RuntimeError` with a password-free message on
+    any failure. ``connect_timeout`` bounds how long libpq waits on an unreachable
+    host before failing.
+    """
+    conninfo = gen_wrds_connection_info(username, password, connect_timeout=connect_timeout)
+    _install_postgres_extension()
+    with duckdb.connect(":memory:") as con:
+        con.execute("LOAD postgres;")
+        _attach_wrds(con, conninfo, password)
+        con.execute("SELECT 1 FROM wrds.information_schema.schemata LIMIT 1")

--- a/src/jkp/data/wrds_connection.py
+++ b/src/jkp/data/wrds_connection.py
@@ -136,7 +136,18 @@ def verify_wrds_connection(
     """
     conninfo = gen_wrds_connection_info(username, password, connect_timeout=connect_timeout)
     _install_postgres_extension()
-    with duckdb.connect(":memory:") as con:
-        con.execute("LOAD postgres;")
-        _attach_wrds(con, conninfo, password)
-        con.execute("SELECT 1 FROM wrds.information_schema.schemata LIMIT 1")
+    try:
+        with duckdb.connect(":memory:") as con:
+            con.execute("LOAD postgres;")
+            _attach_wrds(con, conninfo, password)
+            con.execute("SELECT 1 FROM wrds.information_schema.schemata LIMIT 1")
+    except RuntimeError:
+        # _attach_wrds already raises a friendly, password-free RuntimeError when
+        # the failure text embeds the password; pass it through unchanged.
+        raise
+    except Exception as e:
+        # Any other failure (e.g. a ~/.pgpass auth path where password is None, so
+        # _attach_wrds re-raises the raw DuckDB exception, or a LOAD/query error).
+        # Surface one actionable, password-free message so callers that only handle
+        # RuntimeError (e.g. `jkp connect`) exit cleanly instead of dumping a traceback.
+        raise RuntimeError("Failed to connect to WRDS. Check credentials and MFA approval.") from e

--- a/src/jkp/data/wrds_connection.py
+++ b/src/jkp/data/wrds_connection.py
@@ -148,12 +148,14 @@ def verify_wrds_connection(
         # _attach_wrds already raises a friendly, password-free RuntimeError when
         # the failure text embeds the password; pass it through unchanged.
         raise
-    except Exception as e:
+    except Exception:
         # Any other failure (a failed INSTALL/LOAD, or the ~/.pgpass auth path where
         # password is None and _attach_wrds re-raises the raw DuckDB exception, or a
         # query error). Surface one actionable, password-free message so callers that
         # only handle RuntimeError (e.g. `jkp connect`) exit cleanly instead of a
-        # traceback.
+        # traceback. Use `from None`, not `from e`: the raw DuckDB error can embed the
+        # conninfo/password, and chaining it as __cause__ would carry the secret on the
+        # exception object even though this message is clean.
         raise RuntimeError(
             "Failed to connect to WRDS. Check your network, credentials, and MFA approval."
-        ) from e
+        ) from None

--- a/src/jkp/data/wrds_connection.py
+++ b/src/jkp/data/wrds_connection.py
@@ -135,8 +135,11 @@ def verify_wrds_connection(
     it must leave the user time to approve the Duo MFA push, so it defaults to 25s.
     """
     conninfo = gen_wrds_connection_info(username, password, connect_timeout=connect_timeout)
-    _install_postgres_extension()
     try:
+        # Inside the try: INSTALL can itself fail (e.g. no network to DuckDB's
+        # extension repo, plausible on the headless HPC nodes this targets), and
+        # that must be wrapped too, not left to escape as a raw traceback.
+        _install_postgres_extension()
         with duckdb.connect(":memory:") as con:
             con.execute("LOAD postgres;")
             _attach_wrds(con, conninfo, password)
@@ -146,8 +149,11 @@ def verify_wrds_connection(
         # the failure text embeds the password; pass it through unchanged.
         raise
     except Exception as e:
-        # Any other failure (e.g. a ~/.pgpass auth path where password is None, so
-        # _attach_wrds re-raises the raw DuckDB exception, or a LOAD/query error).
-        # Surface one actionable, password-free message so callers that only handle
-        # RuntimeError (e.g. `jkp connect`) exit cleanly instead of dumping a traceback.
-        raise RuntimeError("Failed to connect to WRDS. Check credentials and MFA approval.") from e
+        # Any other failure (a failed INSTALL/LOAD, or the ~/.pgpass auth path where
+        # password is None and _attach_wrds re-raises the raw DuckDB exception, or a
+        # query error). Surface one actionable, password-free message so callers that
+        # only handle RuntimeError (e.g. `jkp connect`) exit cleanly instead of a
+        # traceback.
+        raise RuntimeError(
+            "Failed to connect to WRDS. Check your network, credentials, and MFA approval."
+        ) from e

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -35,6 +35,7 @@ import os
 import re
 import sys
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -64,6 +65,13 @@ _LEGACY_USER_FILE = Path.home() / ".wrds_user"
 # differs from platformdirs on macOS/Windows — so we must use keyring's function,
 # not platformdirs, to find the file keyrings.alt actually wrote.
 _LEGACY_KEYRING_FILE = Path(_keyring_data_root()) / "keyring_pass.cfg"
+
+
+# Signature of the connectivity check injected into get_wrds_credentials. Taking it
+# as a parameter rather than importing it keeps the dependency one-way: wrds_connection
+# imports the WRDS endpoint constants from here, so importing the verifier back would
+# be a cycle. Called as verify(username, password); raises on failure.
+VerifyConnection = Callable[[str, str | None], None]
 
 
 @dataclass(frozen=True)
@@ -542,14 +550,27 @@ def _resolve_username(env_user: str | None = None) -> str:
     )
 
 
-def _prompt_and_store(username: str) -> Credentials:
-    """Interactively obtain a password and persist it to the best available store."""
+def _prompt_verify_store(username: str, verify: VerifyConnection | None = None) -> Credentials:
+    """Interactively obtain a password, verify it, and persist it to the best store.
+
+    Nothing is written until ``verify`` returns. A mistyped password would otherwise
+    be stored and then resolved by every later run, which never re-prompts — leaving
+    the user stuck until they find ``jkp connect --reset``. With ``verify=None`` the
+    password is stored unverified, which is the historical behavior.
+
+    On the no-keyring fallback the check runs against the typed password in the
+    conninfo and the ``~/.pgpass`` line is written afterwards, so it proves the
+    credential rather than the written file.
+    """
     password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
     if not password:
         # An empty password would be stored as a junk ``…:username:`` pgpass line
         # that later "resolves" while auth silently fails — reject it, mirroring
         # the empty-username guard.
         raise RuntimeError(f"Empty password entered for {username}; nothing stored.")
+    if verify is not None:
+        # Raises on failure, so every write below is unreachable for a bad password.
+        verify(username, password)
     # Cache the username alongside the stored password, so a credential provisioned
     # for an env-provided WRDS_USERNAME (which _resolve_username does not persist)
     # is still revocable via `jkp connect --reset` rather than orphaned.
@@ -581,7 +602,14 @@ def _no_credentials_error(username: str) -> RuntimeError:
     )
 
 
-def get_wrds_credentials() -> Credentials:
+def _verified(creds: Credentials, verify: VerifyConnection | None) -> Credentials:
+    """Run the injected connectivity check against already-stored credentials."""
+    if verify is not None:
+        verify(creds.username, creds.password)
+    return creds
+
+
+def get_wrds_credentials(verify: VerifyConnection | None = None) -> Credentials:
     """Resolve WRDS credentials following the documented precedence order.
 
     Steps:
@@ -590,6 +618,13 @@ def get_wrds_credentials() -> Credentials:
       3. Password: ``WRDS_PASSWORD`` → system keyring → ``~/.pgpass``/``$PGPASSFILE``.
       4. If nothing is found and a terminal is available, prompt and store;
          otherwise raise with actionable guidance.
+
+    ``verify`` is an optional connectivity check (in practice
+    ``wrds_connection.verify_wrds_connection``, injected rather than imported to keep
+    the module dependency one-way). When given it runs on every path exactly once —
+    before persisting on the freshly-prompted path, and as a plain check on the paths
+    that read an existing store — so callers must not verify the result again. Each
+    call opens a real WRDS connection, so a second check risks a second Duo MFA push.
     """
     # Strip before the truthiness check so WRDS_USERNAME="   " is treated as
     # unset rather than accepted as username="".
@@ -600,20 +635,20 @@ def get_wrds_credentials() -> Credentials:
         # "password"-named identifier flows into a logging sink — the value is
         # never logged, only the source label.
         _log_source("the WRDS_USERNAME/WRDS_PASSWORD environment variables")
-        return Credentials(env_user, env_pw)  # env_user already stripped/non-empty
+        return _verified(Credentials(env_user, env_pw), verify)  # env_user already stripped
 
     username = _resolve_username(env_user)
 
     if env_pw:
         _log_source("the WRDS_PASSWORD environment variable")
-        return Credentials(username, env_pw)
+        return _verified(Credentials(username, env_pw), verify)
 
     keyring_pw = _keyring_get(username)
     if keyring_pw:
         # The keyring supersedes any legacy plaintext copy; clean it up.
         _cleanup_legacy_keyring_section(username)
         _log_source("the system keyring")
-        return Credentials(username, keyring_pw)
+        return _verified(Credentials(username, keyring_pw), verify)
 
     # One-time migration off the legacy plaintext keyring, reached only when
     # neither an env password nor a system-keyring entry supplied the password.
@@ -646,10 +681,10 @@ def get_wrds_credentials() -> Credentials:
                 file=sys.stderr,
                 flush=True,
             )
-        return Credentials(username, None)
+        return _verified(Credentials(username, None), verify)
 
     if _interactive():
-        return _prompt_and_store(username)
+        return _prompt_verify_store(username, verify)
 
     raise _no_credentials_error(username)
 

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -43,7 +43,7 @@ import keyring.errors
 import platformdirs
 from keyring.util.platform_ import data_root as _keyring_data_root
 
-# WRDS Postgres endpoint. Shared with aux_functions.gen_wrds_connection_info so
+# WRDS Postgres endpoint. Shared with wrds_connection.gen_wrds_connection_info so
 # the conninfo host/port/db and the ~/.pgpass match key can never drift apart.
 WRDS_HOST = "wrds-pgdata.wharton.upenn.edu"
 WRDS_PORT = "9737"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -172,8 +172,10 @@ class TestConnectCommand:
         result = runner.invoke(app, ["connect"])
         assert result.exit_code == 0
         assert "testuser" in result.output
-        mock_get_creds.assert_called_once()
-        mock_verify.assert_called_once()
+        # The verifier is handed to the resolver rather than called on its result, so
+        # the freshly-prompted path can run it between the prompt and the store.
+        mock_get_creds.assert_called_once_with(verify=mock_verify)
+        mock_verify.assert_not_called()
 
     @patch("jkp.data.wrds_credentials.reset_credentials")
     def test_connect_reset(self, mock_reset):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -165,13 +165,15 @@ class TestPortfolioCommand:
 class TestConnectCommand:
     """Test the connect command routes to wrds_credentials correctly."""
 
+    @patch("jkp.data.wrds_connection.verify_wrds_connection")
     @patch("jkp.data.wrds_credentials.get_wrds_credentials")
-    def test_connect_shows_username(self, mock_get_creds):
+    def test_connect_shows_username(self, mock_get_creds, mock_verify):
         mock_get_creds.return_value = MagicMock(username="testuser")
         result = runner.invoke(app, ["connect"])
         assert result.exit_code == 0
         assert "testuser" in result.output
         mock_get_creds.assert_called_once()
+        mock_verify.assert_called_once()
 
     @patch("jkp.data.wrds_credentials.reset_credentials")
     def test_connect_reset(self, mock_reset):

--- a/tests/unit/test_cli_connect.py
+++ b/tests/unit/test_cli_connect.py
@@ -73,3 +73,24 @@ class TestConnectVerification:
         assert result.exit_code != 0
         combined = _strip_ansi(result.output) + _strip_ansi(result.stderr)
         assert password not in combined
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ValueError("WRDS password contains a newline"),
+            OSError("[Errno 30] Read-only file system: state dir"),
+        ],
+    )
+    @patch("jkp.data.wrds_credentials.get_wrds_credentials")
+    def test_credential_resolution_errors_exit_cleanly_without_traceback(self, mock_get_creds, exc):
+        """Credential resolution can raise ValueError (e.g. a newline password) or
+        OSError (e.g. an unwritable state dir) — the command must surface the message
+        and exit non-zero, not dump a raw traceback."""
+        mock_get_creds.side_effect = exc
+
+        result = runner.invoke(app, ["connect"])
+
+        assert result.exit_code != 0
+        assert str(exc) in _strip_ansi(result.stderr)
+        assert not isinstance(result.exception, (ValueError, OSError))
+        assert "Traceback" not in result.stderr

--- a/tests/unit/test_cli_connect.py
+++ b/tests/unit/test_cli_connect.py
@@ -1,0 +1,75 @@
+"""Tests for the `jkp connect` CLI command's WRDS verification path.
+
+Complements TestConnectCommand in test_cli.py, focusing on how the command
+surfaces verify_wrds_connection's success/failure and never leaks the
+credential password into CLI output.
+"""
+
+import re
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from jkp.data.cli import app
+from jkp.data.wrds_credentials import Credentials
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences (see test_cli.py's identical helper)."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+@pytest.mark.unit
+class TestConnectVerification:
+    """`connect` calls verify_wrds_connection and surfaces its outcome."""
+
+    @patch("jkp.data.wrds_connection.verify_wrds_connection")
+    @patch("jkp.data.wrds_credentials.get_wrds_credentials")
+    def test_success_exits_zero_and_reports_username(self, mock_get_creds, mock_verify):
+        mock_get_creds.return_value = Credentials(username="testuser", password="hunter2")
+        mock_verify.return_value = None
+
+        result = runner.invoke(app, ["connect"])
+
+        assert result.exit_code == 0
+        assert "Connected as:" in result.output
+        mock_verify.assert_called_once_with("testuser", "hunter2")
+
+    @patch("jkp.data.wrds_connection.verify_wrds_connection")
+    @patch("jkp.data.wrds_credentials.get_wrds_credentials")
+    def test_failure_exits_nonzero_with_message_on_stderr_no_traceback(
+        self, mock_get_creds, mock_verify
+    ):
+        mock_get_creds.return_value = Credentials(username="testuser", password="hunter2")
+        message = "Failed to attach WRDS connection. Check credentials and MFA approval."
+        mock_verify.side_effect = RuntimeError(message)
+
+        result = runner.invoke(app, ["connect"])
+
+        assert result.exit_code != 0
+        assert message in _strip_ansi(result.stderr)
+        # handled as a clean exit, not a leaked RuntimeError traceback
+        assert not isinstance(result.exception, RuntimeError)
+        assert "Traceback" not in result.stderr
+
+    @patch("jkp.data.wrds_connection.verify_wrds_connection")
+    @patch("jkp.data.wrds_credentials.get_wrds_credentials")
+    def test_password_never_appears_in_output(self, mock_get_creds, mock_verify):
+        """The real verify_wrds_connection already redacts the password before
+        raising; this pins the CLI to surfacing that message verbatim without
+        introducing a new leak (e.g. by echoing creds directly)."""
+        password = "s3cr3t-p@ss"  # noqa: S105
+        mock_get_creds.return_value = Credentials(username="testuser", password=password)
+        # Message the real code would raise: already password-free.
+        mock_verify.side_effect = RuntimeError(
+            "Failed to attach WRDS connection. Check credentials and MFA approval."
+        )
+
+        result = runner.invoke(app, ["connect"])
+
+        assert result.exit_code != 0
+        combined = _strip_ansi(result.output) + _strip_ansi(result.stderr)
+        assert password not in combined

--- a/tests/unit/test_cli_connect.py
+++ b/tests/unit/test_cli_connect.py
@@ -3,6 +3,11 @@
 Complements TestConnectCommand in test_cli.py, focusing on how the command
 surfaces verify_wrds_connection's success/failure and never leaks the
 credential password into CLI output.
+
+`connect` injects the verifier into get_wrds_credentials rather than calling it
+on the result, so that a freshly prompted password is checked before it is
+stored. Verification failures therefore reach the command as an exception out of
+get_wrds_credentials, which is how these tests simulate them.
 """
 
 import re
@@ -36,16 +41,20 @@ class TestConnectVerification:
 
         assert result.exit_code == 0
         assert "Connected as:" in result.output
-        mock_verify.assert_called_once_with("testuser", "hunter2")
+        # Passed through, not applied here: verifying the returned credentials again
+        # would open a second WRDS connection and risk a second Duo push.
+        mock_get_creds.assert_called_once_with(verify=mock_verify)
+        mock_verify.assert_not_called()
 
     @patch("jkp.data.wrds_connection.verify_wrds_connection")
     @patch("jkp.data.wrds_credentials.get_wrds_credentials")
     def test_failure_exits_nonzero_with_message_on_stderr_no_traceback(
         self, mock_get_creds, mock_verify
     ):
-        mock_get_creds.return_value = Credentials(username="testuser", password="hunter2")
         message = "Failed to attach WRDS connection. Check credentials and MFA approval."
-        mock_verify.side_effect = RuntimeError(message)
+        # The injected verifier raises inside the resolver, so the failure surfaces
+        # from get_wrds_credentials rather than from a separate call in the command.
+        mock_get_creds.side_effect = RuntimeError(message)
 
         result = runner.invoke(app, ["connect"])
 
@@ -62,9 +71,8 @@ class TestConnectVerification:
         raising; this pins the CLI to surfacing that message verbatim without
         introducing a new leak (e.g. by echoing creds directly)."""
         password = "s3cr3t-p@ss"  # noqa: S105
-        mock_get_creds.return_value = Credentials(username="testuser", password=password)
         # Message the real code would raise: already password-free.
-        mock_verify.side_effect = RuntimeError(
+        mock_get_creds.side_effect = RuntimeError(
             "Failed to attach WRDS connection. Check credentials and MFA approval."
         )
 

--- a/tests/unit/test_cli_connect.py
+++ b/tests/unit/test_cli_connect.py
@@ -41,6 +41,9 @@ class TestConnectVerification:
 
         assert result.exit_code == 0
         assert "Connected as:" in result.output
+        # The password reaches the command on this path, so this is where a leak
+        # would surface: `typer.echo(creds)` instead of `creds.username`.
+        assert "hunter2" not in _strip_ansi(result.output) + _strip_ansi(result.stderr)
         # Passed through, not applied here: verifying the returned credentials again
         # would open a second WRDS connection and risk a second Duo push.
         mock_get_creds.assert_called_once_with(verify=mock_verify)
@@ -63,24 +66,6 @@ class TestConnectVerification:
         # handled as a clean exit, not a leaked RuntimeError traceback
         assert not isinstance(result.exception, RuntimeError)
         assert "Traceback" not in result.stderr
-
-    @patch("jkp.data.wrds_connection.verify_wrds_connection")
-    @patch("jkp.data.wrds_credentials.get_wrds_credentials")
-    def test_password_never_appears_in_output(self, mock_get_creds, mock_verify):
-        """The real verify_wrds_connection already redacts the password before
-        raising; this pins the CLI to surfacing that message verbatim without
-        introducing a new leak (e.g. by echoing creds directly)."""
-        password = "s3cr3t-p@ss"  # noqa: S105
-        # Message the real code would raise: already password-free.
-        mock_get_creds.side_effect = RuntimeError(
-            "Failed to attach WRDS connection. Check credentials and MFA approval."
-        )
-
-        result = runner.invoke(app, ["connect"])
-
-        assert result.exit_code != 0
-        combined = _strip_ansi(result.output) + _strip_ansi(result.stderr)
-        assert password not in combined
 
     @pytest.mark.parametrize(
         "exc",

--- a/tests/unit/test_wrds_connection.py
+++ b/tests/unit/test_wrds_connection.py
@@ -189,6 +189,38 @@ class TestGenWrdsConnectionInfo:
 class TestVerifyWrdsConnection:
     """Tests for verify_wrds_connection() — the CLI-facing connectivity check."""
 
+    def test_success_runs_attach_and_probe_with_default_timeout(self, monkeypatch):
+        """On the success path verify must actually ATTACH *and* run the
+        information_schema probe (the step that confirms the DB is queryable, not
+        just attached), and the default 25s connect_timeout must reach the conninfo.
+        Without this, dropping the probe or the timeout default is silently uncaught."""
+        from jkp.data import wrds_connection as mod
+
+        recorded: list[str] = []
+
+        class RecordingConnection:
+            def execute(self, sql, *args):
+                recorded.append(sql)
+                return None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+        monkeypatch.setattr(mod.duckdb, "connect", lambda *a, **kw: RecordingConnection())
+
+        # No explicit connect_timeout → exercises the 25s default.
+        result = mod.verify_wrds_connection("testuser", "pw")  # noqa: S106
+
+        assert result is None
+        joined = " ".join(recorded)
+        attach = next(s for s in recorded if "ATTACH" in s)
+        assert "wrds" in attach
+        assert "connect_timeout=25" in attach  # default flows into the conninfo
+        assert "information_schema" in joined  # the queryable-confirmation probe ran
+
     def test_raises_password_free_runtime_error_on_attach_failure(self, monkeypatch):
         """A failed ATTACH (e.g. bad credentials) must surface as a RuntimeError
         whose message never contains the password, even though the underlying

--- a/tests/unit/test_wrds_connection.py
+++ b/tests/unit/test_wrds_connection.py
@@ -247,3 +247,19 @@ class TestVerifyWrdsConnection:
             mod.verify_wrds_connection("testuser", None, connect_timeout=1)
 
         assert "credentials" in str(exc_info.value).lower()
+
+    def test_install_extension_failure_wrapped_as_runtime_error(self, monkeypatch):
+        """A failed INSTALL postgres (e.g. no network to the extension repo on a
+        headless HPC node) must be wrapped in a RuntimeError, not escape as a raw
+        traceback — it runs before the ATTACH but is still inside the guarded path."""
+        from jkp.data import wrds_connection as mod
+
+        def boom():
+            raise OSError("HTTP Error: failed to download extension 'postgres'")
+
+        monkeypatch.setattr(mod, "_install_postgres_extension", boom)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mod.verify_wrds_connection("testuser", "pw", connect_timeout=1)  # noqa: S106
+
+        assert "wrds" in str(exc_info.value).lower()

--- a/tests/unit/test_wrds_connection.py
+++ b/tests/unit/test_wrds_connection.py
@@ -1,0 +1,222 @@
+"""
+Tests for WRDS connection primitives (jkp.data.wrds_connection).
+
+Covers conninfo building, libpq/SQL escaping, and the password-masking helpers
+used to keep credentials out of error text, plus verify_wrds_connection's
+error-handling contract.
+"""
+
+import pytest
+
+
+class TestGenWrdsConnectionInfo:
+    """Tests for gen_wrds_connection_info() function."""
+
+    def test_connection_string_format(self):
+        """Connection string should have correct format."""
+        from jkp.data.wrds_connection import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("testuser", "testpass")
+
+        assert "host=wrds-pgdata.wharton.upenn.edu" in result
+        assert "port=9737" in result
+        assert "dbname=wrds" in result
+        assert "user='testuser'" in result
+        assert "password='testpass'" in result
+        assert "sslmode=require" in result
+
+    def test_password_with_special_characters_is_quoted_and_escaped(self):
+        """A password containing spaces/quotes/backslashes must be single-quoted
+        with libpq escaping so it can't break the conninfo."""
+        from jkp.data.wrds_connection import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("testuser", "p ss'w\\rd")
+
+        # spaces stay inside the quotes; ' and \ are backslash-escaped
+        assert "password='p ss\\'w\\\\rd'" in result
+        assert "sslmode=require" in result
+
+    def test_username_with_special_characters_is_quoted_and_escaped(self):
+        """A username with a space or quote must be single-quoted and escaped too,
+        or it breaks libpq's conninfo parsing just as an unquoted password would."""
+        from jkp.data.wrds_connection import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("od d'user", None)
+
+        assert "user='od d\\'user'" in result
+
+    def test_password_omitted_when_none(self):
+        """With password=None the password= field is omitted so libpq reads
+        ~/.pgpass / $PGPASSFILE."""
+        from jkp.data.wrds_connection import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("testuser", None)
+
+        assert "user='testuser'" in result
+        assert "password=" not in result
+        assert "sslmode=require" in result
+
+    def test_sql_literal_escapes_conninfo_for_embedding(self):
+        """_sql_literal must escape the conninfo so it embeds in single-quoted
+        ATTACH/postgres_scan SQL without a quoted password terminating the literal.
+        Proven at the parse layer — no postgres extension or network — so it runs
+        unconditionally in CI, unlike the ATTACH integration check below."""
+        duckdb = pytest.importorskip("duckdb")
+        from jkp.data.wrds_connection import _sql_literal, gen_wrds_connection_info
+
+        conninfo = gen_wrds_connection_info("testuser", "p ss'w\\d")
+        con = duckdb.connect()
+
+        # Escaped: the whole conninfo parses as one string literal and round-trips.
+        assert con.execute(f"SELECT '{_sql_literal(conninfo)}'").fetchone()[0] == conninfo
+        # Unescaped: the raw quote terminates the literal early -> ParserException.
+        with pytest.raises(Exception) as excinfo:
+            con.execute(f"SELECT '{conninfo}'")
+        assert "Parser" in type(excinfo.value).__name__
+
+    def test_conninfo_embeds_in_sql_without_parse_error(self):
+        """Integration check (needs the DuckDB postgres extension): a real ATTACH
+        with the escaped conninfo must fail at the *connection* stage, not with a
+        ParserException — proving the SQL literal held together AND libpq accepted
+        the quoted conninfo. Also pins the password's echo format for the masking
+        in _attach_wrds."""
+        duckdb = pytest.importorskip("duckdb")
+        from jkp.data.wrds_connection import _sql_literal, gen_wrds_connection_info
+
+        con = duckdb.connect()
+        try:
+            con.execute("INSTALL postgres; LOAD postgres")
+        except Exception:  # pragma: no cover - environment without the extension
+            pytest.skip("duckdb postgres extension unavailable")
+
+        # A password with a space, a single quote, and a backslash — the exact
+        # class the libpq quoting targets. Point at a dead local endpoint so the
+        # ATTACH fails to *connect* rather than hanging on a real socket.
+        conninfo = (
+            gen_wrds_connection_info("testuser", "p ss'w\\d")
+            .replace("host=wrds-pgdata.wharton.upenn.edu", "host=127.0.0.1")
+            .replace("port=9737", "port=9")
+            .replace("sslmode=require", "sslmode=disable")
+            # cap any hang if something ever happens to listen on :9
+            + " connect_timeout=2"
+        )
+        # Guard the neutering: if the WRDS host/port constants ever change, the
+        # .replace() calls above would silently no-op and this test would dial the
+        # real WRDS endpoint. Assert the substitutions actually took effect.
+        assert "host=127.0.0.1" in conninfo and "port=9 " in conninfo
+        assert "wrds-pgdata.wharton.upenn.edu" not in conninfo
+
+        from jkp.data.wrds_connection import _password_in_error
+
+        with pytest.raises(Exception) as excinfo:
+            con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
+        err = str(excinfo.value)
+        # A ParserException would mean the SQL literal was broken by the password's
+        # quote (the SQL-escaping half of the fix).
+        assert "Parser" not in type(excinfo.value).__name__, err
+        # Reaching the connection stage proves libpq accepted the quoted conninfo
+        # (the libpq-escaping half): a regression from \' to ''-style escaping would
+        # fail here as a conninfo-syntax error even though the parse test still passes.
+        assert "connect" in err.lower(), err
+        # And DuckDB really echoes the password in the libpq-escaped form the masking
+        # matches — pinned against a real error, not a synthesized one, so a DuckDB
+        # echo-format change can't silently regress _attach_wrds's redaction.
+        assert _password_in_error(err, "p ss'w\\d")
+
+    def test_password_masking_matches_libpq_escaped_form(self):
+        """DuckDB echoes the connection string with the password in libpq-escaped
+        form, so the masking must match that form — a raw ``password in text``
+        check misses every special-character password."""
+        from jkp.data.wrds_connection import (
+            _password_in_error,
+            _pg_escape_value,
+            _redact_password,
+        )
+
+        pw = "ab'cd\\e"
+        err = f"IO Error: Unable to connect at password='{_pg_escape_value(pw)}' sslmode=disable"
+
+        assert pw not in err  # the raw password does not appear verbatim
+        assert _password_in_error(err, pw)
+        redacted = _redact_password(err, pw)
+        assert "***" in redacted
+        assert _pg_escape_value(pw) not in redacted
+
+    def test_password_masking_matches_sql_doubled_form(self):
+        """A parser error echoes the *raw statement text*, where the password is
+        SQL-escaped over the libpq-escaped form. Masking must match that composed
+        form too — neither the raw nor the plain libpq-escaped form appears."""
+        from jkp.data.wrds_connection import (
+            _password_in_error,
+            _pg_escape_value,
+            _redact_password,
+            _sql_literal,
+        )
+
+        pw = "ab'cd\\e"
+        composed = _sql_literal(_pg_escape_value(pw))
+        err = f"Parser Error: syntax error near ...{composed}... in statement"
+
+        assert pw not in err and _pg_escape_value(pw) not in err  # only the composed form
+        assert _password_in_error(err, pw)
+        assert composed not in _redact_password(err, pw)
+
+    def test_connect_timeout_included_when_set(self):
+        """connect_timeout, when given, is appended to the conninfo."""
+        from jkp.data.wrds_connection import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("u", "p", connect_timeout=10)
+
+        assert "connect_timeout=10" in result
+
+    def test_connect_timeout_omitted_by_default(self):
+        """Without an explicit connect_timeout, libpq's default (no timeout) applies."""
+        from jkp.data.wrds_connection import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("u", "p")
+
+        assert "connect_timeout" not in result
+
+    def test_password_none_omits_password_field(self):
+        """password=None (no positional password arg) omits password= entirely."""
+        from jkp.data.wrds_connection import gen_wrds_connection_info
+
+        result = gen_wrds_connection_info("u", None)
+
+        assert "password=" not in result
+
+
+class TestVerifyWrdsConnection:
+    """Tests for verify_wrds_connection() — the CLI-facing connectivity check."""
+
+    def test_raises_password_free_runtime_error_on_attach_failure(self, monkeypatch):
+        """A failed ATTACH (e.g. bad credentials) must surface as a RuntimeError
+        whose message never contains the password, even though the underlying
+        DuckDB error echoes it in libpq-escaped form."""
+        from jkp.data import wrds_connection as mod
+
+        password = "hunter2"  # noqa: S105
+
+        class FakeConnection:
+            def execute(self, sql, *args):
+                if "ATTACH" in sql:
+                    escaped = mod._pg_escape_value(password)
+                    raise RuntimeError(
+                        f"IO Error: Unable to connect at password='{escaped}' sslmode=require"
+                    )
+                return None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+        monkeypatch.setattr(mod.duckdb, "connect", lambda *a, **kw: FakeConnection())
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mod.verify_wrds_connection("testuser", password, connect_timeout=1)
+
+        msg = str(exc_info.value)
+        assert password not in msg
+        assert "credentials" in msg.lower()

--- a/tests/unit/test_wrds_connection.py
+++ b/tests/unit/test_wrds_connection.py
@@ -177,14 +177,6 @@ class TestGenWrdsConnectionInfo:
 
         assert "connect_timeout" not in result
 
-    def test_password_none_omits_password_field(self):
-        """password=None (no positional password arg) omits password= entirely."""
-        from jkp.data.wrds_connection import gen_wrds_connection_info
-
-        result = gen_wrds_connection_info("u", None)
-
-        assert "password=" not in result
-
 
 class TestVerifyWrdsConnection:
     """Tests for verify_wrds_connection() — the CLI-facing connectivity check."""
@@ -252,6 +244,10 @@ class TestVerifyWrdsConnection:
         msg = str(exc_info.value)
         assert password not in msg
         assert "credentials" in msg.lower()
+        # The DuckDB error this replaces embeds the password. `from None` would clear
+        # __cause__ but leave it on __context__, still reachable to a crash reporter or
+        # post-mortem debugger; raising outside the handler drops it entirely.
+        assert exc_info.value.__context__ is None
 
     def test_pgpass_auth_failure_wrapped_as_runtime_error(self, monkeypatch):
         """With password=None (the ~/.pgpass auth path) _attach_wrds re-raises the
@@ -279,6 +275,38 @@ class TestVerifyWrdsConnection:
             mod.verify_wrds_connection("testuser", None, connect_timeout=1)
 
         assert "credentials" in str(exc_info.value).lower()
+        assert exc_info.value.__context__ is None  # see the attach-failure test above
+
+    def test_probe_query_failure_wrapped_as_runtime_error(self, monkeypatch):
+        """ATTACH succeeds but the information_schema probe fails — a valid login with
+        revoked or limited WRDS product permissions, or a connection dropped between the
+        attach and the first query. The probe is the step this function exists for, so its
+        failure must surface as the same password-free RuntimeError as an attach failure."""
+        from jkp.data import wrds_connection as mod
+
+        password = "hunter2"  # noqa: S105
+
+        class FakeConnection:
+            def execute(self, sql, *args):
+                if "information_schema" in sql:
+                    raise OSError("Permission denied for schema information_schema")
+                return None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+        monkeypatch.setattr(mod.duckdb, "connect", lambda *a, **kw: FakeConnection())
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mod.verify_wrds_connection("testuser", password, connect_timeout=1)
+
+        msg = str(exc_info.value)
+        assert password not in msg
+        assert "credentials" in msg.lower()
+        assert exc_info.value.__context__ is None
 
     def test_install_extension_failure_wrapped_as_runtime_error(self, monkeypatch):
         """A failed INSTALL postgres (e.g. no network to the extension repo on a

--- a/tests/unit/test_wrds_connection.py
+++ b/tests/unit/test_wrds_connection.py
@@ -220,3 +220,30 @@ class TestVerifyWrdsConnection:
         msg = str(exc_info.value)
         assert password not in msg
         assert "credentials" in msg.lower()
+
+    def test_pgpass_auth_failure_wrapped_as_runtime_error(self, monkeypatch):
+        """With password=None (the ~/.pgpass auth path) _attach_wrds re-raises the
+        raw DuckDB exception; verify_wrds_connection must still wrap it in a
+        RuntimeError so `jkp connect` exits cleanly instead of dumping a traceback."""
+        from jkp.data import wrds_connection as mod
+
+        class FakeConnection:
+            def execute(self, sql, *args):
+                if "ATTACH" in sql:
+                    # A non-RuntimeError, mirroring the raw duckdb IOException that
+                    # escapes _attach_wrds when there is no password to detect/redact.
+                    raise OSError("IO Error: connection to WRDS refused")
+                return None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+        monkeypatch.setattr(mod.duckdb, "connect", lambda *a, **kw: FakeConnection())
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mod.verify_wrds_connection("testuser", None, connect_timeout=1)
+
+        assert "credentials" in str(exc_info.value).lower()

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -156,19 +156,19 @@ def test_empty_prompt_password_is_rejected(monkeypatch, _isolate_credential_stat
     monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "")
 
     with pytest.raises(RuntimeError, match="[Ee]mpty password"):
-        mod._prompt_and_store("testuser")
+        mod._prompt_verify_store("testuser")
     assert not mod._pgpass_path().exists() or "testuser" not in mod._pgpass_path().read_text()
 
 
 @pytest.mark.unit
-def test_prompt_and_store_persists_username_for_reset(monkeypatch, _isolate_credential_state):
+def test_prompt_verify_store_persists_username_for_reset(monkeypatch, _isolate_credential_state):
     """A credential provisioned for an env-provided WRDS_USERNAME (which the
     resolver does not persist) must still cache the username, so `jkp connect
     --reset` can revoke it rather than leaving an orphaned ~/.pgpass line."""
     mod = _isolate_credential_state
     monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
 
-    mod._prompt_and_store("env-user")  # no keyring in tests -> written to ~/.pgpass
+    mod._prompt_verify_store("env-user")  # no keyring in tests -> written to ~/.pgpass
 
     assert mod.LAST_USER_FILE.read_text().strip() == "env-user"  # cached for reset
     pgpass = mod._pgpass_path()
@@ -176,6 +176,140 @@ def test_prompt_and_store_persists_username_for_reset(monkeypatch, _isolate_cred
     # ...and reset can now find + remove it
     mod.reset_credentials(full_reset=True)
     assert not pgpass.exists() or "env-user" not in pgpass.read_text()
+
+
+@pytest.mark.unit
+def test_prompt_verify_store_verifies_before_storing(monkeypatch, _isolate_credential_state):
+    """The connectivity check must run before anything is written, so ordering — not
+    just the end state — is what this pins."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
+    events: list[str] = []
+
+    def record_write(_username, _password):
+        events.append("write_pgpass")
+        return mod._pgpass_path()
+
+    monkeypatch.setattr(mod, "_persist_username", lambda u: events.append("persist_username"))
+    monkeypatch.setattr(mod, "_write_pgpass", record_write)
+
+    mod._prompt_verify_store("testuser", lambda u, p: events.append(f"verify:{u}:{p}"))
+
+    assert events[0] == "verify:testuser:typed-secret"
+    assert events[1:] == ["persist_username", "write_pgpass"]
+
+
+@pytest.mark.unit
+def test_failed_verification_stores_nothing(monkeypatch, _isolate_credential_state):
+    """A mistyped password must leave no trace. Otherwise resolution finds it on the
+    next run, never re-prompts, and the user is stuck until they discover --reset."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "mistyped")
+    stored: dict[str, str] = {}
+    monkeypatch.setattr(mod.keyring, "set_password", lambda s, u, p: stored.update({u: p}))
+
+    def reject(_username, _password):
+        raise RuntimeError("Failed to attach WRDS connection.")
+
+    with pytest.raises(RuntimeError, match="Failed to attach"):
+        mod._prompt_verify_store("testuser", reject)
+
+    assert stored == {}  # nothing in the keyring
+    assert not mod._pgpass_path().exists()  # nothing in ~/.pgpass
+    assert not mod.LAST_USER_FILE.exists()  # no username cached either
+
+
+@pytest.mark.unit
+def test_verification_failure_leaves_next_run_able_to_prompt(
+    monkeypatch, _isolate_credential_state
+):
+    """End-to-end shape of the fix: a rejected password then a good one, with no
+    --reset in between. The second run must still prompt, which only holds because
+    the first stored nothing."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr(mod, "_interactive", lambda: True)
+    typed = iter(["mistyped", "correct-horse"])
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: next(typed))
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    seen: list[str] = []
+
+    def verify(_username, password):
+        seen.append(password)
+        if password == "mistyped":
+            raise RuntimeError("Failed to attach WRDS connection.")
+
+    with pytest.raises(RuntimeError, match="Failed to attach"):
+        mod.get_wrds_credentials(verify=verify)
+    assert not mod._pgpass_path().exists()
+
+    creds = mod.get_wrds_credentials(verify=verify)  # prompts again, no --reset needed
+
+    assert seen == ["mistyped", "correct-horse"]
+    assert creds.username == "testuser"
+    assert "correct-horse" in mod._pgpass_path().read_text()
+
+
+@pytest.mark.unit
+def test_verify_none_stores_without_checking(monkeypatch, _isolate_credential_state):
+    """Default (no verifier injected) keeps the historical behavior, which is what
+    run_pipeline still relies on."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
+
+    creds = mod._prompt_verify_store("testuser")
+
+    assert creds.username == "testuser"
+    assert "typed-secret" in mod._pgpass_path().read_text()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("setup", "expected_password"),
+    [
+        ("env", "env-secret"),
+        ("keyring", "kr-secret"),
+        ("pgpass", None),
+    ],
+)
+def test_stored_credentials_are_verified_exactly_once(
+    monkeypatch, _isolate_credential_state, setup, expected_password
+):
+    """Every resolution path runs the injected check exactly once. The CLI relies on
+    this to skip verifying the result itself — a second call would open a second WRDS
+    connection and risk a second Duo push."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    if setup == "env":
+        monkeypatch.setenv("WRDS_PASSWORD", "env-secret")
+    elif setup == "keyring":
+        monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kr-secret")
+    else:
+        _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:stored\n")
+    calls: list[tuple[str, str | None]] = []
+
+    creds = mod.get_wrds_credentials(verify=lambda u, p: calls.append((u, p)))
+
+    assert calls == [("testuser", expected_password)]
+    assert creds.password == expected_password
+
+
+@pytest.mark.unit
+def test_failed_verification_of_stored_credentials_propagates(
+    monkeypatch, _isolate_credential_state
+):
+    """A stored-but-wrong password still fails loudly; it is simply not re-written."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "stale-secret")
+
+    def reject(_username, _password):
+        raise RuntimeError("Failed to attach WRDS connection.")
+
+    with pytest.raises(RuntimeError, match="Failed to attach"):
+        mod.get_wrds_credentials(verify=reject)
 
 
 @pytest.mark.unit
@@ -208,13 +342,13 @@ def test_locked_keyring_warns_and_falls_through(monkeypatch, _isolate_credential
 @pytest.mark.unit
 def test_prompt_stores_to_pgpass_when_keyring_locked(monkeypatch, _isolate_credential_state):
     """The *store* side of a locked keyring: if set_password raises a KeyringError
-    (not NoKeyringError), _prompt_and_store must fall through to ~/.pgpass rather
+    (not NoKeyringError), _prompt_verify_store must fall through to ~/.pgpass rather
     than crash — the write-side mirror of the locked-keyring read fallback."""
     mod = _isolate_credential_state
     monkeypatch.setattr(mod.keyring, "set_password", _raises(mod.keyring.errors.KeyringLocked))
     monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
 
-    creds = mod._prompt_and_store("testuser")
+    creds = mod._prompt_verify_store("testuser")
 
     assert creds.username == "testuser"
     assert creds.password is None  # written to ~/.pgpass, not returned
@@ -855,7 +989,7 @@ def test_pgpass_escapes_special_username(_isolate_credential_state):
 
 
 @pytest.mark.unit
-def test_prompt_and_store_uses_keyring_when_available(monkeypatch, _isolate_credential_state):
+def test_prompt_verify_store_uses_keyring_when_available(monkeypatch, _isolate_credential_state):
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
     mod.LAST_USER_FILE.write_text("u")
@@ -873,7 +1007,7 @@ def test_prompt_and_store_uses_keyring_when_available(monkeypatch, _isolate_cred
 
 
 @pytest.mark.unit
-def test_prompt_and_store_falls_back_to_pgpass_without_keyring(
+def test_prompt_verify_store_falls_back_to_pgpass_without_keyring(
     monkeypatch, _isolate_credential_state
 ):
     mod = _isolate_credential_state

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -45,159 +45,6 @@ class TestBuildProjection:
         assert "TRY_CAST(sich AS BIGINT) AS sich" in result
 
 
-class TestGenWrdsConnectionInfo:
-    """Tests for gen_wrds_connection_info() function."""
-
-    def test_connection_string_format(self):
-        """Connection string should have correct format."""
-        from jkp.data.aux_functions import gen_wrds_connection_info
-
-        result = gen_wrds_connection_info("testuser", "testpass")
-
-        assert "host=wrds-pgdata.wharton.upenn.edu" in result
-        assert "port=9737" in result
-        assert "dbname=wrds" in result
-        assert "user='testuser'" in result
-        assert "password='testpass'" in result
-        assert "sslmode=require" in result
-
-    def test_password_with_special_characters_is_quoted_and_escaped(self):
-        """A password containing spaces/quotes/backslashes must be single-quoted
-        with libpq escaping so it can't break the conninfo."""
-        from jkp.data.aux_functions import gen_wrds_connection_info
-
-        result = gen_wrds_connection_info("testuser", "p ss'w\\rd")
-
-        # spaces stay inside the quotes; ' and \ are backslash-escaped
-        assert "password='p ss\\'w\\\\rd'" in result
-        assert "sslmode=require" in result
-
-    def test_username_with_special_characters_is_quoted_and_escaped(self):
-        """A username with a space or quote must be single-quoted and escaped too,
-        or it breaks libpq's conninfo parsing just as an unquoted password would."""
-        from jkp.data.aux_functions import gen_wrds_connection_info
-
-        result = gen_wrds_connection_info("od d'user", None)
-
-        assert "user='od d\\'user'" in result
-
-    def test_password_omitted_when_none(self):
-        """With password=None the password= field is omitted so libpq reads
-        ~/.pgpass / $PGPASSFILE."""
-        from jkp.data.aux_functions import gen_wrds_connection_info
-
-        result = gen_wrds_connection_info("testuser", None)
-
-        assert "user='testuser'" in result
-        assert "password=" not in result
-        assert "sslmode=require" in result
-
-    def test_sql_literal_escapes_conninfo_for_embedding(self):
-        """_sql_literal must escape the conninfo so it embeds in single-quoted
-        ATTACH/postgres_scan SQL without a quoted password terminating the literal.
-        Proven at the parse layer — no postgres extension or network — so it runs
-        unconditionally in CI, unlike the ATTACH integration check below."""
-        duckdb = pytest.importorskip("duckdb")
-        from jkp.data.aux_functions import _sql_literal, gen_wrds_connection_info
-
-        conninfo = gen_wrds_connection_info("testuser", "p ss'w\\d")
-        con = duckdb.connect()
-
-        # Escaped: the whole conninfo parses as one string literal and round-trips.
-        assert con.execute(f"SELECT '{_sql_literal(conninfo)}'").fetchone()[0] == conninfo
-        # Unescaped: the raw quote terminates the literal early -> ParserException.
-        with pytest.raises(Exception) as excinfo:
-            con.execute(f"SELECT '{conninfo}'")
-        assert "Parser" in type(excinfo.value).__name__
-
-    def test_conninfo_embeds_in_sql_without_parse_error(self):
-        """Integration check (needs the DuckDB postgres extension): a real ATTACH
-        with the escaped conninfo must fail at the *connection* stage, not with a
-        ParserException — proving the SQL literal held together AND libpq accepted
-        the quoted conninfo. Also pins the password's echo format for the masking
-        in _attach_wrds."""
-        duckdb = pytest.importorskip("duckdb")
-        from jkp.data.aux_functions import _sql_literal, gen_wrds_connection_info
-
-        con = duckdb.connect()
-        try:
-            con.execute("INSTALL postgres; LOAD postgres")
-        except Exception:  # pragma: no cover - environment without the extension
-            pytest.skip("duckdb postgres extension unavailable")
-
-        # A password with a space, a single quote, and a backslash — the exact
-        # class the libpq quoting targets. Point at a dead local endpoint so the
-        # ATTACH fails to *connect* rather than hanging on a real socket.
-        conninfo = (
-            gen_wrds_connection_info("testuser", "p ss'w\\d")
-            .replace("host=wrds-pgdata.wharton.upenn.edu", "host=127.0.0.1")
-            .replace("port=9737", "port=9")
-            .replace("sslmode=require", "sslmode=disable")
-            # cap any hang if something ever happens to listen on :9
-            + " connect_timeout=2"
-        )
-        # Guard the neutering: if the WRDS host/port constants ever change, the
-        # .replace() calls above would silently no-op and this test would dial the
-        # real WRDS endpoint. Assert the substitutions actually took effect.
-        assert "host=127.0.0.1" in conninfo and "port=9 " in conninfo
-        assert "wrds-pgdata.wharton.upenn.edu" not in conninfo
-
-        from jkp.data.aux_functions import _password_in_error
-
-        with pytest.raises(Exception) as excinfo:
-            con.execute(f"ATTACH '{_sql_literal(conninfo)}' AS wrds (TYPE postgres, READ_ONLY)")
-        err = str(excinfo.value)
-        # A ParserException would mean the SQL literal was broken by the password's
-        # quote (the SQL-escaping half of the fix).
-        assert "Parser" not in type(excinfo.value).__name__, err
-        # Reaching the connection stage proves libpq accepted the quoted conninfo
-        # (the libpq-escaping half): a regression from \' to ''-style escaping would
-        # fail here as a conninfo-syntax error even though the parse test still passes.
-        assert "connect" in err.lower(), err
-        # And DuckDB really echoes the password in the libpq-escaped form the masking
-        # matches — pinned against a real error, not a synthesized one, so a DuckDB
-        # echo-format change can't silently regress _attach_wrds's redaction.
-        assert _password_in_error(err, "p ss'w\\d")
-
-    def test_password_masking_matches_libpq_escaped_form(self):
-        """DuckDB echoes the connection string with the password in libpq-escaped
-        form, so the masking must match that form — a raw ``password in text``
-        check misses every special-character password."""
-        from jkp.data.aux_functions import (
-            _password_in_error,
-            _pg_escape_value,
-            _redact_password,
-        )
-
-        pw = "ab'cd\\e"
-        err = f"IO Error: Unable to connect at password='{_pg_escape_value(pw)}' sslmode=disable"
-
-        assert pw not in err  # the raw password does not appear verbatim
-        assert _password_in_error(err, pw)
-        redacted = _redact_password(err, pw)
-        assert "***" in redacted
-        assert _pg_escape_value(pw) not in redacted
-
-    def test_password_masking_matches_sql_doubled_form(self):
-        """A parser error echoes the *raw statement text*, where the password is
-        SQL-escaped over the libpq-escaped form. Masking must match that composed
-        form too — neither the raw nor the plain libpq-escaped form appears."""
-        from jkp.data.aux_functions import (
-            _password_in_error,
-            _pg_escape_value,
-            _redact_password,
-            _sql_literal,
-        )
-
-        pw = "ab'cd\\e"
-        composed = _sql_literal(_pg_escape_value(pw))
-        err = f"Parser Error: syntax error near ...{composed}... in statement"
-
-        assert pw not in err and _pg_escape_value(pw) not in err  # only the composed form
-        assert _password_in_error(err, pw)
-        assert composed not in _redact_password(err, pw)
-
-
 class TestDownloadRawDataTablesBranching:
     """Tests for download_raw_data_tables() branching logic.
 
@@ -383,7 +230,15 @@ class TestParallelDownload:
         context manager (``with duckdb.connect() as con`` binds con to the connection), so the
         worker's ATTACH/DETACH calls are recorded on the same mock and __exit__ closes it.
         """
-        with patch("jkp.data.aux_functions.duckdb") as mock:
+        # Patch duckdb in both modules that open connections on the download path:
+        # the per-worker ATTACH connections live in aux_functions, while the one
+        # up-front INSTALL connection is opened by wrds_connection._install_postgres_extension.
+        # Pointing both names at the same mock keeps a single ordered connect() sequence
+        # (install consumes conns[0], workers consume conns[1:]).
+        with (
+            patch("jkp.data.aux_functions.duckdb") as mock,
+            patch("jkp.data.wrds_connection.duckdb", mock),
+        ):
             conns = [MagicMock(name=f"conn{i}") for i in range(32)]
             for c in conns:
                 c.__enter__.return_value = c

--- a/tests/unit/test_wrds_download.py
+++ b/tests/unit/test_wrds_download.py
@@ -219,31 +219,36 @@ class TestEffectiveDownloadWorkers:
         assert _effective_download_workers(4, 25) == 4
 
 
+@pytest.fixture
+def mock_duckdb_multi():
+    """Patch duckdb so each connect() returns a distinct mock connection.
+
+    Each mock's __enter__ returns itself, mirroring a real DuckDB connection used as a
+    context manager (``with duckdb.connect() as con`` binds con to the connection), so the
+    worker's ATTACH/DETACH calls are recorded on the same mock and __exit__ closes it.
+
+    Module-scoped rather than nested in one test class: every test that reaches the
+    download path needs the dual patch below, and hand-rolled single-module patches
+    silently fall through to a real INSTALL.
+    """
+    # Patch duckdb in both modules that open connections on the download path:
+    # the per-worker ATTACH connections live in aux_functions, while the one
+    # up-front INSTALL connection is opened by wrds_connection._install_postgres_extension.
+    # Pointing both names at the same mock keeps a single ordered connect() sequence
+    # (install consumes conns[0], workers consume conns[1:]).
+    with (
+        patch("jkp.data.aux_functions.duckdb") as mock,
+        patch("jkp.data.wrds_connection.duckdb", mock),
+    ):
+        conns = [MagicMock(name=f"conn{i}") for i in range(32)]
+        for c in conns:
+            c.__enter__.return_value = c
+        mock.connect.side_effect = conns
+        yield mock, conns
+
+
 class TestParallelDownload:
     """Tests for the parallel (max_workers > 1) download path."""
-
-    @pytest.fixture
-    def mock_duckdb_multi(self):
-        """Patch duckdb so each connect() returns a distinct mock connection.
-
-        Each mock's __enter__ returns itself, mirroring a real DuckDB connection used as a
-        context manager (``with duckdb.connect() as con`` binds con to the connection), so the
-        worker's ATTACH/DETACH calls are recorded on the same mock and __exit__ closes it.
-        """
-        # Patch duckdb in both modules that open connections on the download path:
-        # the per-worker ATTACH connections live in aux_functions, while the one
-        # up-front INSTALL connection is opened by wrds_connection._install_postgres_extension.
-        # Pointing both names at the same mock keeps a single ordered connect() sequence
-        # (install consumes conns[0], workers consume conns[1:]).
-        with (
-            patch("jkp.data.aux_functions.duckdb") as mock,
-            patch("jkp.data.wrds_connection.duckdb", mock),
-        ):
-            conns = [MagicMock(name=f"conn{i}") for i in range(32)]
-            for c in conns:
-                c.__enter__.return_value = c
-            mock.connect.side_effect = conns
-            yield mock, conns
 
     def _record_tables(self, mock_dl):
         """Make download_wrds_table_attached record the tables it's asked to download."""
@@ -612,7 +617,7 @@ class TestDateRangeSplitting:
     @patch("jkp.data.aux_functions._compute_histograms")
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_parallel_download_aggregates_concat_failures(
-        self, mock_dl, mock_hist, mock_concat, test_paths
+        self, mock_dl, mock_hist, mock_concat, mock_duckdb_multi, test_paths
     ):
         """A concat failure surfaces as one aggregated error, not a raw first-failure exception."""
         from jkp.data.aux_functions import SPLIT_TABLES, download_raw_data_tables
@@ -620,21 +625,16 @@ class TestDateRangeSplitting:
         mock_hist.return_value = dict.fromkeys(SPLIT_TABLES, [(y, 10) for y in range(2010, 2022)])
         mock_concat.side_effect = RuntimeError("disk full")
 
-        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
-            conns = [MagicMock(name=f"c{i}") for i in range(40)]
-            for c in conns:
-                c.__enter__.return_value = c
-            mock_duckdb.connect.side_effect = conns
-            with pytest.raises(RuntimeError, match="concatenation"):
-                download_raw_data_tables(
-                    test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
-                )
+        with pytest.raises(RuntimeError, match="concatenation"):
+            download_raw_data_tables(
+                test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
+            )
 
     @patch("jkp.data.aux_functions._concat_chunks")
     @patch("jkp.data.aux_functions._compute_histograms")
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_parallel_download_splits_giant_tables(
-        self, mock_dl, mock_hist, mock_concat, test_paths
+        self, mock_dl, mock_hist, mock_concat, mock_duckdb_multi, test_paths
     ):
         """End-to-end (mocked): with an end_date, the giant tables expand into max_workers chunks."""
         from jkp.data.aux_functions import SPLIT_TABLES, download_raw_data_tables
@@ -651,14 +651,9 @@ class TestDateRangeSplitting:
 
         mock_dl.side_effect = record
 
-        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
-            conns = [MagicMock(name=f"c{i}") for i in range(40)]
-            for c in conns:
-                c.__enter__.return_value = c
-            mock_duckdb.connect.side_effect = conns
-            download_raw_data_tables(
-                test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
-            )
+        download_raw_data_tables(
+            test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
+        )
 
         counts = Counter(recorded)
         for split_table in SPLIT_TABLES:
@@ -693,20 +688,15 @@ class TestDateRangeSplitting:
     @patch("jkp.data.aux_functions._compute_histograms")
     @patch("jkp.data.aux_functions.download_wrds_table_attached")
     def test_parallel_download_concatenates_each_split_table(
-        self, mock_dl, mock_hist, mock_concat, test_paths
+        self, mock_dl, mock_hist, mock_concat, mock_duckdb_multi, test_paths
     ):
         """The concat_map -> ThreadPoolExecutor wiring invokes _concat_chunks once per split table."""
         from jkp.data.aux_functions import SPLIT_TABLES, download_raw_data_tables
 
         mock_hist.return_value = dict.fromkeys(SPLIT_TABLES, [(y, 10) for y in range(2010, 2022)])
-        with patch("jkp.data.aux_functions.duckdb") as mock_duckdb:
-            conns = [MagicMock(name=f"c{i}") for i in range(40)]
-            for c in conns:
-                c.__enter__.return_value = c
-            mock_duckdb.connect.side_effect = conns
-            download_raw_data_tables(
-                test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
-            )
+        download_raw_data_tables(
+            test_paths, "user", "pass", end_date=dt.date(2025, 12, 31), max_workers=4
+        )
 
         assert mock_concat.call_count == len(SPLIT_TABLES)
         for call in mock_concat.call_args_list:


### PR DESCRIPTION
Closes #246.
Closes #274.

## Simple explanation

`jkp connect` used to print `Connected as: <user>` after only resolving credentials locally — it never actually opened WRDS. So it reported success even when the credentials were wrong/expired or WRDS was unreachable, and users only discovered the problem later, deep into a `jkp build` run.

Now `jkp connect` opens a real WRDS connection (attaches the database read-only and runs a trivial query) before reporting success, so a green result means credentials, connectivity, and MFA actually work. On failure it prints an actionable, password-free message and exits non-zero instead of dumping a traceback.

Because opening the connection triggers the WRDS **Duo MFA push**, the command waits up to **25 seconds** for the user to approve it on their phone before giving up (the libpq `connect_timeout`). WRDS trusts a username/IP pair for 30 days after a successful approval, so expect a prompt on the first run from a new IP and again once that window expires — not on every run.

## Also includes #276 (verify before persist)

**Also includes the verify-before-persist work from #276.** That was opened as a separate follow-up, then merged into this branch (`467eb23`) rather than retargeted to `main`, so it ships here: roughly 217 lines adding `_prompt_verify_store`, `_verified`, and a `verify` parameter on `get_wrds_credentials`.

The mechanism is dependency injection rather than CLI-layer orchestration. `wrds_connection` imports from `wrds_credentials`, so `wrds_credentials` cannot import the verifier back without a cycle; instead the CLI passes `verify_wrds_connection` in as `get_wrds_credentials(verify=...)`. On the freshly-prompted path the check runs between the prompt and the store, so a mistyped password is never written and the next run simply re-prompts, with no `jkp connect --reset` needed. On the paths that read an existing store (env vars, keyring, `~/.pgpass`) it runs as a plain connectivity check. Every path verifies exactly once, so callers must not verify the result again: a second call would open a second WRDS connection and risk a second Duo push.

This also keeps the plaintext password out of the `connect()` frame on the prompt path, which the CLI-orchestrated alternative would not have done.

`run_pipeline` (`main.py:58`) calls `get_wrds_credentials()` with no argument, so `verify` defaults to `None` and the `jkp build` path is behaviorally unchanged.

## Technical details

- New module `src/jkp/data/wrds_connection.py` holds the WRDS connection primitives, extracted from `aux_functions.py`: `gen_wrds_connection_info` (now with an optional `connect_timeout`), `_attach_wrds`, `_install_postgres_extension`, and the conninfo/password-masking helpers, plus the new `verify_wrds_connection(username, password, *, connect_timeout=25)`. Keeping these in a standalone module lets the CLI verify a connection without importing the heavy pipeline module. Dependency direction is one-way: `wrds_credentials ← wrds_connection ← {aux_functions, cli}`.
- `aux_functions.py` re-imports the five primitives still used by the download workers; ~100 lines removed.
- `cli.py::connect` calls `verify_wrds_connection` before echoing success; the existing `except RuntimeError` surfaces the message and exits 1. `--reset` is unchanged. The docstring now states it verifies connectivity and when to expect a Duo MFA push.
- `verify_wrds_connection` wraps the attach/probe so **any** failure — including the `~/.pgpass` auth path where `password is None` and `_attach_wrds` re-raises the raw DuckDB exception — surfaces as a clean, password-free `RuntimeError` rather than a traceback. (Caught during review of this branch.)
- `connect_timeout` defaults to 25s so libpq doesn't give up before the user approves the Duo push.

No `CHANGELOG_DATA.md` entry — this is CLI/infra only and does not change anything written to `data/processed/`.

## Test plan

- `PYTHONPATH=src uv run --no-sync python -m pytest tests/unit/ -m "not wrds"` — **911 passed**.
- New `tests/unit/test_wrds_connection.py` (conninfo building/escaping, password masking relocated from `test_wrds_download.py`, `connect_timeout` present/absent, `verify_wrds_connection` raising a password-free `RuntimeError` on attach failure for both the password and `~/.pgpass`/`None` paths) and `tests/unit/test_cli_connect.py` (connect success / failure / no-password-leak).
- `ruff check` and `ruff format --check` clean; `pyright` on the changed source: 0 errors.
- Live check (manual, not in CI): `jkp connect` with valid creds returns cleanly after approving the MFA push; with wrong creds it prints the guidance message and exits 1.

/cc @capellini for review (infra/CLI change).



