### PR TITLE
docs: correct Ohlson O-score `_o_lat` definition and working-capital sign

### DIFF
--- a/documentation/documentation.tex
+++ b/documentation/documentation.tex
@@ -2529,7 +2529,7 @@ These stock-level columns are also used as the daily return leg when constructin
             \begin{itemize}
                 \item Create helper variables:
                 \begin{align*}
-                    \_o\_lat_t &= AT\mbox{*}_{t-1} \\
+                    \_o\_lat_t &= log\left(AT\mbox{*}_t\right) \\
                     \_o\_lev_t &= \frac{DEBT\mbox{*}_t}{AT\mbox{*}_t} \\
                     \_o\_wc_t &= \frac{CA\mbox{*}_t - CL\mbox{*}_t}{AT\mbox{*}_t}  \\
                     \_o\_roe_t &= \frac{NIX\mbox{*}_t}{AT\mbox{*}_t} \\

--- a/documentation/documentation.tex
+++ b/documentation/documentation.tex
@@ -2546,7 +2546,7 @@ These stock-level columns are also used as the daily return leg when constructin
             
                 \item Characteristic:
                 \begin{align*}
-                    o\_score_t =& -1.32 - 0.407 \times \_o\_lat_t + 6.03 \times \_o\_lev_t + 1.43 \times \_o\_wc_t + \\ &0.076 \times \_o\_cacl_t - 1.72 \times \_o\_neg\_eq_t - 2.37 \times \_o\_roe_t - \\ &1.83 \times \_o\_ffo_t + 0.285 \times \_o\_neg\_earn_t - 0.52 \times \_o\_nich_t
+                    o\_score_t =& -1.32 - 0.407 \times \_o\_lat_t + 6.03 \times \_o\_lev_t - 1.43 \times \_o\_wc_t + \\ &0.076 \times \_o\_cacl_t - 1.72 \times \_o\_neg\_eq_t - 2.37 \times \_o\_roe_t - \\ &1.83 \times \_o\_ffo_t + 0.285 \times \_o\_neg\_earn_t - 0.52 \times \_o\_nich_t
                 \end{align*}
             \end{itemize}
             

--- a/src/jkp/data/aux_functions.py
+++ b/src/jkp/data/aux_functions.py
@@ -5500,7 +5500,7 @@ def ohlson_o(df, name="o_score"):
     Steps:
         1) Build features: lev=debt/at_x, roe=nix_x/at_x, cacl=cl_x/ca_x, lat=log(at_x),
         wc=(ca_x−cl_x)/at_x, ffo=(pi_x+dp)/lt, neg_eq=1[lt>at_x], neg_earn=1[both nix_x<0], nich=(Δnix)/( |nix|+|nix₋₁| ).
-        2) Apply linear index: −1.32 −0.407*lat +6.03*lev +1.43*wc +0.076*cacl −1.72*neg_eq −2.37*roe −1.83*ffo +0.285*neg_earn −0.52*nich.
+        2) Apply linear index: −1.32 −0.407*lat +6.03*lev −1.43*wc +0.076*cacl −1.72*neg_eq −2.37*roe −1.83*ffo +0.285*neg_earn −0.52*nich.
 
     Output:
         DataFrame with '{name}' continuous score.


### PR DESCRIPTION
Closes #266. Also corrects the stale working-capital sign reported in #264, which turned out to be a documentation bug rather than the code bug it was filed as.

## Simple explanation

Two places in the O-score write-up describe formulas that the code does not actually use. Nothing about the computed data changes here — only the descriptions of it, which were wrong and had already misled one bug report.

1. The documented definition of the `_o_lat` helper said "last period's total assets". The code (and the SAS reference it was ported from) uses the natural log of *this* period's total assets.
2. Both the `ohlson_o` docstring and the documented O-score formula said the working-capital term is added (`+1.43`). It is subtracted (`-1.43`), in the code, in the SAS reference, and in Ohlson's original paper.

## Technical details

**`_o_lat` (#266).** `documentation/documentation.tex` defined it as lagged assets:

```diff
-                    \_o\_lat_t &= AT\mbox{*}_{t-1} \\
+                    \_o\_lat_t &= log\left(AT\mbox{*}_t\right) \\
```

against an implementation that computes `col("at_x").log()`. `log\left(...\right)` matches this document's existing convention — `\log` appears nowhere in it. The note immediately below the block ("If $AT\mbox{*}_t \leq 0$, then $\_o\_lat_t$ ... are set to missing") already matched the code's `at_x > 0` guard, which is corroborating evidence that the formula line was the stale part rather than the guard.

**Working-capital sign (#264).** The docstring and the `.tex` formula both said `+1.43 * wc`; the implementation computes `-1.43 * col("__o_wc")`. #264 filed this as a code bug on the premise that the SAS reference uses `+1.43`. It does not — the upstream SAS corrected that exact sign on 2025-03-05 in bkelly-lab/ReplicationCrisis@b0b01d5a:

```diff
-	&name. = -1.32 - 0.407 * __o_lat + 6.03 * __o_lev + 1.43 * __o_wc
+	&name. = -1.32 - 0.407 * __o_lat + 6.03 * __o_lev - 1.43 * __o_wc
```

`+1.43` is the *old, buggy* SAS. Our own changelog in this same document records that correction under `03-05-2025` — "Corrected error in o-score calculation" — but the formula block further down was never updated to match, and neither was the Python docstring. Both are pre-2025 leftovers.

The negative coefficient is also what Ohlson (1980) publishes, and it is the economically sensible direction: more working capital means a healthier firm and therefore a lower distress score. There is no opposite-orientation reading that would make `+1.43` equivalent — all three definitions of the helper agree on `(ca_x - cl_x) / at_x` (SAS line 484, `col7` in `ohlson_o`, and `.tex` line 2534).

Both fixes are the same failure mode as #265/#267: the O-score section of the documentation drifted from the implementation and was never reconciled.

No `CHANGELOG_DATA.md` entry — nothing written to `data/processed/` changes.

## Test plan

- `documentation.tex` compiles; the O-score `align*` block renders. (Note a pre-existing, unrelated fatal under `-halt-on-error`: an undefined `\citet` at line 1957 in a document that loads `apacite`. It reproduces on unmodified `main` and is tracked separately.)
- `uv run ruff check src/jkp/data/` and `ruff format --check` pass.
- O-score unit tests pass. Worth noting `test_accounting_formulas.py` already asserts `score_healthy < score_distressed` — precisely the property that would have broken had anyone "corrected" the code to match the stale docs, which is why this is a docs-only change.
- The checked-in `documentation.pdf` is not regenerated here, following the precedent set by #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQaokpyPnCv9Qz7PotiN5n
