### PR TITLE
feat: parameterize output directory in slurm batch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
      sbatch slurm/submit_job_som_hpc.slurm
      ```
      to create the factor returns, stock returns, and firm characteristics.
+     The script writes to `data/` by default. To use a different output directory, pass
+     it as an argument: `sbatch slurm/submit_job_som_hpc.slurm /path/to/output`.
      Note that the batch script passes `--force` to `jkp build`, so it overwrites an
      existing output directory without prompting (an interactive `jkp build` asks first).
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Please see the release notes (`documentation/release_notes.html`) for a descript
 
   # Slurm job (set environment variable)
   sbatch --export=ALL,PERSISTENT_WRDS_CONNECTION=1 slurm/submit_job_som_hpc.slurm
+
+  # Slurm job with a custom output directory
+  sbatch --export=ALL,PERSISTENT_WRDS_CONNECTION=1 slurm/submit_job_som_hpc.slurm /path/to/output
   ```
   This reduces MFA prompts from ~26 (one per table) to just 1 (at connection time).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
      ```
      to create the factor returns, stock returns, and firm characteristics.
      The script writes to `data/` by default. To use a different output directory, pass
-     it as an argument: `sbatch slurm/submit_job_som_hpc.slurm /path/to/output`.
+     `--output-dir`: `sbatch slurm/submit_job_som_hpc.slurm --output-dir /path/to/output`.
+     Relative paths resolve against the directory you submit from, and the resolved
+     destination is echoed in the job log. The script rejects unrecognized options and
+     stray arguments, so a mistyped flag or an unquoted path containing a space fails
+     immediately instead of writing to the wrong place. It parses options with the
+     enhanced (util-linux) `getopt`, which is present by default on mainstream Linux
+     distributions but is not a dependency of the `jkp` package itself.
      Note that the batch script passes `--force` to `jkp build`, so it overwrites an
      existing output directory without prompting (an interactive `jkp build` asks first).
 
@@ -94,7 +100,7 @@ Please see the release notes (`documentation/release_notes.html`) for a descript
   sbatch --export=ALL,PERSISTENT_WRDS_CONNECTION=1 slurm/submit_job_som_hpc.slurm
 
   # Slurm job with a custom output directory
-  sbatch --export=ALL,PERSISTENT_WRDS_CONNECTION=1 slurm/submit_job_som_hpc.slurm /path/to/output
+  sbatch --export=ALL,PERSISTENT_WRDS_CONNECTION=1 slurm/submit_job_som_hpc.slurm --output-dir /path/to/output
   ```
   This reduces MFA prompts from ~26 (one per table) to just 1 (at connection time).
 

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -22,6 +22,13 @@ echo "SLURM_NODES are ${SLURM_NODELIST}"
 echo '-------------------------------'
 echo
 
+# Output directory for the pipeline, taken from the first script argument.
+# Relative paths resolve against the submit directory. Defaults to "data":
+#
+#     sbatch slurm/submit_job_som_hpc.slurm /path/to/output
+#
+OUTPUT_DIR="${1:-data}"
+
 # (Optional) Make threaded libs respect Slurm CPU allocation
 export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}
 export MKL_NUM_THREADS=${SLURM_CPUS_PER_TASK}
@@ -48,10 +55,10 @@ source .venv/bin/activate
 # Use --force because a batch job has no TTY to answer the interactive overwrite prompt, and
 # resubmitting the job implies intent to regenerate the data.
 if [ "${PERSISTENT_WRDS_CONNECTION:-0}" = "1" ]; then
-    jkp build data --force --persistent-connection
+    jkp build "${OUTPUT_DIR}" --force --persistent-connection
 else
-    jkp build data --force
+    jkp build "${OUTPUT_DIR}" --force
 fi
 
 # Create portfolio data
-jkp portfolio data
+jkp portfolio "${OUTPUT_DIR}"

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -13,16 +13,59 @@
 # proceeding to `jkp portfolio` against incomplete data.
 set -e
 
-# Output directory for the pipeline, taken from the first script argument.
-# Relative paths resolve against the submit directory. Defaults to "data":
-#
-#     sbatch slurm/submit_job_som_hpc.slurm /path/to/output
-#
-# Assigned after the cd below so relative paths resolve against the submit
-# directory, and echoed so the job log records where the run actually wrote.
+# Option parsing requires the enhanced (util-linux) getopt(1). It is present in
+# the base install of every mainstream Linux distribution, including this
+# cluster's login and compute nodes, and is deliberately NOT a dependency of the
+# `jkp` package: these batch scripts are worked examples of running the pipeline
+# under Slurm, not part of the installed package. The --test guard below fails
+# loudly rather than misparsing if only the legacy getopt is available.
+
+usage() {
+    cat <<'USAGE'
+usage: sbatch slurm/submit_job_som_hpc.slurm [--output-dir DIR]
+
+  --output-dir DIR  Directory for pipeline output (raw, interim and processed
+                    data). Relative paths resolve against the submit directory.
+                    Defaults to "data".
+  -h, --help        Show this message and exit.
+USAGE
+}
+
+# `getopt --test` exits 4 on the enhanced version, so it cannot be run bare
+# under `set -e`.
+GETOPT_TEST_RC=0
+getopt --test >/dev/null || GETOPT_TEST_RC=$?
+if [ "${GETOPT_TEST_RC}" -ne 4 ]; then
+    echo "error: this script requires the enhanced (util-linux) getopt" >&2
+    exit 1
+fi
+
+PARSED=$(getopt -o 'h' --long 'output-dir:,help' -n 'submit_job_som_hpc.slurm' -- "$@") || {
+    usage >&2
+    exit 1
+}
+eval set -- "${PARSED}"
+
+OUTPUT_DIR=data
+while true; do
+    case "$1" in
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        *) echo "error: unhandled option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ "$#" -ne 0 ]; then
+    echo "error: unexpected argument: $1" >&2
+    usage >&2
+    exit 1
+fi
+
+# Resolved after the cd so a relative --output-dir reports the same path the
+# pipeline will actually write to.
 echo '-------------------------------'
 cd "${SLURM_SUBMIT_DIR}"
-OUTPUT_DIR="${1:-data}"
 echo "${SLURM_SUBMIT_DIR}"
 echo "Running on host $(hostname)"
 echo "Time is $(date)"

--- a/slurm/submit_job_som_hpc.slurm
+++ b/slurm/submit_job_som_hpc.slurm
@@ -13,21 +13,23 @@
 # proceeding to `jkp portfolio` against incomplete data.
 set -e
 
-echo '-------------------------------'
-cd "${SLURM_SUBMIT_DIR}"
-echo "${SLURM_SUBMIT_DIR}"
-echo "Running on host $(hostname)"
-echo "Time is $(date)"
-echo "SLURM_NODES are ${SLURM_NODELIST}"
-echo '-------------------------------'
-echo
-
 # Output directory for the pipeline, taken from the first script argument.
 # Relative paths resolve against the submit directory. Defaults to "data":
 #
 #     sbatch slurm/submit_job_som_hpc.slurm /path/to/output
 #
+# Assigned after the cd below so relative paths resolve against the submit
+# directory, and echoed so the job log records where the run actually wrote.
+echo '-------------------------------'
+cd "${SLURM_SUBMIT_DIR}"
 OUTPUT_DIR="${1:-data}"
+echo "${SLURM_SUBMIT_DIR}"
+echo "Running on host $(hostname)"
+echo "Time is $(date)"
+echo "SLURM_NODES are ${SLURM_NODELIST}"
+echo "Output directory is $(realpath -m "${OUTPUT_DIR}")"
+echo '-------------------------------'
+echo
 
 # (Optional) Make threaded libs respect Slurm CPU allocation
 export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}


### PR DESCRIPTION
## Summary

`slurm/submit_job_som_hpc.slurm` hardcoded the output directory as `data`. This PR takes it from an optional `--output-dir` flag instead, used by both `jkp build` invocations and `jkp portfolio` so the two stages always write to the same place:

```sh
sbatch slurm/submit_job_som_hpc.slurm --output-dir /path/to/output
```

With no flag the script behaves exactly as before. Relative paths resolve against the submit directory, and the header block echoes the resolved destination so `slurm/output_jkp_%j.txt` records where the run actually wrote.

Options are parsed with the enhanced (util-linux) `getopt`, so an unrecognized flag, a missing value, or a stray positional argument is rejected with a usage message instead of being silently ignored. `getopt` is not a dependency of the `jkp` package, since these batch scripts are worked examples of running the pipeline under Slurm rather than part of it. The requirement is recorded in the script header and in the README, and the script also checks for it at startup: if `getopt` is missing, or only the legacy version is present, the job exits 1 with an explanatory message rather than misparsing its arguments.

Fixes #262

## Change Type

- [x] Infrastructure change (CI, config, dependencies)

## Methodological Impact

None

## Data Impact

None. The argument changes where output is written, not what is written.

## Breaking Changes

None. The default output directory is unchanged.

## Tests

None added, there is no test harness for the batch scripts. `bash -n` passes and `shellcheck` reports the same single `SC1091` for `source .venv/bin/activate` as it does on `main`, so no new warnings.

Argument handling was verified on the SOM HPC across nine submissions of the real script with the pipeline invocations stubbed out. The five valid forms all COMPLETED with the resolved destination in the job log: no flag (`<submit dir>/data`), `--output-dir` with a space, `--output-dir=` with an equals sign, a relative path, and `--help`. The four invalid forms all FAILED with exit 1 and a usage message: an unquoted path containing a space (`unexpected argument: Runs/jkp`), a bare positional, an unknown flag (`unrecognized option '--frce'`), and `--output-dir` with no value.

Separately confirmed that `sbatch` passes `--output-dir` through to the script untouched, including the `=` form, and that even `--output`, which is a real `sbatch` option, reaches the script when it appears after the script path.

The `getopt` guard was exercised directly, with the binary absent from `PATH` and with a stub standing in for the legacy version. Both exit 1 with the explanatory message rather than proceeding.

An earlier full submission (job 1549091) confirmed end to end that the pipeline creates the `raw`/`interim`/`processed` tree under the requested directory and begins downloading WRDS tables into it, with no stray `data/` created. That job used the positional syntax this PR has since replaced, so it stands as evidence about the directory handling rather than about the current flag.

## Checklist

- [x] I have run the tests locally (`pytest`) - not applicable, no Python code changed
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`) - not applicable, no Python code changed
- [ ] I have verified the pipeline runs successfully after my changes - smoke tested through the start of `DOWNLOAD_RAW_DATA_TABLES` only
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

## Additional Notes

Follow-up to #261, which added `--force` to the same invocations.


