### PR TITLE
docs: correct stale file paths in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ The pipeline has two entry points that run sequentially:
 
 Raw WRDS data → `data/raw/` → intermediate processing in `data/interim/` → final outputs in `data/processed/` (subdirectories: `characteristics/`, `portfolios/`, `return_data/`, `accounting_data/`, `other_output/`).
 
-Static reference data (`data/cluster_labels.csv`, `data/country_classification.xlsx`, `data/factor_details.xlsx`) is checked into the repo and used by the pipeline.
+Static reference data (`src/jkp/data/resources/cluster_labels.csv`, `src/jkp/data/resources/country_classification.xlsx`, `src/jkp/data/resources/factor_details.xlsx`) is packaged with the code and loaded via `_resource_path()` in `paths.py`, not read from the output directory.
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you do not have a WRDS subscription, you can still access pre-computed factor
    **IMPORTANT:** When starting the code, you may be prompted to grant access to WRDS using two-factor authentication, for example via a Duo notification. You need to approve this request, as the program will otherwise fail. After a few seconds or minutes, you should see data being created in the output directory. If that is not the case, please check your internet connection or credentials.
 
 When the code is finished, you can find the output in the `processed/` subdirectory of your output directory (e.g. `data/processed/`).
-Please see the release notes (`documentation/release_notes.html`) for a description of the output files and a comparison between the output of the SAS/R codebase and the new Python codebase.
+Please see the release notes (`documentation/sas_to_python/release_notes.html`) for a description of the output files and a comparison between the output of the SAS/R codebase and the new Python codebase.
 
 ## Notes
 - By default, output files are written in Parquet format. To output CSV files instead (with quoted strings to preserve leading zeros in identifiers like `gvkey`), run:


### PR DESCRIPTION
## Simple explanation

Two places in the docs point at files that have moved, so following either one leads nowhere. This corrects both paths. Nothing about the pipeline changes.

The README one is what a new user is handed right after their first successful run — the pointer to the release notes describing the output files and the SAS/R-to-Python comparison. It renders as plain text rather than a link, so it fails quietly: you try the path, find nothing, and have no way to tell the document exists.

The `CLAUDE.md` one told Claude Code that the static reference data sits in `data/`. It does not — it ships inside the package. That is the kind of stale fact that gets acted on rather than checked, so the line is rewritten to say where the files actually are and how they are loaded.

## Technical details

| File | Was | Now |
| --- | --- | --- |
| `README.md:74` | `documentation/release_notes.html` | `documentation/sas_to_python/release_notes.html` |
| `CLAUDE.md:69` | `data/cluster_labels.csv`, `data/country_classification.xlsx`, `data/factor_details.xlsx` | `src/jkp/data/resources/…`, described as packaged with the code and loaded via `_resource_path()` |

Neither was a typo. Both were correct when written and broke when the files were relocated — the release notes into `documentation/sas_to_python/`, the static data into `src/jkp/data/resources/` as part of packaging. The `CLAUDE.md` line also had its claim corrected, not just its path: "checked into the repo and used by the pipeline" implied the pipeline reads these from the data directory, when `_resource_path()` (`src/jkp/data/paths.py:39-70`) resolves them from package resources. That distinction matters — it is why pointing a run at an arbitrary output directory does not strand the reference data.

This is the first half of #273. The second half — a CI guard so the next relocation fails a check instead of waiting to be tripped over — is deliberately left out so it can be reviewed on its own merits. Without it these two lines are simply correct again, with nothing preventing a third.

## Test plan

No code changed, so there is nothing for pytest or ruff to exercise; CI runs clean by construction.

Verified the paths directly:

```sh
$ ls documentation/sas_to_python/release_notes.html
documentation/sas_to_python/release_notes.html

$ ls src/jkp/data/resources/cluster_labels.csv
src/jkp/data/resources/cluster_labels.csv
```

I also swept every backticked and Markdown-linked repo-relative path in `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, and `tests/README.md`. These two were the only ones that did not resolve, so this PR closes out the current instances in full.

Fixes the reference-correction portion of #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8YH76rEtDH4USyoyUqSdA
