### PR TITLE
fix: pass --force to jkp build in slurm batch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
      sbatch slurm/submit_job_som_hpc.slurm
      ```
      to create the factor returns, stock returns, and firm characteristics.
+     Note that the batch script passes `--force` to `jkp build`, so it overwrites an
+     existing output directory without prompting (an interactive `jkp build` asks first).
 
      In an interactive session, run:
      ```sh

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -45,6 +45,8 @@ source .venv/bin/activate
 
 # Create char data
 # Set PERSISTENT_WRDS_CONNECTION=1 to use a single WRDS connection (reduces MFA on NAT-rotated networks)
+# Use --force because a batch job has no TTY to answer the interactive overwrite prompt, and
+# resubmitting the job implies intent to regenerate the data.
 if [ "${PERSISTENT_WRDS_CONNECTION:-0}" = "1" ]; then
     jkp build data --force --persistent-connection
 else

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -46,9 +46,9 @@ source .venv/bin/activate
 # Create char data
 # Set PERSISTENT_WRDS_CONNECTION=1 to use a single WRDS connection (reduces MFA on NAT-rotated networks)
 if [ "${PERSISTENT_WRDS_CONNECTION:-0}" = "1" ]; then
-    jkp build data --persistent-connection
+    jkp build data --force --persistent-connection
 else
-    jkp build data
+    jkp build data --force
 fi
 
 # Create portfolio data


### PR DESCRIPTION
## Summary

`slurm/submit_job_som_hpc.slurm` is a non-interactive batch script, but `jkp build data` prompts `Output directory 'data' already contains data. Overwrite? [y/N]` when `data/` is non-empty (src/jkp/data/cli.py:77-81). With no TTY the confirm reads EOF and aborts, and `set -e` kills the job — so any resubmission against an existing data directory fails immediately. This PR adds `--force` to both `jkp build` invocations, since resubmitting the batch job implies intent to regenerate the data.

Fixes #260

## Change Type

- [x] Infrastructure change (CI, config, dependencies)

## Methodological Impact

None

## Data Impact

None — the flag only skips the interactive confirmation; the pipeline output is unchanged.

## Breaking Changes

None

## Tests

None added — two-line change to a Slurm shell script; there is no test harness for the batch scripts.

## Checklist

- [x] I have run the tests locally (`pytest`) — not applicable, no Python code changed
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`) — not applicable, no Python code changed
- [ ] I have verified the pipeline runs successfully after my changes
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

## Additional Notes

Encountered in practice: a resubmitted HPC job died on the prompt because `data/` already held output from a prior run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)