### PR TITLE
fix: verify WRDS credentials before persisting them

### DIFF
--- a/src/jkp/data/cli.py
+++ b/src/jkp/data/cli.py
@@ -120,7 +120,9 @@ def connect(
 
     Opens a real WRDS connection (attaches the database read-only and runs a
     trivial query), so a successful run confirms credentials, connectivity,
-    and MFA all actually work. This may trigger a WRDS Duo MFA push: WRDS trusts a
+    and MFA all actually work. A password entered at the prompt is verified
+    before it is stored, so a typo is never persisted and simply re-prompts on
+    the next run. This may trigger a WRDS Duo MFA push: WRDS trusts a
     username/IP pair for 30 days after a successful approval, so expect one on the
     first run from a new IP and again once that window expires.
 
@@ -157,8 +159,13 @@ def connect(
         # plaintext password may be bound in this frame when the import runs.
         from .wrds_connection import verify_wrds_connection
 
-        creds = get_wrds_credentials()
-        verify_wrds_connection(creds.username, creds.password)
+        # Injected rather than called on the result: on the freshly-prompted path the
+        # check has to run between the prompt and the store, which is inside
+        # get_wrds_credentials. It verifies every resolution path exactly once, so
+        # verifying again here would open a second connection (and risk a second Duo
+        # push). Passing the function also keeps the plaintext password out of this
+        # frame on the prompt path.
+        creds = get_wrds_credentials(verify=verify_wrds_connection)
         typer.echo(f"Connected as: {creds.username}")
     except (RuntimeError, ValueError, OSError) as exc:
         # Anticipated, actionable failures from credential resolution and connection
@@ -168,10 +175,12 @@ def connect(
         # Their messages are password-free; surface the message and exit non-zero rather
         # than dumping a traceback.
         typer.echo(str(exc), err=True)
-        # A mistyped password is stored before it is ever verified, so the next run
-        # finds it, never re-prompts, and fails identically forever. --reset is the
-        # only way out, and it belongs here rather than in the wrds_connection
-        # messages, which pipeline workers share and for which it is not the fix.
+        # Still worth pointing at: a password typed at the prompt is now verified
+        # before it is stored, but one that arrived from an env var, an entry
+        # predating this check, or a hand-edited ~/.pgpass can still be wrong, and
+        # resolution never re-prompts while a stored value exists. Kept at the CLI
+        # layer because the wrds_connection messages are shared with pipeline worker
+        # paths, where --reset is not the right advice.
         typer.echo(
             "If a stored password is wrong, run `jkp connect --reset` and re-enter credentials.",
             err=True,

--- a/src/jkp/data/wrds_credentials.py
+++ b/src/jkp/data/wrds_credentials.py
@@ -35,6 +35,7 @@ import os
 import re
 import sys
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -64,6 +65,13 @@ _LEGACY_USER_FILE = Path.home() / ".wrds_user"
 # differs from platformdirs on macOS/Windows — so we must use keyring's function,
 # not platformdirs, to find the file keyrings.alt actually wrote.
 _LEGACY_KEYRING_FILE = Path(_keyring_data_root()) / "keyring_pass.cfg"
+
+
+# Signature of the connectivity check injected into get_wrds_credentials. Taking it
+# as a parameter rather than importing it keeps the dependency one-way: wrds_connection
+# imports the WRDS endpoint constants from here, so importing the verifier back would
+# be a cycle. Called as verify(username, password); raises on failure.
+VerifyConnection = Callable[[str, str | None], None]
 
 
 @dataclass(frozen=True)
@@ -542,14 +550,27 @@ def _resolve_username(env_user: str | None = None) -> str:
     )
 
 
-def _prompt_and_store(username: str) -> Credentials:
-    """Interactively obtain a password and persist it to the best available store."""
+def _prompt_verify_store(username: str, verify: VerifyConnection | None = None) -> Credentials:
+    """Interactively obtain a password, verify it, and persist it to the best store.
+
+    Nothing is written until ``verify`` returns. A mistyped password would otherwise
+    be stored and then resolved by every later run, which never re-prompts — leaving
+    the user stuck until they find ``jkp connect --reset``. With ``verify=None`` the
+    password is stored unverified, which is the historical behavior.
+
+    On the no-keyring fallback the check runs against the typed password in the
+    conninfo and the ``~/.pgpass`` line is written afterwards, so it proves the
+    credential rather than the written file.
+    """
     password = getpass.getpass(f"Password or token for {username} at {SERVICE_NAME}: ")
     if not password:
         # An empty password would be stored as a junk ``…:username:`` pgpass line
         # that later "resolves" while auth silently fails — reject it, mirroring
         # the empty-username guard.
         raise RuntimeError(f"Empty password entered for {username}; nothing stored.")
+    if verify is not None:
+        # Raises on failure, so every write below is unreachable for a bad password.
+        verify(username, password)
     # Cache the username alongside the stored password, so a credential provisioned
     # for an env-provided WRDS_USERNAME (which _resolve_username does not persist)
     # is still revocable via `jkp connect --reset` rather than orphaned.
@@ -581,7 +602,14 @@ def _no_credentials_error(username: str) -> RuntimeError:
     )
 
 
-def get_wrds_credentials() -> Credentials:
+def _verified(creds: Credentials, verify: VerifyConnection | None) -> Credentials:
+    """Run the injected connectivity check against already-stored credentials."""
+    if verify is not None:
+        verify(creds.username, creds.password)
+    return creds
+
+
+def get_wrds_credentials(verify: VerifyConnection | None = None) -> Credentials:
     """Resolve WRDS credentials following the documented precedence order.
 
     Steps:
@@ -590,6 +618,13 @@ def get_wrds_credentials() -> Credentials:
       3. Password: ``WRDS_PASSWORD`` → system keyring → ``~/.pgpass``/``$PGPASSFILE``.
       4. If nothing is found and a terminal is available, prompt and store;
          otherwise raise with actionable guidance.
+
+    ``verify`` is an optional connectivity check (in practice
+    ``wrds_connection.verify_wrds_connection``, injected rather than imported to keep
+    the module dependency one-way). When given it runs on every path exactly once —
+    before persisting on the freshly-prompted path, and as a plain check on the paths
+    that read an existing store — so callers must not verify the result again. Each
+    call opens a real WRDS connection, so a second check risks a second Duo MFA push.
     """
     # Strip before the truthiness check so WRDS_USERNAME="   " is treated as
     # unset rather than accepted as username="".
@@ -600,20 +635,20 @@ def get_wrds_credentials() -> Credentials:
         # "password"-named identifier flows into a logging sink — the value is
         # never logged, only the source label.
         _log_source("the WRDS_USERNAME/WRDS_PASSWORD environment variables")
-        return Credentials(env_user, env_pw)  # env_user already stripped/non-empty
+        return _verified(Credentials(env_user, env_pw), verify)  # env_user already stripped
 
     username = _resolve_username(env_user)
 
     if env_pw:
         _log_source("the WRDS_PASSWORD environment variable")
-        return Credentials(username, env_pw)
+        return _verified(Credentials(username, env_pw), verify)
 
     keyring_pw = _keyring_get(username)
     if keyring_pw:
         # The keyring supersedes any legacy plaintext copy; clean it up.
         _cleanup_legacy_keyring_section(username)
         _log_source("the system keyring")
-        return Credentials(username, keyring_pw)
+        return _verified(Credentials(username, keyring_pw), verify)
 
     # One-time migration off the legacy plaintext keyring, reached only when
     # neither an env password nor a system-keyring entry supplied the password.
@@ -646,10 +681,10 @@ def get_wrds_credentials() -> Credentials:
                 file=sys.stderr,
                 flush=True,
             )
-        return Credentials(username, None)
+        return _verified(Credentials(username, None), verify)
 
     if _interactive():
-        return _prompt_and_store(username)
+        return _prompt_verify_store(username, verify)
 
     raise _no_credentials_error(username)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -172,8 +172,10 @@ class TestConnectCommand:
         result = runner.invoke(app, ["connect"])
         assert result.exit_code == 0
         assert "testuser" in result.output
-        mock_get_creds.assert_called_once()
-        mock_verify.assert_called_once()
+        # The verifier is handed to the resolver rather than called on its result, so
+        # the freshly-prompted path can run it between the prompt and the store.
+        mock_get_creds.assert_called_once_with(verify=mock_verify)
+        mock_verify.assert_not_called()
 
     @patch("jkp.data.wrds_credentials.reset_credentials")
     def test_connect_reset(self, mock_reset):

--- a/tests/unit/test_cli_connect.py
+++ b/tests/unit/test_cli_connect.py
@@ -3,6 +3,11 @@
 Complements TestConnectCommand in test_cli.py, focusing on how the command
 surfaces verify_wrds_connection's success/failure and never leaks the
 credential password into CLI output.
+
+`connect` injects the verifier into get_wrds_credentials rather than calling it
+on the result, so that a freshly prompted password is checked before it is
+stored. Verification failures therefore reach the command as an exception out of
+get_wrds_credentials, which is how these tests simulate them.
 """
 
 import re
@@ -36,16 +41,20 @@ class TestConnectVerification:
 
         assert result.exit_code == 0
         assert "Connected as:" in result.output
-        mock_verify.assert_called_once_with("testuser", "hunter2")
+        # Passed through, not applied here: verifying the returned credentials again
+        # would open a second WRDS connection and risk a second Duo push.
+        mock_get_creds.assert_called_once_with(verify=mock_verify)
+        mock_verify.assert_not_called()
 
     @patch("jkp.data.wrds_connection.verify_wrds_connection")
     @patch("jkp.data.wrds_credentials.get_wrds_credentials")
     def test_failure_exits_nonzero_with_message_on_stderr_no_traceback(
         self, mock_get_creds, mock_verify
     ):
-        mock_get_creds.return_value = Credentials(username="testuser", password="hunter2")
         message = "Failed to attach WRDS connection. Check credentials and MFA approval."
-        mock_verify.side_effect = RuntimeError(message)
+        # The injected verifier raises inside the resolver, so the failure surfaces
+        # from get_wrds_credentials rather than from a separate call in the command.
+        mock_get_creds.side_effect = RuntimeError(message)
 
         result = runner.invoke(app, ["connect"])
 
@@ -62,9 +71,8 @@ class TestConnectVerification:
         raising; this pins the CLI to surfacing that message verbatim without
         introducing a new leak (e.g. by echoing creds directly)."""
         password = "s3cr3t-p@ss"  # noqa: S105
-        mock_get_creds.return_value = Credentials(username="testuser", password=password)
         # Message the real code would raise: already password-free.
-        mock_verify.side_effect = RuntimeError(
+        mock_get_creds.side_effect = RuntimeError(
             "Failed to attach WRDS connection. Check credentials and MFA approval."
         )
 

--- a/tests/unit/test_wrds_credentials.py
+++ b/tests/unit/test_wrds_credentials.py
@@ -156,19 +156,19 @@ def test_empty_prompt_password_is_rejected(monkeypatch, _isolate_credential_stat
     monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "")
 
     with pytest.raises(RuntimeError, match="[Ee]mpty password"):
-        mod._prompt_and_store("testuser")
+        mod._prompt_verify_store("testuser")
     assert not mod._pgpass_path().exists() or "testuser" not in mod._pgpass_path().read_text()
 
 
 @pytest.mark.unit
-def test_prompt_and_store_persists_username_for_reset(monkeypatch, _isolate_credential_state):
+def test_prompt_verify_store_persists_username_for_reset(monkeypatch, _isolate_credential_state):
     """A credential provisioned for an env-provided WRDS_USERNAME (which the
     resolver does not persist) must still cache the username, so `jkp connect
     --reset` can revoke it rather than leaving an orphaned ~/.pgpass line."""
     mod = _isolate_credential_state
     monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
 
-    mod._prompt_and_store("env-user")  # no keyring in tests -> written to ~/.pgpass
+    mod._prompt_verify_store("env-user")  # no keyring in tests -> written to ~/.pgpass
 
     assert mod.LAST_USER_FILE.read_text().strip() == "env-user"  # cached for reset
     pgpass = mod._pgpass_path()
@@ -176,6 +176,140 @@ def test_prompt_and_store_persists_username_for_reset(monkeypatch, _isolate_cred
     # ...and reset can now find + remove it
     mod.reset_credentials(full_reset=True)
     assert not pgpass.exists() or "env-user" not in pgpass.read_text()
+
+
+@pytest.mark.unit
+def test_prompt_verify_store_verifies_before_storing(monkeypatch, _isolate_credential_state):
+    """The connectivity check must run before anything is written, so ordering — not
+    just the end state — is what this pins."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
+    events: list[str] = []
+
+    def record_write(_username, _password):
+        events.append("write_pgpass")
+        return mod._pgpass_path()
+
+    monkeypatch.setattr(mod, "_persist_username", lambda u: events.append("persist_username"))
+    monkeypatch.setattr(mod, "_write_pgpass", record_write)
+
+    mod._prompt_verify_store("testuser", lambda u, p: events.append(f"verify:{u}:{p}"))
+
+    assert events[0] == "verify:testuser:typed-secret"
+    assert events[1:] == ["persist_username", "write_pgpass"]
+
+
+@pytest.mark.unit
+def test_failed_verification_stores_nothing(monkeypatch, _isolate_credential_state):
+    """A mistyped password must leave no trace. Otherwise resolution finds it on the
+    next run, never re-prompts, and the user is stuck until they discover --reset."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "mistyped")
+    stored: dict[str, str] = {}
+    monkeypatch.setattr(mod.keyring, "set_password", lambda s, u, p: stored.update({u: p}))
+
+    def reject(_username, _password):
+        raise RuntimeError("Failed to attach WRDS connection.")
+
+    with pytest.raises(RuntimeError, match="Failed to attach"):
+        mod._prompt_verify_store("testuser", reject)
+
+    assert stored == {}  # nothing in the keyring
+    assert not mod._pgpass_path().exists()  # nothing in ~/.pgpass
+    assert not mod.LAST_USER_FILE.exists()  # no username cached either
+
+
+@pytest.mark.unit
+def test_verification_failure_leaves_next_run_able_to_prompt(
+    monkeypatch, _isolate_credential_state
+):
+    """End-to-end shape of the fix: a rejected password then a good one, with no
+    --reset in between. The second run must still prompt, which only holds because
+    the first stored nothing."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr(mod, "_interactive", lambda: True)
+    typed = iter(["mistyped", "correct-horse"])
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: next(typed))
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    seen: list[str] = []
+
+    def verify(_username, password):
+        seen.append(password)
+        if password == "mistyped":
+            raise RuntimeError("Failed to attach WRDS connection.")
+
+    with pytest.raises(RuntimeError, match="Failed to attach"):
+        mod.get_wrds_credentials(verify=verify)
+    assert not mod._pgpass_path().exists()
+
+    creds = mod.get_wrds_credentials(verify=verify)  # prompts again, no --reset needed
+
+    assert seen == ["mistyped", "correct-horse"]
+    assert creds.username == "testuser"
+    assert "correct-horse" in mod._pgpass_path().read_text()
+
+
+@pytest.mark.unit
+def test_verify_none_stores_without_checking(monkeypatch, _isolate_credential_state):
+    """Default (no verifier injected) keeps the historical behavior, which is what
+    run_pipeline still relies on."""
+    mod = _isolate_credential_state
+    monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
+
+    creds = mod._prompt_verify_store("testuser")
+
+    assert creds.username == "testuser"
+    assert "typed-secret" in mod._pgpass_path().read_text()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("setup", "expected_password"),
+    [
+        ("env", "env-secret"),
+        ("keyring", "kr-secret"),
+        ("pgpass", None),
+    ],
+)
+def test_stored_credentials_are_verified_exactly_once(
+    monkeypatch, _isolate_credential_state, setup, expected_password
+):
+    """Every resolution path runs the injected check exactly once. The CLI relies on
+    this to skip verifying the result itself — a second call would open a second WRDS
+    connection and risk a second Duo push."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    if setup == "env":
+        monkeypatch.setenv("WRDS_PASSWORD", "env-secret")
+    elif setup == "keyring":
+        monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "kr-secret")
+    else:
+        _write_pgpass(mod, "wrds-pgdata.wharton.upenn.edu:9737:wrds:testuser:stored\n")
+    calls: list[tuple[str, str | None]] = []
+
+    creds = mod.get_wrds_credentials(verify=lambda u, p: calls.append((u, p)))
+
+    assert calls == [("testuser", expected_password)]
+    assert creds.password == expected_password
+
+
+@pytest.mark.unit
+def test_failed_verification_of_stored_credentials_propagates(
+    monkeypatch, _isolate_credential_state
+):
+    """A stored-but-wrong password still fails loudly; it is simply not re-written."""
+    mod = _isolate_credential_state
+    mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    mod.LAST_USER_FILE.write_text("testuser")
+    monkeypatch.setattr(mod.keyring, "get_password", lambda *a, **kw: "stale-secret")
+
+    def reject(_username, _password):
+        raise RuntimeError("Failed to attach WRDS connection.")
+
+    with pytest.raises(RuntimeError, match="Failed to attach"):
+        mod.get_wrds_credentials(verify=reject)
 
 
 @pytest.mark.unit
@@ -208,13 +342,13 @@ def test_locked_keyring_warns_and_falls_through(monkeypatch, _isolate_credential
 @pytest.mark.unit
 def test_prompt_stores_to_pgpass_when_keyring_locked(monkeypatch, _isolate_credential_state):
     """The *store* side of a locked keyring: if set_password raises a KeyringError
-    (not NoKeyringError), _prompt_and_store must fall through to ~/.pgpass rather
+    (not NoKeyringError), _prompt_verify_store must fall through to ~/.pgpass rather
     than crash — the write-side mirror of the locked-keyring read fallback."""
     mod = _isolate_credential_state
     monkeypatch.setattr(mod.keyring, "set_password", _raises(mod.keyring.errors.KeyringLocked))
     monkeypatch.setattr("getpass.getpass", lambda *a, **kw: "typed-secret")
 
-    creds = mod._prompt_and_store("testuser")
+    creds = mod._prompt_verify_store("testuser")
 
     assert creds.username == "testuser"
     assert creds.password is None  # written to ~/.pgpass, not returned
@@ -855,7 +989,7 @@ def test_pgpass_escapes_special_username(_isolate_credential_state):
 
 
 @pytest.mark.unit
-def test_prompt_and_store_uses_keyring_when_available(monkeypatch, _isolate_credential_state):
+def test_prompt_verify_store_uses_keyring_when_available(monkeypatch, _isolate_credential_state):
     mod = _isolate_credential_state
     mod.LAST_USER_FILE.parent.mkdir(parents=True, exist_ok=True)
     mod.LAST_USER_FILE.write_text("u")
@@ -873,7 +1007,7 @@ def test_prompt_and_store_uses_keyring_when_available(monkeypatch, _isolate_cred
 
 
 @pytest.mark.unit
-def test_prompt_and_store_falls_back_to_pgpass_without_keyring(
+def test_prompt_verify_store_falls_back_to_pgpass_without_keyring(
     monkeypatch, _isolate_credential_state
 ):
     mod = _isolate_credential_state


### PR DESCRIPTION
Closes #274. Follow-up to the review of #257, where @capellini identified this ordering and deliberately scoped it out of that PR.

**Based on `246-jkp-connect-reports-success-without-testing`, not `main`** — it builds on `verify_wrds_connection`, which only exists on #257. Retarget to `main` once #257 merges.

## Simple explanation

If you mistyped your WRDS password at the `jkp connect` prompt, it got saved anyway. From then on `jkp connect` found the saved bad password, never asked you again, and failed the same way every time. The only escape was `jkp connect --reset`, which you had no particular reason to know about.

Now the password is checked against WRDS *before* it is saved. Get it wrong and nothing is written, so the next run just asks again.

## Technical details

`wrds_credentials` can't call `verify_wrds_connection` directly — `wrds_connection` imports the WRDS endpoint constants from it (`wrds_connection.py:16`), so importing the verifier back is a cycle. So it's injected rather than imported:

```python
def get_wrds_credentials(verify: VerifyConnection | None = None) -> Credentials:
```

On the freshly-prompted path, `_prompt_and_store` becomes `_prompt_verify_store` and the check runs between the prompt and the write:

```python
password = getpass.getpass(...)
if not password:
    raise RuntimeError(...)
if verify is not None:
    verify(username, password)   # raises -> every write below is unreachable
_persist_username(username)
if _keyring_set(username, password):
    ...
```

`verify` also runs on the paths that resolve an existing store (env vars, keyring, `~/.pgpass`), so **every path is verified exactly once** and `jkp connect` no longer calls the verifier on the result. That matters: verifying twice would open a second WRDS connection and risk a second Duo MFA push, which is the whole reason `connect_timeout` is 25s.

Two design notes:

- **Why injection over a prompt/store split.** The alternative — a prompt-without-store function plus an explicit store step orchestrated from the CLI — puts the plaintext password in the `connect()` frame across the verify, which is the hazard #257 just closed at `cli.py:152` and that #258/#259 address more broadly. It also makes every future caller responsible for getting the ordering right. Injection keeps both in one place.
- **`verify=None` is the default**, so behavior is unchanged for `run_pipeline` (`main.py:58`), which still prompts-and-stores without a check. Opting it in is a separate decision, not a silent side effect of this PR.

Two limits recorded rather than silently accepted, both noted in #274:

- On the no-keyring fallback the check runs against the typed password in the conninfo and `~/.pgpass` is written afterwards, so it proves the credential rather than the written file. Re-verifying after the write means a second connection for a case `_write_pgpass` already covers.
- `_migrate_legacy_keyring` still writes `~/.pgpass` during an otherwise read-only resolution, so it remains an unverified persist.

The `--reset` hint added in #257 stays, with its comment corrected — a password from an env var, an entry predating this check, or a hand-edited `~/.pgpass` can still be wrong, and resolution never re-prompts while a stored value exists.

## Test plan

Six new tests in `test_wrds_credentials.py`:

- `test_prompt_verify_store_verifies_before_storing` — pins the *ordering*, not just the end state: records the sequence and asserts `verify` precedes `_persist_username` and `_write_pgpass`.
- `test_failed_verification_stores_nothing` — keyring, `~/.pgpass` and the username cache all untouched.
- `test_verification_failure_leaves_next_run_able_to_prompt` — the end-to-end shape: a rejected password, then a good one, with no `--reset` in between.
- `test_verify_none_stores_without_checking` — the default preserves today's behavior.
- `test_stored_credentials_are_verified_exactly_once` — parametrized over env / keyring / pgpass, asserting one call with the right password (`None` for the pgpass path).
- `test_failed_verification_of_stored_credentials_propagates` — a stored-but-wrong password still fails loudly.

Updated: the three `_prompt_and_store` tests for the rename, and the four CLI tests that asserted the command called the verifier itself — they now assert it is passed through (`assert_called_once_with(verify=mock_verify)`) and that the command does not call it.

Full unit suite: 924 passed. `ruff check`, `ruff format --check` and `pyright` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQaokpyPnCv9Qz7PotiN5n
