### PR TITLE
Compute overnight and intraday portfolio returns

### DIFF
--- a/CHANGELOG_DATA.md
+++ b/CHANGELOG_DATA.md
@@ -3,6 +3,10 @@ This change log keeps track of changes to the underlying data set. In brackets, 
 
 This repository ports the original SAS pipeline ([ReplicationCrisis](https://github.com/bkelly-lab/ReplicationCrisis)) to Python using Polars. Entries up to and including 05-03-2025 are from the original change log.
 
+## 30-07-2026
+__Changes__:
+- Added daily overnight/intraday factor portfolios in both USD and local currency under `portfolios/`, parallel to the standard excess-return daily factors. Sorting and breakpoints use the usual `ret_exc_lead1m` characteristic sorts; only the daily return leg changes. For each component in `{overnight, intraday, overnight_local, intraday_local}` (using `ret_overnight`, `ret_intraday`, `ret_overnight_local`, `ret_intraday_local` respectively), the pipeline writes `pfs_{component}.parquet`, `hml_{component}.parquet`, `lms_{component}.parquet`, `clusters_{component}.parquet`, plus `regional_factors_{component}/`, `regional_clusters_{component}/`, and `country_factors_{component}/`. O/I portfolio returns are not excess returns (no risk-free subtraction). Winsorization of the daily return leg applies only to the standard `ret_exc` path; O/I legs are aggregated as-is. Industry and characteristics-managed portfolios are not rebuilt for O/I components. Monthly O/I factor portfolios are not produced.
+
 ## 23-07-2026
 __Changes__:
 - Added local-currency overnight/intraday return columns (`ret_intraday_local`, `ret_overnight_local`) alongside the existing USD versions, following the Lou, Polk, and Skouras (2019) decomposition:
@@ -11,6 +15,7 @@ __Changes__:
   - `ret_intraday_local = ret_intraday` (FX cancels in the open/close ratio)
   - `ret_overnight_local = (1 + ret_local) / (1 + ret_intraday_local) − 1`
   so that `(1 + ret_intraday)(1 + ret_overnight) = (1 + ret)` and `(1 + ret_intraday_local)(1 + ret_overnight_local) = (1 + ret_local)`. The overnight residual against `ret_local` instead of `ret` means daily FX moves no longer appear in `ret_overnight_local`. New columns are propagated through monthly compounding (`ret_intraday_local`, `ret_overnight_local`), one-month-ahead leads (`ret_intraday_local_lead1m`, `ret_overnight_local_lead1m`), daily country files, monthly returns, and daily factor portfolios. Also added the previously missing `_lead1m` columns for the USD variants to the monthly returns output.
+
 ## 15-07-2026
 __Changes__:
 - Applied the daily `zero_obs < 10` quality screen only to Compustat-sourced rows; CRSP stock-months with many zero-return days are no longer dropped from daily return-based characteristics and market correlation inputs

--- a/documentation/documentation.tex
+++ b/documentation/documentation.tex
@@ -123,8 +123,12 @@ Jensen is at Yale School of Management; \url{www.tijensen.com}. Kelly is at AQR 
 \textbf{Date} & \textbf{Changes} \\
 \hline
 \endhead
+07-30-2026 & \textbullet~Added daily overnight/intraday factor portfolios in USD and local currency under \texttt{portfolios/} for components \texttt{overnight}, \texttt{intraday}, \texttt{overnight\_local}, and \texttt{intraday\_local} (files \texttt{pfs\_\{component\}}, \texttt{hml\_\{component\}}, \texttt{lms\_\{component\}}, \texttt{clusters\_\{component\}}, plus regional and country-factor directories). Sorting uses the standard \texttt{ret\_exc\_lead1m} characteristic sorts; only the daily return leg changes. \\
+& \textbullet~Affected output files: \texttt{portfolios/pfs\_\{overnight,intraday,overnight\_local,intraday\_local\}.parquet}, and the corresponding \texttt{hml\_}, \texttt{lms\_}, \texttt{clusters\_}, \texttt{regional\_factors\_}, \texttt{regional\_clusters\_}, and \texttt{country\_factors\_} outputs. \\
+\hline
 07-23-2026 & \textbullet~Added overnight/intraday return columns (\texttt{ret\_intraday}, \texttt{ret\_overnight}, \texttt{ret\_intraday\_local}, \texttt{ret\_overnight\_local}) and their \texttt{\_lead1m} variants, following Lou, Polk, and Skouras (2019): \texttt{ret\_intraday} $= P_{\mathrm{close}}/P_{\mathrm{open}}-1$, \texttt{ret\_overnight} $=(1+\texttt{ret})/(1+\texttt{ret\_intraday})-1$, \texttt{ret\_intraday\_local} $=\texttt{ret\_intraday}$ (FX cancels), and \texttt{ret\_overnight\_local} $=(1+\texttt{ret\_local})/(1+\texttt{ret\_intraday\_local})-1$. Also added previously missing \texttt{\_lead1m} columns for the USD overnight/intraday variants to the monthly returns output. \\
 & \textbullet~Affected output files: \texttt{return\_data/world\_dsf.parquet}, \texttt{return\_data/world\_ret\_monthly.parquet}, \texttt{return\_data/daily\_rets\_by\_country/}, daily overnight/intraday factor portfolios under \texttt{portfolios/}. \\
+\hline
 07-15-2026 & \textbullet~Made the daily $\geq$10 zero-return-day screen source-conditional. Previously a stock-month with at least ten zero-return days was excluded from all daily return-based rolling statistics. This screen was intended for Compustat Global data quality, but it also removed CRSP stock-months with spurious zero-return days (especially 1973--1982), lowering US coverage of daily return-based characteristics. The screen now applies only to Compustat-sourced rows; CRSP-sourced rows are exempt. \\
 \hline
 04-03-2026 & \textbullet~Added \texttt{ret\_exc\_wins} column to \texttt{world\_dsf}, \texttt{world\_msf}, and \texttt{world\_data}. This is a pre-winsorized excess return clipped at the 0.1\%/99.9\% percentiles per period using cutoffs from \texttt{return\_cutoffs.parquet} / \texttt{return\_cutoffs\_daily.parquet}. CRSP returns are left unchanged; only Compustat returns are winsorized. \\
@@ -195,6 +199,7 @@ Jensen is at Yale School of Management; \url{www.tijensen.com}. Kelly is at AQR 
 	\item For a factor return to be non-missing, we require that it has at least 5 stocks in each of the long and short legs. We also require a minimum of 60 valid monthly observations for each country-specific factor for inclusion in our sample.  
 	\item We update characteristics with the most recent accounting data (which could be either annual or quarterly) starting four months after the end of the fiscal period.
 	\item To compute a cluster (theme) return, we first sign factors according to the original reference, then we equal-weight the returns of factors within a specific cluster. The signing convention and cluster allocation follows  \cite{JensenKellyPedersen2023} and we show it in table \ref{tbl:factor:details}.
+	\item In addition to standard excess-return factors, we construct daily overnight and intraday factor portfolios in both USD and local currency, following Lou, Polk, and Skouras (2019). Characteristic sorts and breakpoints are identical to the standard daily factors; only the contemporaneous daily return leg aggregated into portfolio weights differs (\texttt{ret\_overnight}, \texttt{ret\_intraday}, \texttt{ret\_overnight\_local}, or \texttt{ret\_intraday\_local}). See \hyperref[sec:oi-portfolios]{Overnight and Intraday Factor Portfolios} for output files.
 \end{itemize}
 
 \section{Public data not on jkpfactors.com}
@@ -286,6 +291,51 @@ We share long/short factor returns on \url{jkpfactors.com/factor-returns}, but w
 	ret\_vw\_cap & Capped value weight return for the tercile on the date.\\[1ex]
 	
 \end{longtable}}
+
+
+\subsection{Overnight and Intraday Factor Portfolios}\label{sec:oi-portfolios}
+
+\begin{itemize}
+  \item Alongside the standard excess-return daily factors (\texttt{pfs\_daily}, \texttt{hml\_daily}, \texttt{lms\_daily}, \ldots), we write parallel daily factor portfolios that use overnight or intraday stock returns as the return leg, in both USD and local currency.
+  \item Characteristic sorts, breakpoints, EW/VW/VW-cap weighting, and HML/LMS/cluster/regional aggregation reuse the standard portfolio machinery. Only the daily return column aggregated into portfolio weights changes.
+  \item The four components and their return columns are:
+
+  \begin{center}
+  \begin{tabular}{|l|l|l|}
+  \hline
+  \textbf{Component} & \textbf{Daily return column} & \textbf{Currency} \\
+  \hline
+  \texttt{overnight} & \texttt{ret\_overnight} & USD \\
+  \texttt{intraday} & \texttt{ret\_intraday} & USD \\
+  \texttt{overnight\_local} & \texttt{ret\_overnight\_local} & Local \\
+  \texttt{intraday\_local} & \texttt{ret\_intraday\_local} & Local \\
+  \hline
+  \end{tabular}
+  \end{center}
+
+  \item For each component \texttt{\{component\}}, the following outputs are written under \texttt{portfolios/}:
+
+  \begin{center}
+  \begin{tabular}{|l|p{8.5cm}|}
+  \hline
+  \textbf{Path} & \textbf{Description} \\
+  \hline
+  \texttt{pfs\_\{component\}.parquet} & Daily tercile portfolio returns \\
+  \texttt{hml\_\{component\}.parquet} & Daily high-minus-low spreads \\
+  \texttt{lms\_\{component\}.parquet} & Daily long-minus-short factors \\
+  \texttt{clusters\_\{component\}.parquet} & Daily cluster (theme) factors \\
+  \texttt{regional\_factors\_\{component\}/} & Daily regional factors (one file per region) \\
+  \texttt{regional\_clusters\_\{component\}/} & Daily regional cluster factors \\
+  \texttt{country\_factors\_\{component\}/} & Daily per-country factors (one file per country) \\
+  \hline
+  \end{tabular}
+  \end{center}
+
+  \item Column schemas match the corresponding standard daily files (e.g.\ \texttt{pfs\_daily}, \texttt{lms\_daily}): \texttt{date}, \texttt{characteristic}, \texttt{excntry}, \texttt{ret\_ew}, \texttt{ret\_vw}, \texttt{ret\_vw\_cap}, and related fields.
+  \item Daily-return winsorization applies only to the standard \texttt{ret\_exc} path; O/I legs are aggregated as-is.
+  \item For US/CRSP stocks, local and USD O/I components coincide. Local variants matter for international Compustat securities, where FX would otherwise enter the USD overnight residual. Because FX cancels in the open/close ratio, \texttt{ret\_intraday\_local} equals \texttt{ret\_intraday}, so the \texttt{intraday} and \texttt{intraday\_local} portfolio suites are identical.
+  \item Industry portfolios and characteristics-managed portfolios (\texttt{cmp}) are not rebuilt for O/I components. Monthly overnight/intraday factor portfolios are not produced.
+\end{itemize}
 
 
 \subsection{GICS Industry Returns (\texttt{industry\_gics.csv})}
@@ -1934,8 +1984,7 @@ Monthly overnight and intraday returns are obtained by compounding the correspon
     r_{\mathrm{month}}
         = \prod_{d \in \mathrm{month}} \left(1 + r_d\right) - 1.
 \]
-```
-
+These stock-level columns are also used as the daily return leg when constructing overnight/intraday factor portfolios; see \hyperref[sec:oi-portfolios]{Overnight and Intraday Factor Portfolios}.
 
 \noindent\textbf{Market Variables}
 

--- a/src/jkp/data/portfolio.py
+++ b/src/jkp/data/portfolio.py
@@ -22,6 +22,7 @@ __all__ = [  # noqa: F822 — lazy via __getattr__
     "_build_industry_daily_returns",
     "_build_industry_monthly_returns",
     "_build_hml_lms",
+    "_build_oi_factor_returns",
     "portfolios",
     "regional_data",
     "_build_regional_loop",
@@ -60,6 +61,160 @@ def __getattr__(name: str) -> _Any:
 def __dir__() -> list[str]:
     standard_dunders = {n for n in globals() if n.startswith("__") and n.endswith("__")}
     return sorted(set(__all__) | standard_dunders)
+
+
+def _build_oi_factor_returns(
+    *,
+    component: str,
+    daily_ret_col: str,
+    paths: DataPaths,
+    countries: list[str],
+    chars: list[str],
+    settings: dict,
+    char_info: pl.DataFrame,
+    cluster_labels: pl.DataFrame,
+    regions: pl.DataFrame,
+    market_daily: pl.DataFrame,
+    nyse_size_cutoffs: pl.DataFrame,
+    ret_cutoffs: pl.DataFrame,
+    ret_cutoffs_daily: pl.DataFrame | None,
+) -> dict[str, pl.DataFrame | None]:
+    """Build daily factor portfolios for an overnight or intraday return component.
+
+    Description:
+        Run the per-country portfolio loop with ``daily_ret_col`` overriding
+        the default daily return column, keeping the standard
+        ``ret_exc_lead1m`` sort.  Only daily outputs are produced (monthly
+        O/I factor portfolios are not constructed).  The function stacks
+        country results and builds HML, LMS, cluster, and regional daily
+        aggregates.
+    Output:
+        Dict with keys ``pf_daily``, ``hml_daily``, ``lms_daily``,
+        ``cluster_pfs_daily``, ``regional_pfs_daily``,
+        ``regional_clusters_daily`` (values may be ``None``).
+    """
+    from .aux_functions import (
+        _build_hml_lms,
+        _build_regional_loop,
+        _stack_outputs,
+        portfolios,
+    )
+
+    portfolio_data: dict = {}
+    for ex in countries:
+        print(
+            f"  {component} – {ex}: {countries.index(ex) + 1} out of {len(countries)}",
+            flush=True,
+        )
+        result = portfolios(
+            paths=paths,
+            excntry=ex,
+            chars=chars,
+            pfs=settings["pfs"],
+            bps=settings["bps"],
+            bp_min_n=settings["bp_min_n"],
+            nyse_size_cutoffs=nyse_size_cutoffs,
+            source=settings["source"],
+            wins_ret=settings["wins_ret"],
+            cmp_key=False,
+            signals=False,
+            daily_pf=True,
+            ind_pf=False,
+            ret_cutoffs=ret_cutoffs,
+            ret_cutoffs_daily=ret_cutoffs_daily,
+            daily_ret_col=daily_ret_col,
+        )
+        portfolio_data[ex] = result
+
+    pf_daily = _stack_outputs(
+        portfolio_data, "pf_daily", ["excntry", "characteristic", "pf", "date"]
+    )
+
+    if pf_daily is None or pf_daily.height == 0:
+        return {}
+
+    hml_daily, lms_daily = _build_hml_lms(
+        pf_daily, char_info, settings["pfs"], "date", include_signal=False
+    )
+
+    cluster_pfs_daily: pl.DataFrame | None = None
+    if lms_daily is not None:
+        cluster_pfs_daily = (
+            lms_daily.join(cluster_labels, on="characteristic", how="left")
+            .group_by(["excntry", "cluster", "date"])
+            .agg(
+                [
+                    pl.len().alias("n_factors"),
+                    pl.col("ret_ew").mean().alias("ret_ew"),
+                    pl.col("ret_vw").mean().alias("ret_vw"),
+                    pl.col("ret_vw_cap").mean().alias("ret_vw_cap"),
+                ]
+            )
+        )
+
+    weighting = settings["regional_pfs"]["country_weights"]
+    months_min = settings["regional_pfs"]["months_min"]
+    stocks_min = settings["regional_pfs"]["stocks_min"]
+    lms_cols_daily = [
+        "region",
+        "characteristic",
+        "direction",
+        "date",
+        "n_countries",
+        "ret_ew",
+        "ret_vw",
+        "ret_vw_cap",
+        "mkt_vw_exc",
+    ]
+    cluster_cols_daily = [
+        "region",
+        "cluster",
+        "date",
+        "n_countries",
+        "ret_ew",
+        "ret_vw",
+        "ret_vw_cap",
+        "mkt_vw_exc",
+    ]
+
+    regional_pfs_daily: pl.DataFrame | None = None
+    if lms_daily is not None:
+        regional_pfs_daily = _build_regional_loop(
+            data=lms_daily,
+            mkt=market_daily,
+            regions=regions,
+            date_col="date",
+            char_col="characteristic",
+            output_cols=lms_cols_daily,
+            weighting=weighting,
+            periods_min=months_min * 21,
+            stocks_min=stocks_min,
+        )
+
+    regional_clusters_daily: pl.DataFrame | None = None
+    if cluster_pfs_daily is not None:
+        regional_clusters_daily = _build_regional_loop(
+            data=cluster_pfs_daily.rename({"n_factors": "n_stocks_min"}).with_columns(
+                pl.lit(None).cast(pl.Float64).alias("direction")
+            ),
+            mkt=market_daily,
+            regions=regions,
+            date_col="date",
+            char_col="cluster",
+            output_cols=cluster_cols_daily,
+            weighting=weighting,
+            periods_min=months_min * 21,
+            stocks_min=1,
+        )
+
+    return {
+        "pf_daily": pf_daily,
+        "hml_daily": hml_daily,
+        "lms_daily": lms_daily,
+        "cluster_pfs_daily": cluster_pfs_daily,
+        "regional_pfs_daily": regional_pfs_daily,
+        "regional_clusters_daily": regional_clusters_daily,
+    }
 
 
 def run_portfolio(*, output_format: str = "parquet", output_dir: Path) -> None:
@@ -491,6 +646,87 @@ def run_portfolio(*, output_format: str = "parquet", output_dir: Path) -> None:
             "date",
             end_date,
         )
+
+    # Overnight / Intraday daily factor portfolios (LPS 2019 decomposition).
+    # Sorting uses the standard ret_exc_lead1m universe; only the daily
+    # return column aggregated into portfolio weights changes.
+    if settings["daily_pf"]:
+        oi_components = [
+            ("overnight", "ret_overnight"),
+            ("intraday", "ret_intraday"),
+            ("overnight_local", "ret_overnight_local"),
+            ("intraday_local", "ret_intraday_local"),
+        ]
+        for component, ret_col in oi_components:
+            sample_path = (
+                paths.processed_dir
+                / "return_data"
+                / "daily_rets_by_country"
+                / f"{countries[0]}.parquet"
+            )
+            daily_schema = pl.scan_parquet(sample_path).collect_schema()
+            if ret_col not in daily_schema.names():
+                print(
+                    f"Skipping {component}: {ret_col} not found in daily return files",
+                    flush=True,
+                )
+                continue
+
+            print(f"Building {component} daily factor portfolios...", flush=True)
+            oi = _build_oi_factor_returns(
+                component=component,
+                daily_ret_col=ret_col,
+                paths=paths,
+                countries=countries,
+                chars=chars,
+                settings=settings,
+                char_info=char_info,
+                cluster_labels=cluster_labels,
+                regions=regions,
+                market_daily=market_daily,
+                nyse_size_cutoffs=nyse_size_cutoffs,
+                ret_cutoffs=ret_cutoffs,
+                ret_cutoffs_daily=ret_cutoffs_daily,
+            )
+
+            if not oi:
+                print(f"No {component} results produced", flush=True)
+                continue
+
+            oi_single = [
+                (oi.get("pf_daily"), f"pfs_{component}.parquet"),
+                (oi.get("hml_daily"), f"hml_{component}.parquet"),
+                (oi.get("lms_daily"), f"lms_{component}.parquet"),
+                (oi.get("cluster_pfs_daily"), f"clusters_{component}.parquet"),
+            ]
+            for df, name in oi_single:
+                if df is not None:
+                    _write_filtered(df, portfolios_dir / name, "date", end_date)
+
+            if oi.get("regional_pfs_daily") is not None:
+                _write_split_by_key(
+                    oi["regional_pfs_daily"],
+                    portfolios_dir / f"regional_factors_{component}",
+                    "region",
+                    "date",
+                    end_date,
+                )
+            if oi.get("regional_clusters_daily") is not None:
+                _write_split_by_key(
+                    oi["regional_clusters_daily"],
+                    portfolios_dir / f"regional_clusters_{component}",
+                    "region",
+                    "date",
+                    end_date,
+                )
+            if oi.get("lms_daily") is not None:
+                _write_split_by_key(
+                    oi["lms_daily"],
+                    portfolios_dir / f"country_factors_{component}",
+                    "excntry",
+                    "date",
+                    end_date,
+                )
 
     # Convert to CSV if configured
     convert_outputs_to_csv(processed_dir=paths.processed_dir)


### PR DESCRIPTION
# Daily overnight/intraday factor portfolios (USD and local)

## Summary

This PR builds on #253 and extends the portfolio step (`jkp portfolio`) to construct **daily** factor portfolios using overnight and intraday return components in both **USD** and **local currency**, writing them as parallel outputs alongside the existing excess-return factors under `data/processed/portfolios/`.

It reuses the standard JKP portfolio machinery (ECDF sorting, breakpoints, EW/VW/VW-cap weighting, HML/LMS aggregation, country/regional/cluster rollups).

**Prerequisite:** Stock-level O/I columns must already exist in `data/processed/return_data/daily_rets_by_country/` from the build step:
`ret_overnight`, `ret_intraday`, `ret_overnight_local`, `ret_intraday_local`.

### Return columns used

| Component | Daily portfolio return column | Currency |
|-----------|-------------------------------|----------|
| Overnight | `ret_overnight` | USD |
| Intraday | `ret_intraday` | USD |
| Overnight (local) | `ret_overnight_local` | Local |
| Intraday (local) | `ret_intraday_local` | Local |

- **Sorting / universe:** always the standard monthly `ret_exc_lead1m` from characteristics (unchanged).
- **Daily return leg:** the component column above (contemporaneous daily returns).
- **Monthly O/I factor portfolios:** not produced (monthly compounded O/I stock returns exist in characteristics, but are not used here).

### Implementation

- **`_build_oi_factor_returns`** (`portfolio.py`): Runs the full per-country portfolio loop for one return component at daily frequency only. Calls `portfolios()` with the standard sort (`ret_exc_lead1m`) and an overridden `daily_ret_col`, then stacks country results and builds daily HML, LMS, cluster, and regional outputs.
- **`run_portfolio`** (`portfolio.py`): After writing standard excess-return outputs, when `daily_pf` is enabled, loops over:

  ```python
  ("overnight", "ret_overnight"),
  ("intraday", "ret_intraday"),
  ("overnight_local", "ret_overnight_local"),
  ("intraday_local", "ret_intraday_local"),
  ```

  Checks that the required daily column exists in the daily return files; skips gracefully with a log message if not.
- **`portfolios()`** (`aux_functions.py`): Accepts `daily_ret_col` (default `ret_exc`). Dynamically selects the requested daily return column. Winsorization of daily returns is applied only for the standard `ret_exc` path; O/I legs are aggregated as-is.

### Output files

Written under `data/processed/portfolios/` when `daily_pf` is enabled. For each `{component}` in
`overnight`, `intraday`, `overnight_local`, `intraday_local`:

| Path | Description |
|------|-------------|
| `pfs_{component}.parquet` | Daily decile portfolio returns |
| `hml_{component}.parquet` | Daily HML spreads |
| `lms_{component}.parquet` | Daily LMS factors |
| `clusters_{component}.parquet` | Daily cluster factors |
| `regional_factors_{component}/` | Daily regional factors (one parquet per region) |
| `regional_clusters_{component}/` | Daily regional clusters |
| `country_factors_{component}/` | Daily per-country factors (one parquet per country) |

Existing standard outputs (`pfs.parquet`, `pfs_daily.parquet`, `lms.parquet`, industry files, etc.) are unchanged.

### Design notes

- Sorting and breakpoints are identical to standard factors; only the daily return leg aggregated into portfolio weights differs.
- Component returns are **not** excess returns (no risk-free subtraction on the O/I leg). This matches Lou, Polk, and Skouras (2019).
- For US/CRSP stocks, local and USD O/I components coincide (`ret_local == ret`). Local variants matter for international Compustat securities where FX moves would otherwise enter the USD overnight residual.
- Industry portfolios and characteristics-managed portfolios (`cmp`) are not rebuilt for O/I components.
- Monthly overnight/intraday factor portfolios are out of scope for this PR.

## Methodology reference

Lou, Polk, and Skouras (2019), *A Tug of War: Overnight Versus Intraday Expected Returns*, Journal of Financial Economics.

## Test plan

- [ ] `uv run pytest tests/unit/` — existing unit tests still pass
- [ ] `uv run ruff check src/jkp/data/portfolio.py src/jkp/data/aux_functions.py`
- [ ] `uv run ruff format --check src/jkp/data/ tests/`
- [ ] Run `jkp portfolio data/` and confirm under `data/processed/portfolios/`:
  - [ ] Standard monthly/daily outputs still written
  - [ ] All four O/I suites present (`overnight`, `intraday`, `overnight_local`, `intraday_local`)
  - [ ] Files such as `lms_overnight.parquet`, `lms_intraday_local.parquet`, and `country_factors_overnight/USA.parquet` have expected columns (`date`, `characteristic`, `ret_ew` / `ret_vw` / `ret_vw_cap`, …)
  - [ ] For a given characteristic, daily O/I LMS returns differ from standard `lms_daily` excess returns
  - [ ] For a non-US country with FX variation, local and USD overnight LMS series are not identical