### PR TITLE
docs: use apacite's `\citeA` so documentation.tex compiles

### DIFF
--- a/documentation/documentation.tex
+++ b/documentation/documentation.tex
@@ -1954,7 +1954,7 @@ $\\
 ```latex
 \noindent\textbf{Overnight and Intraday Returns}
 
-Following \citet{LouPolkSkouras2019}, we decompose daily close-to-close returns into overnight and intraday components in both U.S. dollars and local currency:
+Following \citeA{LouPolkSkouras2019}, we decompose daily close-to-close returns into overnight and intraday components in both U.S. dollars and local currency:
 \begin{align*}
     \texttt{ret\_intraday}
         &= \frac{P_{\mathrm{close}}}{P_{\mathrm{open}}} - 1, \\


### PR DESCRIPTION
Closes #278.

## Simple explanation

The documentation PDF can't be built from source right now. One citation on line 1957 uses a command from a different citation package than the one this document loads, so LaTeX stops with an error and produces nothing.

This changes one word. It doesn't alter any wording, formula, or data — it just makes the document build again.

## Technical details

`documentation.tex` loads `apacite` (line 20) and uses apacite's `\citeA` for all 144 of its other in-text citations. Line 1957 used natbib's `\citet` instead, which apacite does not define:

```diff
-Following \citet{LouPolkSkouras2019}, we decompose daily close-to-close returns into overnight and intraday components
+Following \citeA{LouPolkSkouras2019}, we decompose daily close-to-close returns into overnight and intraday components
```

The bibliography key itself is fine — `LouPolkSkouras2019` is defined at `documentation.bib:1308`. Only the command was wrong.

Why this sat on `main` unnoticed: under plain `-interaction=nonstopmode`, LaTeX skips the undefined control sequence and still emits a PDF, with the citation silently missing from the rendered sentence. It is fatal only under `-halt-on-error`. It came in with the overnight/intraday returns documentation (#253 / #268).

## Test plan

Before, on `main`:

```
$ pdflatex -halt-on-error -interaction=nonstopmode documentation.tex; echo $?
! Undefined control sequence.
l.1957 Following \citet
                       {LouPolkSkouras2019}, we decompose daily close-to-clo...
!  ==> Fatal error occurred, no output PDF file produced!
1
```

After, on this branch:

```
$ pdflatex -halt-on-error -interaction=nonstopmode documentation.tex; echo $?
0
```

producing a 58-page PDF with the citation rendered. TeX Live 2026 on macOS.

No `CHANGELOG_DATA.md` entry — nothing written to `data/processed/` changes.

Two adjacent points deliberately left out of this PR, both noted in #278: nothing builds this document in CI, which is why a fatal LaTeX error could sit on `main` at all; and the checked-in `documentation.pdf` is several commits stale relative to the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQaokpyPnCv9Qz7PotiN5n
