### PR TITLE
fix: mask WRDS password in Credentials repr

### DIFF
--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -19,6 +19,11 @@ app = typer.Typer(
     name="jkp",
     help="JKP Factor Data generation pipeline.",
     no_args_is_help=True,
+    # Defense in depth: never render frame locals in tracebacks. A WRDS
+    # Credentials object bound in a command frame would otherwise be exposed to
+    # Typer's pretty exception handler. Typer only defaulted this off in 0.23.0
+    # and the project floor is typer>=0.15.0, so set it explicitly.
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -71,6 +71,15 @@ class Credentials:
     username: str
     password: str | None  # None => authenticate via ~/.pgpass (omit password=)
 
+    def __repr__(self) -> str:
+        # Mask the password so tools that render frame locals via repr() (pretty
+        # tracebacks, pytest --showlocals, debuggers) cannot leak the secret. The
+        # None vs non-None distinction is preserved because password=None marks
+        # ~/.pgpass authentication, which is useful to see when debugging. The
+        # username is intentionally not masked (the CLI already prints it).
+        pw = "***" if self.password is not None else None
+        return f"Credentials(username={self.username!r}, password={pw!r})"
+
 
 def _interactive() -> bool:
     return sys.stdin.isatty()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -185,3 +185,15 @@ class TestConnectCommand:
         result = runner.invoke(app, ["connect", "-r"])
         assert result.exit_code == 0
         mock_reset.assert_called_once_with(full_reset=True)
+
+
+@pytest.mark.unit
+class TestCliAppConfig:
+    """Guard the app-level configuration that hardens credential handling."""
+
+    def test_pretty_exceptions_show_locals_disabled(self) -> None:
+        """Frame locals must never be rendered in tracebacks: a WRDS Credentials
+        object bound in a command frame would otherwise be exposed to Typer's
+        pretty exception handler. This pins the setting so a future refactor of
+        the Typer(...) constructor cannot silently drop it."""
+        assert app.pretty_exceptions_show_locals is False

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -1147,3 +1147,56 @@ def _write_pgpass_append(mod, content):
     path = mod._pgpass_path()
     with path.open("a") as fh:
         fh.write(content)
+
+
+@pytest.mark.unit
+def test_repr_masks_password() -> None:
+    """repr() shows the username but replaces a real password with a mask, so a
+    tool that renders frame locals (pretty tracebacks, --showlocals) cannot leak
+    the secret."""
+    from jkp.data.wrds_credentials import Credentials
+
+    password = "super-secret-value"  # noqa: S105
+    creds = Credentials("some-user", password)
+    text = repr(creds)
+    assert "some-user" in text
+    assert "***" in text
+    assert password not in text
+
+
+@pytest.mark.unit
+def test_repr_preserves_none_password() -> None:
+    """password=None (the ~/.pgpass authentication path) stays distinguishable in
+    the repr, since that visibility is useful when debugging."""
+    from jkp.data.wrds_credentials import Credentials
+
+    creds = Credentials("pgpass-user", None)
+    text = repr(creds)
+    assert "pgpass-user" in text
+    assert "password=None" in text
+    assert "***" not in text
+
+
+@pytest.mark.unit
+def test_repr_masks_empty_password() -> None:
+    """An empty-string password is still masked, not rendered as its real value,
+    and is not confused with the None (pgpass) case."""
+    from jkp.data.wrds_credentials import Credentials
+
+    creds = Credentials("empty-user", "")  # noqa: S106
+    text = repr(creds)
+    assert "***" in text
+    assert "password=''" not in text
+    assert "password=None" not in text
+
+
+@pytest.mark.unit
+def test_str_is_password_free() -> None:
+    """str() falls through to __repr__, so it is likewise free of the secret."""
+    from jkp.data.wrds_credentials import Credentials
+
+    password = "another-secret-value"  # noqa: S105
+    creds = Credentials("str-user", password)
+    text = str(creds)
+    assert password not in text
+    assert "***" in text


### PR DESCRIPTION
## Summary

Masks the WRDS password in the `Credentials` dataclass repr so it can no longer be
leaked by tools that render frame locals.

Closes #258

## The hazard

The frozen `Credentials` dataclass in `src/jkp/data/wrds_credentials.py` holds the
WRDS password in plaintext. Its auto-generated dataclass repr printed the secret:

```
Credentials(username='...', password='<plaintext>')
```

Wherever a `Credentials` object is a local in a frame that gets rendered via
`repr()`, the password is exposed. That includes Typer's pretty exception handler
(on typer < 0.23.0, `pretty_exceptions_show_locals` defaulted to True, and
`pyproject.toml` allows typer>=0.15.0), pytest `--showlocals`, interactive
debuggers, and crash reporters. The hazard is the default repr, not any single
call site.

## The fix

1. A custom `__repr__` on the `Credentials` dataclass that masks the password with
   `***` but preserves the None vs non-None distinction. `password=None` marks
   `~/.pgpass` authentication in this codebase, and keeping that visible is useful
   when debugging. An empty-string password is masked too. The username is left
   unmasked since the CLI already prints it. A user-defined `__repr__` in the class
   body is respected by `@dataclass` (it is not overwritten), so no decorator
   change is needed.

2. `pretty_exceptions_show_locals=False` on the `typer.Typer(...)` app in
   `src/jkp/data/cli.py`, as defense in depth for the same hazard. Typer only
   changed this default in 0.23.0, and the project floor is typer>=0.15.0, so it is
   set explicitly.

## Tests

New unit tests in `tests/unit/test_wrds_credentials.py`:

- repr with a password: username present, `***` present, real value absent
- repr with `password=None`: still shown as None (the pgpass path stays
  distinguishable)
- repr with an empty-string password: still masked, real value absent
- `str()` is likewise password-free (str falls through to `__repr__`)

## Why this is a standalone PR

The unsafe repr predates PR #257 and the fix is independent of it. This was
surfaced during review of #257 (which adds a fallible statement after `creds` is
bound in the `connect` command, widening the window where an exception could
render that frame's locals), but keeping this fix in its own PR means a future
revert of #257 cannot remove the protection.

No `CHANGELOG_DATA.md` entry: this changes nothing written to `data/processed/`.

## Verification

- `uv run pytest tests/unit/` (all pass)
- `uv run ruff check src/jkp/data/ tests/` and `ruff format --check` (clean)
- `uv run pyright src/jkp/data/` (no new findings in the changed files)
