### PR TITLE
docs: correct Ohlson O-score intercept

### DIFF
--- a/documentation/documentation.tex
+++ b/documentation/documentation.tex
@@ -2443,7 +2443,7 @@ $\\
             
                 \item Characteristic:
                 \begin{align*}
-                    o\_score_t =& -1.37 - 0.407 \times \_o\_lat_t + 6.03 \times \_o\_lev_t + 1.43 \times \_o\_wc_t + \\ &0.076 \times \_o\_cacl_t - 1.72 \times \_o\_neg\_eq_t - 2.37 \times \_o\_roe_t - \\ &1.83 \times \_o\_ffo_t + 0.285 \times \_o\_neg\_earn_t - 0.52 \times \_o\_nich_t
+                    o\_score_t =& -1.32 - 0.407 \times \_o\_lat_t + 6.03 \times \_o\_lev_t + 1.43 \times \_o\_wc_t + \\ &0.076 \times \_o\_cacl_t - 1.72 \times \_o\_neg\_eq_t - 2.37 \times \_o\_roe_t - \\ &1.83 \times \_o\_ffo_t + 0.285 \times \_o\_neg\_earn_t - 0.52 \times \_o\_nich_t
                 \end{align*}
             \end{itemize}
             


### PR DESCRIPTION
## Summary

Correct the Ohlson O-score intercept in the detailed documentation from `-1.37` to `-1.32`, matching both the Python implementation and the reference SAS implementation.

Fixes #265.

## Change Type

- [ ] Methodology change (affects factor definitions or calculations)
- [ ] Data/output change (affects computed outputs users download)
- [ ] Infrastructure change (CI, config, dependencies)
- [x] Documentation only
- [ ] Performance-impacting change

## Methodological Impact

None. This aligns the documentation with the coefficient already used by the implementations.

## Data Impact

None. No calculation or output code changes.

## Breaking Changes

None.

## Tests

- `uv run pytest tests/unit/test_accounting_formulas.py` — 18 passed
- `uv run ruff check src/jkp/data/ tests/` — passed
- `uv run ruff format --check src/jkp/data/ tests/` — 95 files already formatted

No test was added because this is a documentation-only correction; the existing O-score tests pass.

## Checklist

- [x] I have run the tests locally (`pytest`)
- [x] I have run the linter locally (`ruff check src/jkp/data/ tests/`)
- [ ] I have verified the pipeline runs successfully after my changes
- [x] I have updated documentation if needed
- [x] I have considered whether this change affects factor calculations

## Additional Notes

The data pipeline was not run because this change only corrects a documented constant and does not modify executable code.
